### PR TITLE
RC3-5: classify current accepted-evidence false support

### DIFF
--- a/docs/roadmaps/interactive-evidence-review-mvp/RC3_BASELINE_REGISTRY.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/RC3_BASELINE_REGISTRY.json
@@ -5,18 +5,6 @@
     "id": "VM0007",
     "version": "v1.8"
   },
-  "provisional": {
-    "artifactIsNotIndexedAsFrozen": true,
-    "logicalLabel": "rc3-5",
-    "mustRegenerateAfter": "PR 2",
-    "note": "The provisional PR #1046 artifact is not present on main and is intentionally excluded from v2 until PR 3 regenerates it against the audited truth.",
-    "officialFrozenBaseline": false,
-    "purpose": "existing false-support taxonomy pending audited-baseline regeneration",
-    "sourceArtifactPath": "docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json",
-    "sourceBranch": "roadmap/rc3-5-false-support-taxonomy",
-    "sourcePr": "#1046",
-    "status": "provisional"
-  },
   "reproduction": {
     "auditedCommand": "npm run preverif:rc3:audited-pre-fix-baseline",
     "diagnosticOutputsAreProductionOutputs": false,
@@ -183,6 +171,10 @@
         {
           "path": "docs/roadmaps/interactive-evidence-review-mvp/RC3_AUDITED_CURRENT_COMPARISON.json",
           "sha256": "f12754ca3e4c1eec6c9330139da46a3777276959c0b0dda569f6f93f023af329"
+        },
+        {
+          "path": "docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json",
+          "sha256": "32181d976bea24d01884c6c1d8586afd5e858ea40eb708a7f5156f2c71e11865"
         }
       ],
       "extraction": {

--- a/docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json
@@ -1,0 +1,9178 @@
+{
+  "affectedRuleCount": 58,
+  "auditAcceptance": {
+    "acceptedInAuditResult": 174,
+    "draftInvented": 0,
+    "draftPreserved": 174,
+    "serializationInvented": 0,
+    "serializedPreserved": 174
+  },
+  "bestMainCount": 58,
+  "complementaryCount": 116,
+  "events": [
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:020a074a2d032595a020d3d72b2f577f18e54e3bc88f6b09b5117d2be7dad101:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 114,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0014"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:03e4a8bdc3bb675cb8ce99033fa95c9ab10d4dac6817c50a32da1ef3ee5195b2:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "eventId": "accepted:false_support:042a4923db21b38129dd609c982d6885a91dcf31e65e23492126c296c791b76b:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "initial crediting period start date shall: 1) be consistent with the definition of initial crediting period start date in the vcs program definitions. 2) conform to any criteria set out in the applied methodology. 3) be established based on implementation of the earliest project activity, where the project includes multiple project activities. 4) determine the start of the first project monitoring period, which shall begin on the initial crediting period start date. some methodologies may require project proponents to quantify emissions that occur prior to this date to account for all project or baseline emissions. the initial crediting period start date for the marcondes redd+ project is 01 may 2023, which is consistent with the definition of the initial crediting period start date under the vcs program and conforms to the criteria specified in the applied methodology. the project does not involve multiple project activities and implements a single redd+ activity in a grouped project design aimed at avoiding planned deforestation (apd). accordingly, the crediting period start date is established based on the earliest implementation of project activities undertaken to prevent planned deforestation. the selected date corresponds to the commencement of project implementation activities, including the execution of carbon credit agreements with participating landowners and the initiation of monitoring activities across properties located in the municipalities of nhamundá, parintins, and barreirinha in the state of amazonas. this date also determines the start of the first monitoring period, from which emission reductions are accounted for under the project. the applied methodology does not require quantification of emissions occurring prior to the crediting period start date; therefore, this provision is not applicable to the project. further details on the project start date and commencement of implementation are provided in section 2.1.10 of the pd.. listing and registration deadlines -- 15 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "The",
+        "sectionPath": [
+          "The"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "score": 66,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:04d692e005d2140a33178fefd68ac5d20f50aca5803838fe7b4d422cb30e38a2:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 149,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0014"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:04e15f69b0585f94bcb1ae465b1e5dfca0e9f631da6ecd58c632e669cbd17a95:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 93,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:05a564ee66c7d2c34cecbabd7adcd66b9c328831c8389905f3e3b1a00c4ed3b8:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 104,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:05b34c99dee966278e7725167a2c7c27930c2f10664371fc21d1ca5c933b72f9:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 110,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:074eb76eaf06046fb55bffd2016ec37b35575f429067bd7a446d06dc0590d0d4:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 107,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:097a8e5fc11303f416d14f8ba55504e1d861a7ff5e237137c5e9001cb43f29d5:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:0a4153b8a3bcf1e67f49ecfb29d2062fccaac9b2aa82bc18425b884148b43880:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 83,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:0abd85916b31f82dba0bbeba437c1f6e32d4868b9225dbef75cabbf400763d6a:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 93,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-4-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:0b6b386d595b6dcd140e4c1dd497e7cb6d63337bb7265448500629c72f6e6ca0:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 113,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:0ba76b6b8c913c187e1a782ed27f126a40d8f37b6ac537ccb63cfc9cf80dcce9:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:0ce9e2986ca52c513e6b73e48be568d2599f41d8c3b5dbbc2dc066d8dc108f56:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 101,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:0eab8e3ade6b36735804d63ff300cd6f379f579838d6b579461a195c34b879ee:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 110,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "eventId": "accepted:false_support:0ebfce965d9a7a9d514ba17d964c0e0d9276d2d1ea4326950534cc59fb368fef:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 land ownership and tenure of the marcondes redd+ project properties are governed by applicable federal and state legislation in brazil, which establishes the legal basis for possession, environmental registration, georeferenced boundary certification, and formal land tenure rights. federal legislation ▪ brazilian civil code (law no. 10.406/2002, articles 1.196–1.228): recognizes possession (posse) as a protected right and establishes usucapião as a legal pathway to ownership. ▪ brazilian forest code (law no. 12.651/2012): establishes the requirement for cadastro ambiental rural (car) registration and mandates an 80% legal reserve for rural properties located in the legal amazon. ▪ law no. 10.267/2001 and decree no. 4.449/2002: establish the sigef system (sistema de gestão fundiária) and define requirements for georeferenced rural property registration. ▪ law no. 6.015/1973 (public registries law): regulates property registration and the matrícula system at the cartório de registro de imóveis. state legislation (amazonas) ▪ state law no. 2.665/2001: regulates state land policy, including the issuance of concessão de direito real de uso (cdru) for state lands and terras devolutas. ▪ state law no. 3.135/2007: establishes the amazonas state policy on climate change, providing the legal framework for carbon credit projects and ecosystem services. land ownership the marcondes redd+ project is a grouped project and for validation comprises 36 rural properties located primarily in the municipality of nhamundá, parintins and barreirinha, state of amazonas, brazil. the total project area is approximately 74,698 hectares, held by approximately 24 landowners and legal entities. all 36 project properties are registered in the sigef system (sistema de gestão fundiária) managed by incra, providing legally recognized, georeferenced, non-overlapping property boundaries. all properties are also registered in the cadastro ambiental rural (car), which includes declared georeferenced boundaries, identification of permanent protection areas (ap ps), and demarcation of legal reserves in accordance with the 80% requirement applicable in the legal amazon. applications for concessão de direito real de uso (cdru) have been submitted to the sect (secretaria de estado das cidades e territórios) for all properties, providing secure long-term rights of land use and management. environmental license applications (autorização de supressão vegetal — asv) have been filed with ipaam (instituto de proteção ambiental do amazonas) for all properties, confirming the legal authorization for land conversion that constitutes the basis for the apd baseline scenario. table 9. overview of applicable land regularization pathway land type state lands (terras devolutas) and lands with occupation history -- 22 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:11a3d75e6b98fa1d89b00478b35cb47fd82a2910f2250c279f10a2305c1419ce:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 85,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-4-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:121baeb88f6b0a6cad529121d5c4f61f266698cebb30b208cd49de0a1a561d17:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 96,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0009"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:123ac0ab4366f7f909df9c98f6871ffb35a1dfe68129b5e5951d91cfce2d4a90:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 100,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:13abe30c523c944f962c7e27c3a3f2cde81a2b58e1c554983038c276627d43c0:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:16912ced2f04b8fec530e964be284cc305de2768656b75b64cabc6a60e5d34dd:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 139,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:16db461f5d26a24c653e3c7d9c53fa25476d221d52f36467fc710c364a1a36d2:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:1aa039cfb79b3f8065a03ce9358a26eb7a21463dd0d746e279fba5fbafebdfc1:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 99,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "eventId": "accepted:false_support:1b8fe27b9168c7bb0863a111354bd803416ebed369571259f9874c3b7c7b7544:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 carbon stocks in tree above and below ground biomass in the project case. carbon stocks will be estimated through forest inventory plots using allometric equations. vmd0005 v1.2 this module is applicable to all cases where wood is harvested for conversion to wood products for commercial markets, for all forest types and age classes. this module is applicable to all cases where timber is harvested for conversion into timber products for commercial markets, for all forest phyto physiognomies and age classes. this module is applicable in the baseline, as the wood products pool is included as part of the project boundary, as per applicability criteria in the redd-mf framework module, specifically: ▪ timber harvesting occurs before or during the deforestation process, and the timber is destined for commercial markets. ▪ the wood product pool is determined to be significant (using t gis). vmd0009 v1.3 the module is applicable for estimating the leakage emissions due to activity shifting from forest lands that are legally authorized and documented to be converted to non-forest land, including activity shifting to forested wetland that is drained or degraded as a consequence of project implementation. the module is also applicable for estimating the leakage emissions due to activity shifting from non-forested wetlands that are legally authorized and documented to be converted and degraded. under these situations, displacement of baseline activities can be controlled and measured directly by monitoring the baseline deforestation or wetland degradation agents or class of agents. this tool must be used for projects in areas where planned deforestation happens on forested wetlands, regardless of the absence of wetland within the project boundaries. the module is mandatory if the bl-pl module is used to define the baseline, and the applicability conditions in the bl-pl module must be met in full. -- 64 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "score": 69,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": false,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:1ce85aa65712feb115ffe201f66f82e6796c7ddc26a1d1eae6169d968f9dc473:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 73,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0010"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:1ee57b38e3cb23a7df9a12e629ed550e703d61ce5964210c2729fd7dc05f2305:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 116,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:1f57cb9faa9976d9bf6f7dd033b649ea9a7dc30315b6dd5dc69fa157e2eab1af:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 105,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:2013153a1a4658e246ba36d40afd02d7367240d70bf3a59e3242f90b7e439aa8:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 99,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:20dd0f7342444860c49b235e82884b47a73b052ede6231af004920d9a0939b06:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 136,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:21f24416eb5d603e41804602286a3c1939c8ef83b7ddd7c1dc0d001ea99bf0a8:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 99,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:26f5a9c6d8adab67c6c02995c57b7119e705b38ee3e2354079676d647fcf0206:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 107,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:277fd58ae36864c7838f0b4e794a0fde56897cb4106c4b957635470d5ecf779f:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": false,
+        "retrievalCandidate": true,
+        "selectedCandidate": false,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:295e8f7d9a041e2c859f62e9239e6f05ca6b94436e30537f659a3aa1ac2cfd35:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:2a67d99d45b35286870ed675a41cde4cfb7bf24e10aff8213a304dd8c0a8e2d1:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 107,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:2de42bc12b07ac2f8c8ebb421b3775bacc5e7e3cc69cc9ec56fc9d032e5964a8:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 83,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.2.3"
+      },
+      "eventId": "accepted:false_support:2e6b1eac240adc54a90a414e15daf8e5b6be19c961c51e717630451e24a41e4f:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "and biodiversity additionality (ccb, g2.2) in the absence of the marcondes redd+ project, neither the community benefits nor the biodiversity conservation outcomes would occur. the project area is located in a region of the -- 42 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 43 ccb v3.0, vcs v4.4 eastern amazon where planned deforestation is legally permissible and widely practiced due to expanding pressures from cattle ranching, agriculture, timber extraction, and other land-use conversion activities. without the project, these drivers would continue to advance, resulting in large-scale forest loss, degradation of ecosystems, and a decline in ecosystem services that sustain local communities. no government program, private organization, or community initiative currently possesses the financial, technical, or institutional capacity to prevent this deforestation or to generate the significant social and environmental benefits that the project will deliver. although brazilian environmental legislation primarily the forest code establishes requirements for legal reserves and areas of permanent preservation, enforcement in remote amazonian regions is limited. environmental agencies such as ibama, icm bio, and state-level authorities operate with insufficient personnel, financial resources, and field presence to monitor land-use change effectively. as a result, illegal deforestation persists, and legally authorized clearing continues unchecked. the project activities would not occur without carbon finance due to substantial financial barriers. local communities lack the investment capacity needed to install renewable energy systems, develop potable water infrastructure, or establish agro-industries for processing ntf ps. landowners similarly lack resources to implement forest monitoring systems, engage professional biodiversity technicians, or conduct long-term conservation planning. no government or donor program is currently committed to filling these gaps. significant technological and knowledge barriers also prevent the implementation of sustainable development actions in the without-project scenario. community members do not have access to the technical expertise required to manage ntfp value chains, apply sustainable harvesting techniques, conduct biodiversity monitoring, or maintain renewable energy systems.",
+      "primarySubtype": "accepted_project_specific_but_unmatched",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Community",
+        "sectionPath": [
+          "Community"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.2.3"
+      },
+      "score": 70,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": false
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.2.3"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:2f07b0f6d7b4a0b5211c2049dc2d7cd656166c9a884d15ab01db7d6f0d623d08:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 82,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:2fd0d9c865babd5d5e429747d6439e9fddfa4469d8460c6caa2978e73afddb8e:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 98,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:30e410aee85aea9bc35503f1ae6ca7e6c19c1fdbed8c5cd32b4c1e13d675a7ad:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 86,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:31346b8ddeb72c4bd9e7a010fa568f228dc34f3a9c1fdc780ac1d17072e8a216:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:32cfe9c84ee518d1432e1a4734712d640e528c86ed6478198ac5abe038ec6c84:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:371d47fa22c3153d6bd7d05556712dde9db3a1c3ae17e645926adab5c7176878:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:388359a8da01c7fc1c410a6a80c330fe7d4e154b565577acf97f8e91a6d26dd1:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:3be1431062d1af6779c1e3341225e01a6eb5ec9f2f7bd41eca1698cd2df1d169:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 74,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:3d6f43aadef1a8f8d521c07389d3ceb45718dc319330c7101f2f03c9a291454d:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 105,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-4-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:3f3447c4b2ba5292d8905ac9aa2e7a194d06816cb06d4f0e10383054ac432ad6:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 122,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:46fae4c26c30895284b3fed5cb4573057fe9d76a520b95812d06c5c6dd18a983:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:494b802faa7640f0a54a65b06d77b0473aef13a840aae0729a31e05db531fb26:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 119,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:49e99b47599c2cccf9bd95635cdd7b397739824693187194f123382d59f3bc50:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 127,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:4cbbd7c13d33f7a006c05961ed206dff5c69a7da028c3a99817a476ab957ce5f:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 111,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:4d8c10aca15e30b1df5e0365cf439969c4a78a1e2dcf0031b5a1a7eefd1a58ee:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 133,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "eventId": "accepted:false_support:4f06a8e07c6cc17029a28d885bb1572e2449fe3192aab262f3c129890dbe2d08:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 land ownership and tenure of the marcondes redd+ project properties are governed by applicable federal and state legislation in brazil, which establishes the legal basis for possession, environmental registration, georeferenced boundary certification, and formal land tenure rights. federal legislation ▪ brazilian civil code (law no. 10.406/2002, articles 1.196–1.228): recognizes possession (posse) as a protected right and establishes usucapião as a legal pathway to ownership. ▪ brazilian forest code (law no. 12.651/2012): establishes the requirement for cadastro ambiental rural (car) registration and mandates an 80% legal reserve for rural properties located in the legal amazon. ▪ law no. 10.267/2001 and decree no. 4.449/2002: establish the sigef system (sistema de gestão fundiária) and define requirements for georeferenced rural property registration. ▪ law no. 6.015/1973 (public registries law): regulates property registration and the matrícula system at the cartório de registro de imóveis. state legislation (amazonas) ▪ state law no. 2.665/2001: regulates state land policy, including the issuance of concessão de direito real de uso (cdru) for state lands and terras devolutas. ▪ state law no. 3.135/2007: establishes the amazonas state policy on climate change, providing the legal framework for carbon credit projects and ecosystem services. land ownership the marcondes redd+ project is a grouped project and for validation comprises 36 rural properties located primarily in the municipality of nhamundá, parintins and barreirinha, state of amazonas, brazil. the total project area is approximately 74,698 hectares, held by approximately 24 landowners and legal entities. all 36 project properties are registered in the sigef system (sistema de gestão fundiária) managed by incra, providing legally recognized, georeferenced, non-overlapping property boundaries. all properties are also registered in the cadastro ambiental rural (car), which includes declared georeferenced boundaries, identification of permanent protection areas (ap ps), and demarcation of legal reserves in accordance with the 80% requirement applicable in the legal amazon. applications for concessão de direito real de uso (cdru) have been submitted to the sect (secretaria de estado das cidades e territórios) for all properties, providing secure long-term rights of land use and management. environmental license applications (autorização de supressão vegetal — asv) have been filed with ipaam (instituto de proteção ambiental do amazonas) for all properties, confirming the legal authorization for land conversion that constitutes the basis for the apd baseline scenario. table 9. overview of applicable land regularization pathway land type state lands (terras devolutas) and lands with occupation history -- 22 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "score": 73,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:52da62ac5d299003864673544c60c51523934e3807a932f6c1e1aed2ad94ddc1:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:5429e7315c0152a5bcd36da8514bb665661a535909050e32962a03221eea9df2:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:5496ada4b5bafcbc56113741b04097adbc4e5dc2c2939aa56a331897acc142b6:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:562a1927afeb074f7f41fbbea86ead63350d202a2a98f29f695b9a65261080d2:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 127,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:576410a6f2d7f7155136707fb6a89b184dd5990348440d45748f5b598d88b956:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 70,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:583483d35fe1e85175073b7918d62e3fec71f5904975293f316c65f6fe2bd284:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 82,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:5891b2037915b469727fe7b5fd0249808e4ba8920ce3c938b3b7d3d983cb030a:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 133,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "eventId": "accepted:false_support:595a9b5faddb41a0e8763210e7ff0937c3cee4f4fdca31885ef997aa9d390f68:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 land ownership and tenure of the marcondes redd+ project properties are governed by applicable federal and state legislation in brazil, which establishes the legal basis for possession, environmental registration, georeferenced boundary certification, and formal land tenure rights. federal legislation ▪ brazilian civil code (law no. 10.406/2002, articles 1.196–1.228): recognizes possession (posse) as a protected right and establishes usucapião as a legal pathway to ownership. ▪ brazilian forest code (law no. 12.651/2012): establishes the requirement for cadastro ambiental rural (car) registration and mandates an 80% legal reserve for rural properties located in the legal amazon. ▪ law no. 10.267/2001 and decree no. 4.449/2002: establish the sigef system (sistema de gestão fundiária) and define requirements for georeferenced rural property registration. ▪ law no. 6.015/1973 (public registries law): regulates property registration and the matrícula system at the cartório de registro de imóveis. state legislation (amazonas) ▪ state law no. 2.665/2001: regulates state land policy, including the issuance of concessão de direito real de uso (cdru) for state lands and terras devolutas. ▪ state law no. 3.135/2007: establishes the amazonas state policy on climate change, providing the legal framework for carbon credit projects and ecosystem services. land ownership the marcondes redd+ project is a grouped project and for validation comprises 36 rural properties located primarily in the municipality of nhamundá, parintins and barreirinha, state of amazonas, brazil. the total project area is approximately 74,698 hectares, held by approximately 24 landowners and legal entities. all 36 project properties are registered in the sigef system (sistema de gestão fundiária) managed by incra, providing legally recognized, georeferenced, non-overlapping property boundaries. all properties are also registered in the cadastro ambiental rural (car), which includes declared georeferenced boundaries, identification of permanent protection areas (ap ps), and demarcation of legal reserves in accordance with the 80% requirement applicable in the legal amazon. applications for concessão de direito real de uso (cdru) have been submitted to the sect (secretaria de estado das cidades e territórios) for all properties, providing secure long-term rights of land use and management. environmental license applications (autorização de supressão vegetal — asv) have been filed with ipaam (instituto de proteção ambiental do amazonas) for all properties, confirming the legal authorization for land conversion that constitutes the basis for the apd baseline scenario. table 9. overview of applicable land regularization pathway land type state lands (terras devolutas) and lands with occupation history -- 22 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:59ed8e06ee74dccd53f98b2c1e46e541d07122132b179b854c729de0c4177d13:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-4-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:5b4ad2c8d17fe5d489b7388e4ae8b8a0123a406a4e0045072f829b560a39e2bb:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 80,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:5b7e6dde71b953d1e39fdccb2c6f4acda056d4585f604f7a4d9240ab1a950f1c:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0016"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:5d248edbddcb17a45974d6beef4cb6533ef97656ee9343804a2341ce5ff55c2c:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 113,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:5d4ce86d67d3c5cf55820acd1ae62389024fb218dfa4311bcdc3526345bc5262:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 133,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:5e636ab58af61cea0ce1cdffcf9a762d50567a1cb083086576fb267f7ba0ce15:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 130,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.22"
+      },
+      "eventId": "accepted:false_support:5ee417fb7ee2a00c53794063628b91e96bc5ae318660489e3f413bfdc55127d8:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(ccb, g1.12) financing of project activities is guaranteed by funds committed by the project proponents from the project start date until the first verification. the financing structure for the marcondes redd+ project is based on carbon credit revenues under the vcs program, supplemented by initial investment from the project proponent: the project proponent has secured project financing through carbon credit offtaker agreements that provide advance funding for project implementation. a portion of the forecasted carbon credits has been committed under forward purchase agreements, ensuring financial resources are available from the project start date through the first verification cycle. this pre-financing covers monitoring infrastructure, community program implementation, and project development costs. ongoing project financing is sustained through the sale of verified carbon credits (vc us) on the voluntary carbon market, with revenues allocated according to the benefit-sharing structure defined in the carbon credit agreements with landowners. a portion of carbon credit revenues is dedicated to the community benefit fund, administered in consultation with the comunidade são tomé do mocambo, ensuring long-term financial sustainability of community programs and biodiversity conservation activities. 2.2 without-project land use scenario and additionality",
+      "primarySubtype": "accepted_project_specific_but_unmatched",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Financial Sustainability",
+        "sectionPath": [
+          "Financial Sustainability"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.22"
+      },
+      "score": 67,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": false
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.22"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-4-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:64f35a3d32d416f0d298445e68a8bc86eac5eb87ed4219cb4a24ba5234685321:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:65c9032f873c6f969e388c7974f62496fa265537f52af0b76b60effd2d4ac772:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "eventId": "accepted:false_support:663ea38db7a1b6e075fde5d1c857e186088b06936ffc9f1d8b0a7b4711ce280b:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "initial crediting period start date shall: 1) be consistent with the definition of initial crediting period start date in the vcs program definitions. 2) conform to any criteria set out in the applied methodology. 3) be established based on implementation of the earliest project activity, where the project includes multiple project activities. 4) determine the start of the first project monitoring period, which shall begin on the initial crediting period start date. some methodologies may require project proponents to quantify emissions that occur prior to this date to account for all project or baseline emissions. the initial crediting period start date for the marcondes redd+ project is 01 may 2023, which is consistent with the definition of the initial crediting period start date under the vcs program and conforms to the criteria specified in the applied methodology. the project does not involve multiple project activities and implements a single redd+ activity in a grouped project design aimed at avoiding planned deforestation (apd). accordingly, the crediting period start date is established based on the earliest implementation of project activities undertaken to prevent planned deforestation. the selected date corresponds to the commencement of project implementation activities, including the execution of carbon credit agreements with participating landowners and the initiation of monitoring activities across properties located in the municipalities of nhamundá, parintins, and barreirinha in the state of amazonas. this date also determines the start of the first monitoring period, from which emission reductions are accounted for under the project. the applied methodology does not require quantification of emissions occurring prior to the crediting period start date; therefore, this provision is not applicable to the project. further details on the project start date and commencement of implementation are provided in section 2.1.10 of the pd.. listing and registration deadlines -- 15 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "The",
+        "sectionPath": [
+          "The"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "score": 73,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:6a0ef2df2fcea10aa3a034133170b58c244d2090a425af83b64a67bef57460eb:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 127,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:6a7fb51513b8a57869ebf5fc8189b2abced7b6a029891b32e7529df7f5d3bf1b:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 80,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:6b2e2a0b4293a52f70d44e9a9798ddc462d02f0f393916e3bb067d1d2edc0364:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 80,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:6b9e852109b7aeb48bc2a950f1b5f194b254f750230e1ed493740722806b40d6:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 96,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0010"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:6d747b107435ae018c7f66d635138691fdf5dc28d1466ab17539166256c56887:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:70656318577ea39eeb301f6b79e1222dc16207c2601e90567954161863733d0c:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:7312be705f04e0f148337556e89b96e89076ae29d9966f1d3f9f7c402d73fcdb:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 133,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:76e61a42ed50e7e8b11b19963b6bffcc8ea1458edbc73ef14eabbaf0b8af5e3f:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 130,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": false,
+        "retrievalCandidate": true,
+        "selectedCandidate": false,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:775b154d30a2600591418c338535ecfc88f996181936e7cbeafa78a418de205f:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0011"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:77bb6b9f1b3328cbc34d123ded0402bd1e2bbe199c66dfcd65cf7cc6e8dacb33:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 76,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:7a273cdcafd1edd3232af475d02365823473ddd3abf9ae6e4e8d63c0395d5e1b:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 93,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:7b0c7d0fc274150c1b98ffc1477e51c9130519ac8f5b77cfeee1252a1c26bdb5:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 104,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:7c6750e49f3fc3dd1e6dbaf62a0527e341133fc794cf50ab554f70444162de0a:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 102,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:7ce5bbedff280a275a3798ccc0d855bb01ed0d06004b1f868e51a7b2efa62aff:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 107,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:7d821205f35b8de37fce857d94a83749b423f2a63b493d1909c39d957a694e74:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 107,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:7ea6464495a9b7715806b282d8291c573793c2b4cd6fce33af6be5f45d99d233:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 139,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:7ffa8a73af8f150d37ab82866bf57cd53130b0015af57980078b9b10c1c7f6cd:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 113,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": false,
+        "retrievalCandidate": true,
+        "selectedCandidate": false,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:81ff2aa83dec24516818de2aafa69a34630de9574e4af7303f638ebbfe845766:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:86594c405c89fbf98b00df6cc5c8dc99961fb52e4a09b3e5aa8ad2ed8237c1b8:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 130,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0015"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:8970c21e25075453a621e3c8883a27670296dde402fa0735f1007024bd958856:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 136,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:904958a4b12cfd9641a95084258089cbe267ff2576de60163e9184eb885e747c:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 110,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "eventId": "accepted:false_support:90e0c96bf60123a15e1c0dfd163a0e882ae838cba5ab727dcf8fa8d1b50861be:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 land ownership and tenure of the marcondes redd+ project properties are governed by applicable federal and state legislation in brazil, which establishes the legal basis for possession, environmental registration, georeferenced boundary certification, and formal land tenure rights. federal legislation ▪ brazilian civil code (law no. 10.406/2002, articles 1.196–1.228): recognizes possession (posse) as a protected right and establishes usucapião as a legal pathway to ownership. ▪ brazilian forest code (law no. 12.651/2012): establishes the requirement for cadastro ambiental rural (car) registration and mandates an 80% legal reserve for rural properties located in the legal amazon. ▪ law no. 10.267/2001 and decree no. 4.449/2002: establish the sigef system (sistema de gestão fundiária) and define requirements for georeferenced rural property registration. ▪ law no. 6.015/1973 (public registries law): regulates property registration and the matrícula system at the cartório de registro de imóveis. state legislation (amazonas) ▪ state law no. 2.665/2001: regulates state land policy, including the issuance of concessão de direito real de uso (cdru) for state lands and terras devolutas. ▪ state law no. 3.135/2007: establishes the amazonas state policy on climate change, providing the legal framework for carbon credit projects and ecosystem services. land ownership the marcondes redd+ project is a grouped project and for validation comprises 36 rural properties located primarily in the municipality of nhamundá, parintins and barreirinha, state of amazonas, brazil. the total project area is approximately 74,698 hectares, held by approximately 24 landowners and legal entities. all 36 project properties are registered in the sigef system (sistema de gestão fundiária) managed by incra, providing legally recognized, georeferenced, non-overlapping property boundaries. all properties are also registered in the cadastro ambiental rural (car), which includes declared georeferenced boundaries, identification of permanent protection areas (ap ps), and demarcation of legal reserves in accordance with the 80% requirement applicable in the legal amazon. applications for concessão de direito real de uso (cdru) have been submitted to the sect (secretaria de estado das cidades e territórios) for all properties, providing secure long-term rights of land use and management. environmental license applications (autorização de supressão vegetal — asv) have been filed with ipaam (instituto de proteção ambiental do amazonas) for all properties, confirming the legal authorization for land conversion that constitutes the basis for the apd baseline scenario. table 9. overview of applicable land regularization pathway land type state lands (terras devolutas) and lands with occupation history -- 22 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "score": 100,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:91acc7c4f1af97d354db0bf79e9389b50a34e57f87b07105fa4a5c56221148a0:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 110,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:9286c5e3f26585cfc339558a1c5962abd62bc22b75d416e94a9e6c35d2ba129e:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 82,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:93b8081142d7e00a1a22b86c8fc3bbe01f399c8815a7987d5df76dac84fa2f0f:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 113,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:94e58fbaaddb7438dd5e0be6de6fbcd6b4aad031a2d6cb645bbbad0b7da94854:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 93,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:965bfcadd890827cdf96be1e923e134397db0ff6ef61a5c761960f7501dc2309:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 88,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0009"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:971f3bb4499fa991ef114fafd4fb003831d079d7efe371625525b8509f2fe26c:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 110,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:97cc236ba80b386b73a39bdf5af0e0cf918d58c969ff796426041a521517251f:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:99cb39c732b86661b0071b84f67e1f56dcc927064ded89f28f988a616b1381b9:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 83,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:9a07d68152bcf029de5ae22c7131b8be5f86e8c3fb0119d94565648fa46a5201:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "eventId": "accepted:false_support:9a5743451c18b76a217d105aa9dc1ff4109337c1084caf45f137bbd3298e9453:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 carbon stocks in tree above and below ground biomass in the project case. carbon stocks will be estimated through forest inventory plots using allometric equations. vmd0005 v1.2 this module is applicable to all cases where wood is harvested for conversion to wood products for commercial markets, for all forest types and age classes. this module is applicable to all cases where timber is harvested for conversion into timber products for commercial markets, for all forest phyto physiognomies and age classes. this module is applicable in the baseline, as the wood products pool is included as part of the project boundary, as per applicability criteria in the redd-mf framework module, specifically: ▪ timber harvesting occurs before or during the deforestation process, and the timber is destined for commercial markets. ▪ the wood product pool is determined to be significant (using t gis). vmd0009 v1.3 the module is applicable for estimating the leakage emissions due to activity shifting from forest lands that are legally authorized and documented to be converted to non-forest land, including activity shifting to forested wetland that is drained or degraded as a consequence of project implementation. the module is also applicable for estimating the leakage emissions due to activity shifting from non-forested wetlands that are legally authorized and documented to be converted and degraded. under these situations, displacement of baseline activities can be controlled and measured directly by monitoring the baseline deforestation or wetland degradation agents or class of agents. this tool must be used for projects in areas where planned deforestation happens on forested wetlands, regardless of the absence of wetland within the project boundaries. the module is mandatory if the bl-pl module is used to define the baseline, and the applicability conditions in the bl-pl module must be met in full. -- 64 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "score": 66,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:9a9a3550d69b5e957f63d66cbcd2b51d1af3554ffb8c63e59bdfd3cc89ea883d:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 104,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:9c975e50a421ea19cdef5c352bb1e8ade4552b388185ff3b72ee1d613e3e80a3:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 102,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:9cc7c9a9cba32340c56ec84f483fcb4a0e9acc882c9cfb00e18248402d13b93d:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 140,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:9e3597620f9d388c1d6334219c7d209a714efd38a83e8a787adae659ce415fcf:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 89,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:9ef75f4bd433e664c95542565a2a1d05577e61bea33f9779431e4c62454e8113:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:9f72ce4adc1cd298d8825653c590982f0f2d6924fb09854d43263d12d4db5ce3:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:a12522654464d3294bfe411714fdce9f27d80e3065add1b31948b6a5aa8aa799:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 93,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:a227910c59ffccdadbb6aecf6f5b1c65d1817d6518cbb97d1a57aba1d06c5a97:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 133,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:a27c66c5dfe7ef77492e9c21d663ed0b2d7e55351aba9fcc4bc77f4704352aa0:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:a4983cc6c9db630b4687cf30b963f714243d6ac905534b0f3bc3b864b03c5ecd:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 110,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:a52222776e9e87e12c3efb79895e07c4f9d047f738d98147beccb0e03919a12d:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 82,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:a7576595b8258552ae0a156be31b683d7b184dd2357a47731c68c466e17e1288:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 88,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:a85dfe76a9808360be0ea4be7a1db811e3e1a82f96f72bded7e38cebd4d21ef1:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 101,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:a8b9ad28ab381bd1c0718a7bdb3fdf097169e1b14e3a28b749002c9458bf577a:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 82,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:aa77310084ed61d67a559c5567671855a52818a1ed2f35df22e3f89f7e070cd7:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:ac911da40a073b6018d2a76bdfac5be41282d8df1d2605da5f62ae4b2c84ed02:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 110,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:ad5d1419d5561989bf1a2bc8c310b6b98b15b1e55030600fc0540e97f48fbbd7:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 102,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:addd90c0ab48a73322b2c0457c5e8dbcb94484154b2ff3ce4b67e55b1e1cfd7c:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 89,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:aeabd4f82211e80e9eabb8742303ce863fb16ceac9f887db2e9594054f2d31ac:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:aeef169820eba1ce0c2dd7aabf5dcc5c6538ea14c433f46d9f9138ad0d7f76b8:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 119,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:b09fad18a93b65a1f58ccc0f9ecca06edaa3949fe6e6d0c4c98a02e54d9865c3:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 93,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0015"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:b4ab29bdf4a17861243e503b1e92522e215106aeb81a88ad382e7b88c40a85ec:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 107,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0009"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:baa68e2f31c23d1902d6f5b73a496340fdd66f1ace0f3265fdba88b7d0ba3ca1:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 71,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "eventId": "accepted:false_support:bb169ae811060694541f82c1f3eb62ee635dd39fc4253949427d9be90bd2d377:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 carbon stocks in tree above and below ground biomass in the project case. carbon stocks will be estimated through forest inventory plots using allometric equations. vmd0005 v1.2 this module is applicable to all cases where wood is harvested for conversion to wood products for commercial markets, for all forest types and age classes. this module is applicable to all cases where timber is harvested for conversion into timber products for commercial markets, for all forest phyto physiognomies and age classes. this module is applicable in the baseline, as the wood products pool is included as part of the project boundary, as per applicability criteria in the redd-mf framework module, specifically: ▪ timber harvesting occurs before or during the deforestation process, and the timber is destined for commercial markets. ▪ the wood product pool is determined to be significant (using t gis). vmd0009 v1.3 the module is applicable for estimating the leakage emissions due to activity shifting from forest lands that are legally authorized and documented to be converted to non-forest land, including activity shifting to forested wetland that is drained or degraded as a consequence of project implementation. the module is also applicable for estimating the leakage emissions due to activity shifting from non-forested wetlands that are legally authorized and documented to be converted and degraded. under these situations, displacement of baseline activities can be controlled and measured directly by monitoring the baseline deforestation or wetland degradation agents or class of agents. this tool must be used for projects in areas where planned deforestation happens on forested wetlands, regardless of the absence of wetland within the project boundaries. the module is mandatory if the bl-pl module is used to define the baseline, and the applicability conditions in the bl-pl module must be met in full. -- 64 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "score": 75,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:bb6ce8a89df516a0567f5addb9e6ec506c21416860e031134739b7450c296b52:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0012"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": false,
+        "retrievalCandidate": true,
+        "selectedCandidate": false,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "eventId": "accepted:false_support:be0942b0966b0a3e3cb95f486766a9de6132bb9f51a2b42a14ff7cbd14125ed0:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "initial crediting period start date shall: 1) be consistent with the definition of initial crediting period start date in the vcs program definitions. 2) conform to any criteria set out in the applied methodology. 3) be established based on implementation of the earliest project activity, where the project includes multiple project activities. 4) determine the start of the first project monitoring period, which shall begin on the initial crediting period start date. some methodologies may require project proponents to quantify emissions that occur prior to this date to account for all project or baseline emissions. the initial crediting period start date for the marcondes redd+ project is 01 may 2023, which is consistent with the definition of the initial crediting period start date under the vcs program and conforms to the criteria specified in the applied methodology. the project does not involve multiple project activities and implements a single redd+ activity in a grouped project design aimed at avoiding planned deforestation (apd). accordingly, the crediting period start date is established based on the earliest implementation of project activities undertaken to prevent planned deforestation. the selected date corresponds to the commencement of project implementation activities, including the execution of carbon credit agreements with participating landowners and the initiation of monitoring activities across properties located in the municipalities of nhamundá, parintins, and barreirinha in the state of amazonas. this date also determines the start of the first monitoring period, from which emission reductions are accounted for under the project. the applied methodology does not require quantification of emissions occurring prior to the crediting period start date; therefore, this provision is not applicable to the project. further details on the project start date and commencement of implementation are provided in section 2.1.10 of the pd.. listing and registration deadlines -- 15 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "The",
+        "sectionPath": [
+          "The"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "score": 59,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.1"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:befb7a33067ed7eccf56e02544382c4625aadef237a559ca42dae152322a9d53:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 110,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:bf6dcd88f4eecb91d5e0f39f7573b3b9ae30554e9b83d439600a120b1552200b:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:c090616f0f3ba13f6b14fbe05b154aff9749ea78e6521b9e2da0203cf0e6b911:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 83,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:c21be7773619b3d1ef2b9670a70dc7a03c2d8e5a79802101d17c06ed0746b784:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 82,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-4-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:c2404269951008fd157b34d2c7d6ec9ed88e353ceabbeeec8f4dc927c5333888:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 70,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:c5a5c32fe4440762d3218ae73d9999318792ba875c28cb8e7e61bf22470de2d2:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 96,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:c7da514ddb20825cae9a8a01a21a24dd24a3c7b328da18e94b342fae0b38fe0e:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 67,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:c8619ce84f589c12fc0db45508a39e73d7fa2bc46474c18268c0f5d0666f3ce8:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 101,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:cb5e6824d0076241411c392739b36ace725ea1009fa5f41c0f4fd6f03ee45764:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:cc663678f3cee0e65980db00e3b1bbf59be5d98b7ce4df0e01823df8a65eb661:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 91,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:ced9bbf66b61f12362207b33d0b928838ecd5c8fd5e84b517951d3dd3032969d:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:d028b658f3e019364b19197a0a0d50cb7047dff1b25e8a57210800699780cdd1:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 103,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:d12689e4e57b847b9e0ef44be9a1d9c5abc1fb06728cbbdd61f068a4e4438d06:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 96,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0009"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:d488914dc0a85bb537aa8b842caaa27d8e08b44a23c1d2505c38437778ef41ea:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 104,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "eventId": "accepted:false_support:d49cb099f89594616d259e7a559c642edf0fb4bac46588c40ce2402bd7765c99:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 carbon stocks in tree above and below ground biomass in the project case. carbon stocks will be estimated through forest inventory plots using allometric equations. vmd0005 v1.2 this module is applicable to all cases where wood is harvested for conversion to wood products for commercial markets, for all forest types and age classes. this module is applicable to all cases where timber is harvested for conversion into timber products for commercial markets, for all forest phyto physiognomies and age classes. this module is applicable in the baseline, as the wood products pool is included as part of the project boundary, as per applicability criteria in the redd-mf framework module, specifically: ▪ timber harvesting occurs before or during the deforestation process, and the timber is destined for commercial markets. ▪ the wood product pool is determined to be significant (using t gis). vmd0009 v1.3 the module is applicable for estimating the leakage emissions due to activity shifting from forest lands that are legally authorized and documented to be converted to non-forest land, including activity shifting to forested wetland that is drained or degraded as a consequence of project implementation. the module is also applicable for estimating the leakage emissions due to activity shifting from non-forested wetlands that are legally authorized and documented to be converted and degraded. under these situations, displacement of baseline activities can be controlled and measured directly by monitoring the baseline deforestation or wetland degradation agents or class of agents. this tool must be used for projects in areas where planned deforestation happens on forested wetlands, regardless of the absence of wetland within the project boundaries. the module is mandatory if the bl-pl module is used to define the baseline, and the applicability conditions in the bl-pl module must be met in full. -- 64 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "score": 72,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:64"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0003"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:d7d08bdf0c09bc982d2c3c53282579f8e21393084305dcb2c97392bca27c16b7:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 107,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-3-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:d7e18bfa283be1aa73bfbf841a4a445ee930d82fc108547624bbcf66088d6acd:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 80,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:da913024ee6309b1d0bd23f2912a4f143b1e9e892ded7e5299dc52661540b162:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 113,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0015"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:dc1888258a850c5da941e9dfaea12182ea64ddfeb9978204eb2f4341f8897976:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:dc1b87281f1ad34827e1863dfc83ff86dc164bb15a7b319a8a689bcf6ea331a1:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 105,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:e0f3e7ea9055c9ff2e9ebc3cc8eb54347252ab5428a778409153cda7179525d2:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 71,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:e13e751a9ec1f7156f901c8708eb6338af52888623717483b881d80b92d88680:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 100,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0002"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:e2380461793fee894cea925fd1b40f76ce7f03e9f8016bc96831841a12c24b2d:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 93,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0011"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:e268fa07a4e58fb46faa29b9f4ef8f9a0f5e2d6bd9b3381aa6843068a1cd17a2:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:e43121fac478c197cf545f0b01d32d7fee3c5d1a3d7273063548560bda777404:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "eventId": "accepted:false_support:e4f861d6fcac3c785e2788bc3ed4c2c42bb50d4b15d068a44388c991672ff7eb:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.17) the marcondes redd+ project contributes to the following united nations sustainable development goals (sd gs) and is aligned with brazil's nationally determined contribution (ndc) under the paris agreement: ▪ sdg 1 (no poverty): alternative income through benefit-sharing and ntfp value chains ▪ sdg 4 (quality education): environmental education and training programs ▪ sdg 6 (clean water and sanitation): provision of water filtration and treatment systems to riverine communities within the project zone, improving access to safe drinking water. ▪ sdg 7 (affordable and clean energy): installation of solar photovoltaic systems and battery storage for off-grid communities, replacing diesel generators and reducing reliance on fossil fuels. ▪ sdg 8 (decent work): local employment through monitoring, patrol, ntfp processing ▪ sdg 13 (climate action): direct ghg emission reductions through avoided deforestation ▪ sdg 15 (life on land): forest conservation and biodiversity protection the project is aligned with brazil's updated ndc (cop26), which commits to eliminating illegal deforestation by 2028 and achieving climate neutrality by 2050. the project also supports the objectives of the ppcd am (action plan for prevention and control of deforestation in the legal amazon) and the national redd+ strategy (enredd+). at the state level, the project contributes to the amazonas state climate change policy (law no. 3.135/2007) and the state redd+ system.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Sustainable Development Contributions",
+        "sectionPath": [
+          "Sustainable Development Contributions"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "score": 80,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.18"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "eventId": "accepted:false_support:e51df59bf09441f00d0e72a282352e111dbec1e05f007dd02232b3f00f83465b:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 land ownership and tenure of the marcondes redd+ project properties are governed by applicable federal and state legislation in brazil, which establishes the legal basis for possession, environmental registration, georeferenced boundary certification, and formal land tenure rights. federal legislation ▪ brazilian civil code (law no. 10.406/2002, articles 1.196–1.228): recognizes possession (posse) as a protected right and establishes usucapião as a legal pathway to ownership. ▪ brazilian forest code (law no. 12.651/2012): establishes the requirement for cadastro ambiental rural (car) registration and mandates an 80% legal reserve for rural properties located in the legal amazon. ▪ law no. 10.267/2001 and decree no. 4.449/2002: establish the sigef system (sistema de gestão fundiária) and define requirements for georeferenced rural property registration. ▪ law no. 6.015/1973 (public registries law): regulates property registration and the matrícula system at the cartório de registro de imóveis. state legislation (amazonas) ▪ state law no. 2.665/2001: regulates state land policy, including the issuance of concessão de direito real de uso (cdru) for state lands and terras devolutas. ▪ state law no. 3.135/2007: establishes the amazonas state policy on climate change, providing the legal framework for carbon credit projects and ecosystem services. land ownership the marcondes redd+ project is a grouped project and for validation comprises 36 rural properties located primarily in the municipality of nhamundá, parintins and barreirinha, state of amazonas, brazil. the total project area is approximately 74,698 hectares, held by approximately 24 landowners and legal entities. all 36 project properties are registered in the sigef system (sistema de gestão fundiária) managed by incra, providing legally recognized, georeferenced, non-overlapping property boundaries. all properties are also registered in the cadastro ambiental rural (car), which includes declared georeferenced boundaries, identification of permanent protection areas (ap ps), and demarcation of legal reserves in accordance with the 80% requirement applicable in the legal amazon. applications for concessão de direito real de uso (cdru) have been submitted to the sect (secretaria de estado das cidades e territórios) for all properties, providing secure long-term rights of land use and management. environmental license applications (autorização de supressão vegetal — asv) have been filed with ipaam (instituto de proteção ambiental do amazonas) for all properties, confirming the legal authorization for land conversion that constitutes the basis for the apd baseline scenario. table 9. overview of applicable land regularization pathway land type state lands (terras devolutas) and lands with occupation history -- 22 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:22"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:e9176c2e5dc9b83fb1cd23f8b40660919204ade76fc620a394922c43d2c3823c:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 102,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0013"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:ea057a3c814683fa42d193e5e41f192906423104f7b4ac3d7cbb861a7d2d2646:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 96,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:ea87ab8925ae217e8d241a7fb46e37674f2685f996c7476a8a447c2d2639bd92:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 124,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "eventId": "accepted:false_support:eacc90115f2ad8b3fbb45e3d737cf2c20adc328b46c10ae59551e989a6b55244:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "proponents shall submit a pipeline listing request within one year of the initial crediting period start date. the requirement under section 3.8.2 of the vcs standard v5.0 requires project proponents to submit a pipeline listing request within one year of the initial crediting period start date. however, as clarified in the document “vcs version 5: overview of vcs program updates and effective dates” released by verra on 16 december 2025, this requirement is only effective for pipeline listing requests submitted on or after 1 january 2027. therefore, this requirement is not applicable to the present project, and the project remains eligible for pipeline listing even though the submission occurs more than one year after the initial crediting period start date.",
+      "primarySubtype": "duplicated_across_multiple_rules",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project",
+        "sectionPath": [
+          "Project"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "score": 84,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.8.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:eaf1b3c57a253f495bc9d1f494110d3a380e73e8ddc4378b2bda7196b0eeab8b:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 87,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:ec2f5c2d39ee952da84b19171f7db5b68d8faf5e75c2678e7ca88958f35936da:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 127,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0009"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:ecfc18af33a589206018e3f1792ef56faccbcef9b53e02a0ae7a1b77564c3cea:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 121,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": false,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:ecfcd8339f782ebe10ce9ec29b8b98ed7ba9cd2ea00420c983203f848e3e23d9:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 130,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:f032514d65a5de48c83c7badbb2dd44e76fe439429943c28eb99a8aa54600cb1:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 104,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:f18bd2ce516e6055da8e13d552ed168451e9217a062ab187eb73f324547f056c:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 93,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0012"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:f49d535858af20aef21e3778c49ae041878be0a6da8305019ddf25f6b8a9f7e7:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 76,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0007"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:f585aaf0b42e9e32d13c0fd72c60942d6632f74dfa1f5f94a18ec737ea466193:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 139,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0005"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "eventId": "accepted:false_support:f5d39944c97cdd3a3e7f3fec72a9a23e50ede1e3f7d277c90239ec576b956576:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 a) unplanned deforestation (vcs category au def) b) planned deforestation (vcs category ap def) properties in the legal amazon. the ap def category is applicable. redd activity types are not applicable under the following condition: 4) leakage prevention activities include: a) flooding agricultural lands to increase production (e.g., rice paddies); and / or b) intensifying livestock production through use of feed-lots and / or manure lagoons. leakage mitigation activities under the project do not implement flooded agriculture or livestock intensification through feedlots or manure lagoons. avoiding planned deforestation activities are applicable under the following condition: 7) where conversion of forest lands to a deforested condition is legally permitted all 36 project properties are classified as forest. in the baseline scenario, landowners would exercise their legal right to deforest up to 20% of each property. deforestation is authorized under the brazilian forest code (law 12.651/2012). all 36 property owners have filed asv applications with ipaam. sigef and car registrations confirm legal property boundaries and forest code compliance. vmd0006 v1.4 the module is applicable for estimating the baseline emissions on forest lands (usually privately or government owned) that are legally authorized and documented to be converted to non- forest land. the marcondes project reduces emissions from planned deforestation (apd) on forest land (privately owned) within the legal amazon that are legally authorized and documented to be converted to non-forest land. vmd0001 v1.2 the module allows for the ex-ante estimation of carbon stocks in tree and non- tree above and below ground biomass in the baseline scenario (for both pre- and post-deforestation stocks) and in the project case and for the ex-post estimation of the change in this module is applicable to all forest phyto physiognomies and age classes. the inclusion of the above ground tree biomass pool as part of the project boundary is mandatory according to the redd-mf module. -- 63 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:63"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0004"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "eventId": "accepted:false_support:f67533b48d376cf297d2442a133c74a62bcd17a2cd7643292ec37770d50422c4:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "(vcs, 3.1, 3.6, 3.8, 3.18, 4.1; ccb program rules, 4.2.4, 4.6.4) the project is eligible under the vcs program redd activity category of avoiding planned deforestation as per appendix 1 of the vcs standard v5.0. the project area qualifies as forest and has remained forested for more than 10 years prior to the project start date, meeting the applicable forest definition thresholds. in the absence of the project, the area was legally authorized and documented for conversion to non-forest land, which would have resulted in significant loss of forest carbon stocks. the project activities prevent this planned conversion by maintaining the forest cover and protecting existing carbon stocks, thereby reducing net ghg emissions associated with deforestation. general requirements general eligibility of the project as per section 3.1 of the vcs standard v5.0: general eligibility as per vcs standard v5.0 justification",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Project Eligibility",
+        "sectionPath": [
+          "Project Eligibility"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "score": 76,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.1.4"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:f770541f01ef6be87790abb6b41ded9d1ae9cae69b9c81493f97b17e2a676f81:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 116,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-1-0001"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "eventId": "accepted:false_support:fa71d0f9d98577441b727e575a93b27f938414de51d0eaaa98308db6282cbc59:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "v3.0, vcs v4.4 vmd0011 v1.2 this module is applicable for calculating market-effects leakage from projects that are anticipated to reduce levels of wood harvest substantially and permanently. when project activities result in reductions in wood harvest, it is likely that production could shift to other areas of the country to compensate for the reduction, including activity shifting to forested peatland that is drained as a consequence of project implementation. this tool shall be used in countries where wood harvest happens on forested peatland regardless of the absence of peatland within the project boundary. as referenced in the framework (redd mf), the module is mandatory where: the deforestation process involves harvesting timber for commercial markets. baseline is calculated using bl-dfw and firewood or charcoal is harvested for commercial markets. in all other circumstances, the module should not be used. the module is mandatory when the deforestation process involves the extraction of timber for commercial markets. the module is applicable to the marcondes project as project activities are expected to substantially reduce and prevent wood harvesting within the project boundary through the protection and conservation of native forest areas. such reductions in timber supply could potentially lead to market-effects leakage if wood production shifts to other regions within brazil to meet market demand. the project therefore assesses the potential for market-effects leakage. vmd0013 v1.3 this module is applicable to redd project activities with emissions from biomass burning and redd-wrc project activities with emissions from biomass and / or peat burning. this module is also applicable to rwe and arr-rwe project activities with emissions from peat burning. in the baseline scenario, fire is used to clear land, resulting in emissions of co2, n2o and ch4. when used in the baseline, accounting must occur both under the baseline and in the project scenario and both in the project area and in the leakage belt. where fires occur ex- post in areas that coincide with deforested or degraded areas in the baseline, the module should be used to account for greenhouse gas emissions. vmd0016 v1.3 this module provides guidance on how to stratify the project area into discrete, relatively homogeneous units to improve the accuracy and precision of strata are only used for forest classes under deforestation pressure and are the same in the case of the baseline and project scenario. -- 65 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "CCB",
+        "sectionPath": [
+          "CCB"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "score": 104,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:65"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-6-0008"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:fd12bc81c817f8fd7ec8ee949511e738dcf29c8bca7ee2a3d5b88d6966e17315:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0014"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": true,
+        "retrievalCandidate": true,
+        "selectedCandidate": true,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "eventId": "accepted:false_support:fefd99670497edcb084f9cb76ddffe84203a5b25bab74b77219ad8fb67913be4:1",
+      "evidenceType": "project_specific_implementation",
+      "isBestMainCandidate": false,
+      "isComplementarySelectedEvidence": true,
+      "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
+      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Further Information",
+        "sectionPath": [
+          "Further Information"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "score": 90,
+      "secondaryFlags": {
+        "bestCandidate": false,
+        "boilerplate": false,
+        "broadSpanMatch": true,
+        "complementaryCandidate": true,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": true,
+        "projectSpecificScope": false,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:2.6.2"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-5-0006"
+    },
+    {
+      "acceptedInAuditResult": true,
+      "auditStage": {
+        "acceptedEvidenceRecord": true,
+        "postFilterCandidate": false,
+        "retrievalCandidate": true,
+        "selectedCandidate": false,
+        "stageWhereAccepted": "auditEvidence.result.evidence"
+      },
+      "draftMapping": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "eventId": "accepted:false_support:ff2b5056a262547252ccca9eaf064066dd0adc9c5679240c2dc0f629b22bbaf1:1",
+      "evidenceType": "project_specific_scope",
+      "isBestMainCandidate": true,
+      "isComplementarySelectedEvidence": false,
+      "normalizedQuote": "— afolu non-permanence risk tool 4.2 3.1.2 applicability of methodology (vcs, 3.1) the applicability conditions of the vm0007 methodology and its associated modules are detailed in the table below. table 31. applicability conditions and justification of conformance reference applicability condition justification of conformance vm0007 v1.8 1) land in the project area has qualified as forest (following the definition used by the vcs; in addition, see section 5.1.2) for at least the 10 years prior to the project start date. mangrove forests are excluded from any tree height requirement in a forest definition, as they consist of 95 percent mangrove species, which often do not reach the same height as other tree species. mangroves occupy contiguous areas and their functioning as a forest is independent of tree height. map biomas collection 10 and prodes / inpe data confirm continuous forest cover for all 36 properties throughout the historical reference period (2013– 2023). annual lulc maps demonstrate dense ombrophilous forest classification without interruption. 2) where land within the project area is peatland or tidal wetlands and emissions from the soc pool are deemed significant, the relevant wrc modules (see table 3) are applied alongside other relevant modules. there are no peat soils and tidal wetlands present in the marcondes redd+ project area. 3) baseline deforestation in the project area falls within either of the following categories: deforestation in the project area is legally authorized under the brazilian forest code (law 12.651/2012), article 12, which permits clearing of up to 20% of rural -- 62 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4",
+      "primarySubtype": "quote_reviewed_under_different_rule",
+      "provenance": {
+        "docId": "quick-check-review-question",
+        "page": 1,
+        "sectionHeading": "Tool",
+        "sectionPath": [
+          "Tool"
+        ],
+        "sourceType": "PDD",
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "score": 67,
+      "secondaryFlags": {
+        "bestCandidate": true,
+        "boilerplate": false,
+        "broadSpanMatch": false,
+        "complementaryCandidate": false,
+        "crossRuleMatch": true,
+        "fragmentMatch": false,
+        "moduleDeclaration": false,
+        "noisy": false,
+        "projectSpecificImplementation": false,
+        "projectSpecificScope": true,
+        "reusedAcrossRules": true
+      },
+      "serializedReload": {
+        "matchBasis": "exact_span_and_quote",
+        "present": true,
+        "spanId": "quick-check-review-question:element:paragraph:3.0"
+      },
+      "stableRuleId": "Verra.AFOLU.VM0007.v1-8.R-2-0008"
+    }
+  ],
+  "evidenceTypeDistribution": {
+    "project_specific_implementation": 134,
+    "project_specific_scope": 40
+  },
+  "fixtureProtection": {
+    "machineProposalUnchanged": true,
+    "rc2BaselineUnchanged": true,
+    "reviewedTruthUnchanged": true
+  },
+  "primarySubtypeCounts": {
+    "accepted_incomplete_or_noisy": 0,
+    "accepted_methodology_boilerplate": 0,
+    "accepted_module_or_tool_declaration": 0,
+    "accepted_project_specific_but_unmatched": 2,
+    "broad_span_contains_reviewed_quote_same_rule": 36,
+    "duplicated_across_multiple_rules": 29,
+    "machine_fragment_of_reviewed_quote_same_rule": 0,
+    "quote_reviewed_under_different_rule": 107,
+    "unresolved": 0
+  },
+  "primarySubtypePercentages": {
+    "accepted_incomplete_or_noisy": 0,
+    "accepted_methodology_boilerplate": 0,
+    "accepted_module_or_tool_declaration": 0,
+    "accepted_project_specific_but_unmatched": 0.011494252873563218,
+    "broad_span_contains_reviewed_quote_same_rule": 0.20689655172413793,
+    "duplicated_across_multiple_rules": 0.16666666666666666,
+    "machine_fragment_of_reviewed_quote_same_rule": 0,
+    "quote_reviewed_under_different_rule": 0.6149425287356322,
+    "unresolved": 0
+  },
+  "primarySubtypePrecedence": [
+    "broad_span_contains_reviewed_quote_same_rule",
+    "machine_fragment_of_reviewed_quote_same_rule",
+    "quote_reviewed_under_different_rule",
+    "duplicated_across_multiple_rules",
+    "accepted_methodology_boilerplate",
+    "accepted_module_or_tool_declaration",
+    "accepted_incomplete_or_noisy",
+    "accepted_project_specific_but_unmatched",
+    "unresolved"
+  ],
+  "repeatedEmissionCount": 162,
+  "schemaVersion": "vm0007-rc3-false-support-taxonomy-v1",
+  "source": {
+    "auditExecutionSha256": "c35eb8957a068ca791bde8b0851a8f884b313309d6b30353719f60b946ba7c2b",
+    "currentProposalKind": "same_run_serialized_reload",
+    "frozenRc2BaselineSha256": "15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf",
+    "generatedProposalSha256": "27bb22ae48d11239cff66f79a016de9ce1d8fb069bcb87f5bf64a5ee6a080a57",
+    "machineProposalFrozenSha256": "068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6",
+    "reviewedTruthSha256": "b53fc19a8316f88896b7f9564a8e2d2d0dd8b08c9e05868a7b427140f47e1127",
+    "sourceExtractionSha256": "7031b49bf70d541679788e65f74efef09921712a506a0ba4aa28d0b0bcd98747"
+  },
+  "topRepeatedSpans": [
+    {
+      "emissionCount": 38,
+      "eventIds": [
+        "accepted:false_support:020a074a2d032595a020d3d72b2f577f18e54e3bc88f6b09b5117d2be7dad101:1",
+        "accepted:false_support:04e15f69b0585f94bcb1ae465b1e5dfca0e9f631da6ecd58c632e669cbd17a95:1",
+        "accepted:false_support:05b34c99dee966278e7725167a2c7c27930c2f10664371fc21d1ca5c933b72f9:1",
+        "accepted:false_support:097a8e5fc11303f416d14f8ba55504e1d861a7ff5e237137c5e9001cb43f29d5:1",
+        "accepted:false_support:0a4153b8a3bcf1e67f49ecfb29d2062fccaac9b2aa82bc18425b884148b43880:1",
+        "accepted:false_support:0b6b386d595b6dcd140e4c1dd497e7cb6d63337bb7265448500629c72f6e6ca0:1",
+        "accepted:false_support:0eab8e3ade6b36735804d63ff300cd6f379f579838d6b579461a195c34b879ee:1",
+        "accepted:false_support:11a3d75e6b98fa1d89b00478b35cb47fd82a2910f2250c279f10a2305c1419ce:1",
+        "accepted:false_support:13abe30c523c944f962c7e27c3a3f2cde81a2b58e1c554983038c276627d43c0:1",
+        "accepted:false_support:1ee57b38e3cb23a7df9a12e629ed550e703d61ce5964210c2729fd7dc05f2305:1",
+        "accepted:false_support:26f5a9c6d8adab67c6c02995c57b7119e705b38ee3e2354079676d647fcf0206:1",
+        "accepted:false_support:2a67d99d45b35286870ed675a41cde4cfb7bf24e10aff8213a304dd8c0a8e2d1:1",
+        "accepted:false_support:31346b8ddeb72c4bd9e7a010fa568f228dc34f3a9c1fdc780ac1d17072e8a216:1",
+        "accepted:false_support:388359a8da01c7fc1c410a6a80c330fe7d4e154b565577acf97f8e91a6d26dd1:1",
+        "accepted:false_support:494b802faa7640f0a54a65b06d77b0473aef13a840aae0729a31e05db531fb26:1",
+        "accepted:false_support:5d248edbddcb17a45974d6beef4cb6533ef97656ee9343804a2341ce5ff55c2c:1",
+        "accepted:false_support:6a7fb51513b8a57869ebf5fc8189b2abced7b6a029891b32e7529df7f5d3bf1b:1",
+        "accepted:false_support:6d747b107435ae018c7f66d635138691fdf5dc28d1466ab17539166256c56887:1",
+        "accepted:false_support:7b0c7d0fc274150c1b98ffc1477e51c9130519ac8f5b77cfeee1252a1c26bdb5:1",
+        "accepted:false_support:7d821205f35b8de37fce857d94a83749b423f2a63b493d1909c39d957a694e74:1",
+        "accepted:false_support:7ffa8a73af8f150d37ab82866bf57cd53130b0015af57980078b9b10c1c7f6cd:1",
+        "accepted:false_support:93b8081142d7e00a1a22b86c8fc3bbe01f399c8815a7987d5df76dac84fa2f0f:1",
+        "accepted:false_support:971f3bb4499fa991ef114fafd4fb003831d079d7efe371625525b8509f2fe26c:1",
+        "accepted:false_support:9a9a3550d69b5e957f63d66cbcd2b51d1af3554ffb8c63e59bdfd3cc89ea883d:1",
+        "accepted:false_support:9cc7c9a9cba32340c56ec84f483fcb4a0e9acc882c9cfb00e18248402d13b93d:1",
+        "accepted:false_support:9f72ce4adc1cd298d8825653c590982f0f2d6924fb09854d43263d12d4db5ce3:1",
+        "accepted:false_support:a4983cc6c9db630b4687cf30b963f714243d6ac905534b0f3bc3b864b03c5ecd:1",
+        "accepted:false_support:a85dfe76a9808360be0ea4be7a1db811e3e1a82f96f72bded7e38cebd4d21ef1:1",
+        "accepted:false_support:aeef169820eba1ce0c2dd7aabf5dcc5c6538ea14c433f46d9f9138ad0d7f76b8:1",
+        "accepted:false_support:b4ab29bdf4a17861243e503b1e92522e215106aeb81a88ad382e7b88c40a85ec:1",
+        "accepted:false_support:bb6ce8a89df516a0567f5addb9e6ec506c21416860e031134739b7450c296b52:1",
+        "accepted:false_support:befb7a33067ed7eccf56e02544382c4625aadef237a559ca42dae152322a9d53:1",
+        "accepted:false_support:d7d08bdf0c09bc982d2c3c53282579f8e21393084305dcb2c97392bca27c16b7:1",
+        "accepted:false_support:da913024ee6309b1d0bd23f2912a4f143b1e9e892ded7e5299dc52661540b162:1",
+        "accepted:false_support:e9176c2e5dc9b83fb1cd23f8b40660919204ade76fc620a394922c43d2c3823c:1",
+        "accepted:false_support:ea057a3c814683fa42d193e5e41f192906423104f7b4ac3d7cbb861a7d2d2646:1",
+        "accepted:false_support:eaf1b3c57a253f495bc9d1f494110d3a380e73e8ddc4378b2bda7196b0eeab8b:1",
+        "accepted:false_support:f5d39944c97cdd3a3e7f3fec72a9a23e50ede1e3f7d277c90239ec576b956576:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"CCB\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:63\"\n}"
+    },
+    {
+      "emissionCount": 38,
+      "eventIds": [
+        "accepted:false_support:04d692e005d2140a33178fefd68ac5d20f50aca5803838fe7b4d422cb30e38a2:1",
+        "accepted:false_support:05a564ee66c7d2c34cecbabd7adcd66b9c328831c8389905f3e3b1a00c4ed3b8:1",
+        "accepted:false_support:074eb76eaf06046fb55bffd2016ec37b35575f429067bd7a446d06dc0590d0d4:1",
+        "accepted:false_support:0ce9e2986ca52c513e6b73e48be568d2599f41d8c3b5dbbc2dc066d8dc108f56:1",
+        "accepted:false_support:123ac0ab4366f7f909df9c98f6871ffb35a1dfe68129b5e5951d91cfce2d4a90:1",
+        "accepted:false_support:16912ced2f04b8fec530e964be284cc305de2768656b75b64cabc6a60e5d34dd:1",
+        "accepted:false_support:20dd0f7342444860c49b235e82884b47a73b052ede6231af004920d9a0939b06:1",
+        "accepted:false_support:2fd0d9c865babd5d5e429747d6439e9fddfa4469d8460c6caa2978e73afddb8e:1",
+        "accepted:false_support:3d6f43aadef1a8f8d521c07389d3ceb45718dc319330c7101f2f03c9a291454d:1",
+        "accepted:false_support:3f3447c4b2ba5292d8905ac9aa2e7a194d06816cb06d4f0e10383054ac432ad6:1",
+        "accepted:false_support:49e99b47599c2cccf9bd95635cdd7b397739824693187194f123382d59f3bc50:1",
+        "accepted:false_support:4cbbd7c13d33f7a006c05961ed206dff5c69a7da028c3a99817a476ab957ce5f:1",
+        "accepted:false_support:4d8c10aca15e30b1df5e0365cf439969c4a78a1e2dcf0031b5a1a7eefd1a58ee:1",
+        "accepted:false_support:562a1927afeb074f7f41fbbea86ead63350d202a2a98f29f695b9a65261080d2:1",
+        "accepted:false_support:5891b2037915b469727fe7b5fd0249808e4ba8920ce3c938b3b7d3d983cb030a:1",
+        "accepted:false_support:5d4ce86d67d3c5cf55820acd1ae62389024fb218dfa4311bcdc3526345bc5262:1",
+        "accepted:false_support:5e636ab58af61cea0ce1cdffcf9a762d50567a1cb083086576fb267f7ba0ce15:1",
+        "accepted:false_support:6a0ef2df2fcea10aa3a034133170b58c244d2090a425af83b64a67bef57460eb:1",
+        "accepted:false_support:7312be705f04e0f148337556e89b96e89076ae29d9966f1d3f9f7c402d73fcdb:1",
+        "accepted:false_support:76e61a42ed50e7e8b11b19963b6bffcc8ea1458edbc73ef14eabbaf0b8af5e3f:1",
+        "accepted:false_support:7ce5bbedff280a275a3798ccc0d855bb01ed0d06004b1f868e51a7b2efa62aff:1",
+        "accepted:false_support:7ea6464495a9b7715806b282d8291c573793c2b4cd6fce33af6be5f45d99d233:1",
+        "accepted:false_support:86594c405c89fbf98b00df6cc5c8dc99961fb52e4a09b3e5aa8ad2ed8237c1b8:1",
+        "accepted:false_support:8970c21e25075453a621e3c8883a27670296dde402fa0735f1007024bd958856:1",
+        "accepted:false_support:904958a4b12cfd9641a95084258089cbe267ff2576de60163e9184eb885e747c:1",
+        "accepted:false_support:91acc7c4f1af97d354db0bf79e9389b50a34e57f87b07105fa4a5c56221148a0:1",
+        "accepted:false_support:a227910c59ffccdadbb6aecf6f5b1c65d1817d6518cbb97d1a57aba1d06c5a97:1",
+        "accepted:false_support:ac911da40a073b6018d2a76bdfac5be41282d8df1d2605da5f62ae4b2c84ed02:1",
+        "accepted:false_support:c8619ce84f589c12fc0db45508a39e73d7fa2bc46474c18268c0f5d0666f3ce8:1",
+        "accepted:false_support:d488914dc0a85bb537aa8b842caaa27d8e08b44a23c1d2505c38437778ef41ea:1",
+        "accepted:false_support:e13e751a9ec1f7156f901c8708eb6338af52888623717483b881d80b92d88680:1",
+        "accepted:false_support:ea87ab8925ae217e8d241a7fb46e37674f2685f996c7476a8a447c2d2639bd92:1",
+        "accepted:false_support:ec2f5c2d39ee952da84b19171f7db5b68d8faf5e75c2678e7ca88958f35936da:1",
+        "accepted:false_support:ecfcd8339f782ebe10ce9ec29b8b98ed7ba9cd2ea00420c983203f848e3e23d9:1",
+        "accepted:false_support:f032514d65a5de48c83c7badbb2dd44e76fe439429943c28eb99a8aa54600cb1:1",
+        "accepted:false_support:f585aaf0b42e9e32d13c0fd72c60942d6632f74dfa1f5f94a18ec737ea466193:1",
+        "accepted:false_support:f770541f01ef6be87790abb6b41ded9d1ae9cae69b9c81493f97b17e2a676f81:1",
+        "accepted:false_support:fa71d0f9d98577441b727e575a93b27f938414de51d0eaaa98308db6282cbc59:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"CCB\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:65\"\n}"
+    },
+    {
+      "emissionCount": 32,
+      "eventIds": [
+        "accepted:false_support:03e4a8bdc3bb675cb8ce99033fa95c9ab10d4dac6817c50a32da1ef3ee5195b2:1",
+        "accepted:false_support:0abd85916b31f82dba0bbeba437c1f6e32d4868b9225dbef75cabbf400763d6a:1",
+        "accepted:false_support:121baeb88f6b0a6cad529121d5c4f61f266698cebb30b208cd49de0a1a561d17:1",
+        "accepted:false_support:16db461f5d26a24c653e3c7d9c53fa25476d221d52f36467fc710c364a1a36d2:1",
+        "accepted:false_support:1aa039cfb79b3f8065a03ce9358a26eb7a21463dd0d746e279fba5fbafebdfc1:1",
+        "accepted:false_support:1ce85aa65712feb115ffe201f66f82e6796c7ddc26a1d1eae6169d968f9dc473:1",
+        "accepted:false_support:1f57cb9faa9976d9bf6f7dd033b649ea9a7dc30315b6dd5dc69fa157e2eab1af:1",
+        "accepted:false_support:2013153a1a4658e246ba36d40afd02d7367240d70bf3a59e3242f90b7e439aa8:1",
+        "accepted:false_support:21f24416eb5d603e41804602286a3c1939c8ef83b7ddd7c1dc0d001ea99bf0a8:1",
+        "accepted:false_support:295e8f7d9a041e2c859f62e9239e6f05ca6b94436e30537f659a3aa1ac2cfd35:1",
+        "accepted:false_support:32cfe9c84ee518d1432e1a4734712d640e528c86ed6478198ac5abe038ec6c84:1",
+        "accepted:false_support:46fae4c26c30895284b3fed5cb4573057fe9d76a520b95812d06c5c6dd18a983:1",
+        "accepted:false_support:5b7e6dde71b953d1e39fdccb2c6f4acda056d4585f604f7a4d9240ab1a950f1c:1",
+        "accepted:false_support:64f35a3d32d416f0d298445e68a8bc86eac5eb87ed4219cb4a24ba5234685321:1",
+        "accepted:false_support:6b9e852109b7aeb48bc2a950f1b5f194b254f750230e1ed493740722806b40d6:1",
+        "accepted:false_support:775b154d30a2600591418c338535ecfc88f996181936e7cbeafa78a418de205f:1",
+        "accepted:false_support:7c6750e49f3fc3dd1e6dbaf62a0527e341133fc794cf50ab554f70444162de0a:1",
+        "accepted:false_support:81ff2aa83dec24516818de2aafa69a34630de9574e4af7303f638ebbfe845766:1",
+        "accepted:false_support:9c975e50a421ea19cdef5c352bb1e8ade4552b388185ff3b72ee1d613e3e80a3:1",
+        "accepted:false_support:a12522654464d3294bfe411714fdce9f27d80e3065add1b31948b6a5aa8aa799:1",
+        "accepted:false_support:a27c66c5dfe7ef77492e9c21d663ed0b2d7e55351aba9fcc4bc77f4704352aa0:1",
+        "accepted:false_support:b09fad18a93b65a1f58ccc0f9ecca06edaa3949fe6e6d0c4c98a02e54d9865c3:1",
+        "accepted:false_support:bf6dcd88f4eecb91d5e0f39f7573b3b9ae30554e9b83d439600a120b1552200b:1",
+        "accepted:false_support:d12689e4e57b847b9e0ef44be9a1d9c5abc1fb06728cbbdd61f068a4e4438d06:1",
+        "accepted:false_support:dc1888258a850c5da941e9dfaea12182ea64ddfeb9978204eb2f4341f8897976:1",
+        "accepted:false_support:dc1b87281f1ad34827e1863dfc83ff86dc164bb15a7b319a8a689bcf6ea331a1:1",
+        "accepted:false_support:e0f3e7ea9055c9ff2e9ebc3cc8eb54347252ab5428a778409153cda7179525d2:1",
+        "accepted:false_support:e2380461793fee894cea925fd1b40f76ce7f03e9f8016bc96831841a12c24b2d:1",
+        "accepted:false_support:e268fa07a4e58fb46faa29b9f4ef8f9a0f5e2d6bd9b3381aa6843068a1cd17a2:1",
+        "accepted:false_support:f18bd2ce516e6055da8e13d552ed168451e9217a062ab187eb73f324547f056c:1",
+        "accepted:false_support:fd12bc81c817f8fd7ec8ee949511e738dcf29c8bca7ee2a3d5b88d6966e17315:1",
+        "accepted:false_support:ff2b5056a262547252ccca9eaf064066dd0adc9c5679240c2dc0f629b22bbaf1:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"Tool\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:3.0\"\n}"
+    },
+    {
+      "emissionCount": 20,
+      "eventIds": [
+        "accepted:false_support:0ba76b6b8c913c187e1a782ed27f126a40d8f37b6ac537ccb63cfc9cf80dcce9:1",
+        "accepted:false_support:277fd58ae36864c7838f0b4e794a0fde56897cb4106c4b957635470d5ecf779f:1",
+        "accepted:false_support:2de42bc12b07ac2f8c8ebb421b3775bacc5e7e3cc69cc9ec56fc9d032e5964a8:1",
+        "accepted:false_support:30e410aee85aea9bc35503f1ae6ca7e6c19c1fdbed8c5cd32b4c1e13d675a7ad:1",
+        "accepted:false_support:5496ada4b5bafcbc56113741b04097adbc4e5dc2c2939aa56a331897acc142b6:1",
+        "accepted:false_support:583483d35fe1e85175073b7918d62e3fec71f5904975293f316c65f6fe2bd284:1",
+        "accepted:false_support:65c9032f873c6f969e388c7974f62496fa265537f52af0b76b60effd2d4ac772:1",
+        "accepted:false_support:6b2e2a0b4293a52f70d44e9a9798ddc462d02f0f393916e3bb067d1d2edc0364:1",
+        "accepted:false_support:70656318577ea39eeb301f6b79e1222dc16207c2601e90567954161863733d0c:1",
+        "accepted:false_support:7a273cdcafd1edd3232af475d02365823473ddd3abf9ae6e4e8d63c0395d5e1b:1",
+        "accepted:false_support:94e58fbaaddb7438dd5e0be6de6fbcd6b4aad031a2d6cb645bbbad0b7da94854:1",
+        "accepted:false_support:965bfcadd890827cdf96be1e923e134397db0ff6ef61a5c761960f7501dc2309:1",
+        "accepted:false_support:97cc236ba80b386b73a39bdf5af0e0cf918d58c969ff796426041a521517251f:1",
+        "accepted:false_support:9e3597620f9d388c1d6334219c7d209a714efd38a83e8a787adae659ce415fcf:1",
+        "accepted:false_support:a7576595b8258552ae0a156be31b683d7b184dd2357a47731c68c466e17e1288:1",
+        "accepted:false_support:aa77310084ed61d67a559c5567671855a52818a1ed2f35df22e3f89f7e070cd7:1",
+        "accepted:false_support:c21be7773619b3d1ef2b9670a70dc7a03c2d8e5a79802101d17c06ed0746b784:1",
+        "accepted:false_support:d7e18bfa283be1aa73bfbf841a4a445ee930d82fc108547624bbcf66088d6acd:1",
+        "accepted:false_support:e43121fac478c197cf545f0b01d32d7fee3c5d1a3d7273063548560bda777404:1",
+        "accepted:false_support:eacc90115f2ad8b3fbb45e3d737cf2c20adc328b46c10ae59551e989a6b55244:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"Project\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:3.8.2\"\n}"
+    },
+    {
+      "emissionCount": 14,
+      "eventIds": [
+        "accepted:false_support:371d47fa22c3153d6bd7d05556712dde9db3a1c3ae17e645926adab5c7176878:1",
+        "accepted:false_support:3be1431062d1af6779c1e3341225e01a6eb5ec9f2f7bd41eca1698cd2df1d169:1",
+        "accepted:false_support:52da62ac5d299003864673544c60c51523934e3807a932f6c1e1aed2ad94ddc1:1",
+        "accepted:false_support:5429e7315c0152a5bcd36da8514bb665661a535909050e32962a03221eea9df2:1",
+        "accepted:false_support:59ed8e06ee74dccd53f98b2c1e46e541d07122132b179b854c729de0c4177d13:1",
+        "accepted:false_support:9a07d68152bcf029de5ae22c7131b8be5f86e8c3fb0119d94565648fa46a5201:1",
+        "accepted:false_support:9ef75f4bd433e664c95542565a2a1d05577e61bea33f9779431e4c62454e8113:1",
+        "accepted:false_support:a8b9ad28ab381bd1c0718a7bdb3fdf097169e1b14e3a28b749002c9458bf577a:1",
+        "accepted:false_support:ad5d1419d5561989bf1a2bc8c310b6b98b15b1e55030600fc0540e97f48fbbd7:1",
+        "accepted:false_support:c5a5c32fe4440762d3218ae73d9999318792ba875c28cb8e7e61bf22470de2d2:1",
+        "accepted:false_support:cb5e6824d0076241411c392739b36ace725ea1009fa5f41c0f4fd6f03ee45764:1",
+        "accepted:false_support:ced9bbf66b61f12362207b33d0b928838ecd5c8fd5e84b517951d3dd3032969d:1",
+        "accepted:false_support:f49d535858af20aef21e3778c49ae041878be0a6da8305019ddf25f6b8a9f7e7:1",
+        "accepted:false_support:fefd99670497edcb084f9cb76ddffe84203a5b25bab74b77219ad8fb67913be4:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"Further Information\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:2.6.2\"\n}"
+    },
+    {
+      "emissionCount": 9,
+      "eventIds": [
+        "accepted:false_support:576410a6f2d7f7155136707fb6a89b184dd5990348440d45748f5b598d88b956:1",
+        "accepted:false_support:77bb6b9f1b3328cbc34d123ded0402bd1e2bbe199c66dfcd65cf7cc6e8dacb33:1",
+        "accepted:false_support:aeabd4f82211e80e9eabb8742303ce863fb16ceac9f887db2e9594054f2d31ac:1",
+        "accepted:false_support:baa68e2f31c23d1902d6f5b73a496340fdd66f1ace0f3265fdba88b7d0ba3ca1:1",
+        "accepted:false_support:c2404269951008fd157b34d2c7d6ec9ed88e353ceabbeeec8f4dc927c5333888:1",
+        "accepted:false_support:c7da514ddb20825cae9a8a01a21a24dd24a3c7b328da18e94b342fae0b38fe0e:1",
+        "accepted:false_support:d028b658f3e019364b19197a0a0d50cb7047dff1b25e8a57210800699780cdd1:1",
+        "accepted:false_support:ecfc18af33a589206018e3f1792ef56faccbcef9b53e02a0ae7a1b77564c3cea:1",
+        "accepted:false_support:f67533b48d376cf297d2442a133c74a62bcd17a2cd7643292ec37770d50422c4:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"Project Eligibility\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:2.1.4\"\n}"
+    },
+    {
+      "emissionCount": 9,
+      "eventIds": [
+        "accepted:false_support:2f07b0f6d7b4a0b5211c2049dc2d7cd656166c9a884d15ab01db7d6f0d623d08:1",
+        "accepted:false_support:5b4ad2c8d17fe5d489b7388e4ae8b8a0123a406a4e0045072f829b560a39e2bb:1",
+        "accepted:false_support:9286c5e3f26585cfc339558a1c5962abd62bc22b75d416e94a9e6c35d2ba129e:1",
+        "accepted:false_support:99cb39c732b86661b0071b84f67e1f56dcc927064ded89f28f988a616b1381b9:1",
+        "accepted:false_support:a52222776e9e87e12c3efb79895e07c4f9d047f738d98147beccb0e03919a12d:1",
+        "accepted:false_support:addd90c0ab48a73322b2c0457c5e8dbcb94484154b2ff3ce4b67e55b1e1cfd7c:1",
+        "accepted:false_support:c090616f0f3ba13f6b14fbe05b154aff9749ea78e6521b9e2da0203cf0e6b911:1",
+        "accepted:false_support:cc663678f3cee0e65980db00e3b1bbf59be5d98b7ce4df0e01823df8a65eb661:1",
+        "accepted:false_support:e4f861d6fcac3c785e2788bc3ed4c2c42bb50d4b15d068a44388c991672ff7eb:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"Sustainable Development Contributions\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:2.1.18\"\n}"
+    },
+    {
+      "emissionCount": 5,
+      "eventIds": [
+        "accepted:false_support:0ebfce965d9a7a9d514ba17d964c0e0d9276d2d1ea4326950534cc59fb368fef:1",
+        "accepted:false_support:4f06a8e07c6cc17029a28d885bb1572e2449fe3192aab262f3c129890dbe2d08:1",
+        "accepted:false_support:595a9b5faddb41a0e8763210e7ff0937c3cee4f4fdca31885ef997aa9d390f68:1",
+        "accepted:false_support:90e0c96bf60123a15e1c0dfd163a0e882ae838cba5ab727dcf8fa8d1b50861be:1",
+        "accepted:false_support:e51df59bf09441f00d0e72a282352e111dbec1e05f007dd02232b3f00f83465b:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"CCB\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:22\"\n}"
+    },
+    {
+      "emissionCount": 4,
+      "eventIds": [
+        "accepted:false_support:1b8fe27b9168c7bb0863a111354bd803416ebed369571259f9874c3b7c7b7544:1",
+        "accepted:false_support:9a5743451c18b76a217d105aa9dc1ff4109337c1084caf45f137bbd3298e9453:1",
+        "accepted:false_support:bb169ae811060694541f82c1f3eb62ee635dd39fc4253949427d9be90bd2d377:1",
+        "accepted:false_support:d49cb099f89594616d259e7a559c642edf0fb4bac46588c40ce2402bd7765c99:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"CCB\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:64\"\n}"
+    },
+    {
+      "emissionCount": 3,
+      "eventIds": [
+        "accepted:false_support:042a4923db21b38129dd609c982d6885a91dcf31e65e23492126c296c791b76b:1",
+        "accepted:false_support:663ea38db7a1b6e075fde5d1c857e186088b06936ffc9f1d8b0a7b4711ce280b:1",
+        "accepted:false_support:be0942b0966b0a3e3cb95f486766a9de6132bb9f51a2b42a14ff7cbd14125ed0:1"
+      ],
+      "sourceSpan": "{\n  \"docId\": \"quick-check-review-question\",\n  \"page\": 1,\n  \"sectionPath\": [\n    \"The\"\n  ],\n  \"spanId\": \"quick-check-review-question:element:paragraph:3.8.1\"\n}"
+    }
+  ],
+  "totalEvents": 174,
+  "traceVersion": "rc3-current-false-support-taxonomy-v1",
+  "uniqueSourceSpanCount": 12
+}

--- a/docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json
@@ -6812,7 +6812,7 @@
       "isBestMainCandidate": false,
       "isComplementarySelectedEvidence": true,
       "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
-      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "primarySubtype": "quote_reviewed_under_different_rule",
       "provenance": {
         "docId": "quick-check-review-question",
         "page": 1,
@@ -6827,7 +6827,7 @@
       "secondaryFlags": {
         "bestCandidate": false,
         "boilerplate": false,
-        "broadSpanMatch": true,
+        "broadSpanMatch": false,
         "complementaryCandidate": true,
         "crossRuleMatch": true,
         "fragmentMatch": false,
@@ -6965,7 +6965,7 @@
       "isBestMainCandidate": false,
       "isComplementarySelectedEvidence": true,
       "normalizedQuote": "-- 60 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 61 ccb v3.0, vcs v4.4 this section is not required at the under development stage in accordance with section 3.1.6 of the verra registration and issuance process v5.0. the relevant information will be provided during the validation stage of the project. 3 climate 3.1 application of methodology 3.1.1 title and reference of methodology (vcs, 3.1) the marcondes redd+ project applies the climate, communities and biodiversity (ccb) and verified carbon standard (vcs) with the intention of reducing co2 emissions from planned (apd) deforestation compared to baseline levels. as required by vm0007 v1.7, the project area consists of contiguous, discrete areas covered by forest that meet the definition of eligible forest, which would be an area that has been forested for at least 10 years prior to the project start date. methodology vm0007 applies to project activities that prevent conversion of forest to non-forest and of native grassland to a non-native state. table 30. methodologies, modules, and tools applied type reference id title version applied methodology vm0007 redd+ methodology framework (redd+mf) (avoided planned deforestation) 1.8 module vmd0001 estimation of carbon stocks in the above- and below-ground biomass in live trees and non-tree pools 1.2 module vmd0002 estimation of carbon stocks in the dead wood pool 1.1 module vmd0003 estimation of carbon stocks in the litter pool 1.1 module vmd0005 estimation of carbon stocks in the soil organic carbon (soc) pool 1.1 module vmd0006 estimation of baseline carbon stock changes and ghg emissions from planned deforestation (bl- pl) 1.4 module vmd0009 estimation of emissions from activity shifting for avoiding planned deforestation / forest degradation and avoiding planned wetland degradation (lk-asp) 1.3 module vmd0011 estimation of emissions from market leakage (lk- me) 1.2 -- 61 of 81 -- ccb & vcs project description template ccb version 3.0, vcs version 4.4 62 ccb v3.0, vcs v4.4 module vmd0015 methods for monitoring of greenhouse gas emissions and removals (m-redd) 2.3 module vmd0016 methods for stratification of the project area (x- str) 1.3 module vmd0017 estimation of uncertainty for redd project activities (x-unc) 2.2 tool vt0001 tool for the demonstration and assessment of additionality in vcs-afolu project activities",
-      "primarySubtype": "broad_span_contains_reviewed_quote_same_rule",
+      "primarySubtype": "quote_reviewed_under_different_rule",
       "provenance": {
         "docId": "quick-check-review-question",
         "page": 1,
@@ -6980,7 +6980,7 @@
       "secondaryFlags": {
         "bestCandidate": false,
         "boilerplate": false,
-        "broadSpanMatch": true,
+        "broadSpanMatch": false,
         "complementaryCandidate": true,
         "crossRuleMatch": true,
         "fragmentMatch": false,
@@ -8899,10 +8899,10 @@
     "accepted_methodology_boilerplate": 0,
     "accepted_module_or_tool_declaration": 0,
     "accepted_project_specific_but_unmatched": 2,
-    "broad_span_contains_reviewed_quote_same_rule": 36,
+    "broad_span_contains_reviewed_quote_same_rule": 34,
     "duplicated_across_multiple_rules": 29,
     "machine_fragment_of_reviewed_quote_same_rule": 0,
-    "quote_reviewed_under_different_rule": 107,
+    "quote_reviewed_under_different_rule": 109,
     "unresolved": 0
   },
   "primarySubtypePercentages": {
@@ -8910,10 +8910,10 @@
     "accepted_methodology_boilerplate": 0,
     "accepted_module_or_tool_declaration": 0,
     "accepted_project_specific_but_unmatched": 0.011494252873563218,
-    "broad_span_contains_reviewed_quote_same_rule": 0.20689655172413793,
+    "broad_span_contains_reviewed_quote_same_rule": 0.19540229885057472,
     "duplicated_across_multiple_rules": 0.16666666666666666,
     "machine_fragment_of_reviewed_quote_same_rule": 0,
-    "quote_reviewed_under_different_rule": 0.6149425287356322,
+    "quote_reviewed_under_different_rule": 0.6264367816091954,
     "unresolved": 0
   },
   "primarySubtypePrecedence": [
@@ -8928,14 +8928,14 @@
     "unresolved"
   ],
   "repeatedEmissionCount": 162,
-  "schemaVersion": "vm0007-rc3-false-support-taxonomy-v1",
+  "schemaVersion": "vm0007-rc3-false-support-taxonomy-v2",
   "source": {
-    "auditExecutionSha256": "c35eb8957a068ca791bde8b0851a8f884b313309d6b30353719f60b946ba7c2b",
+    "auditExecutionSha256": "770b05a6e82757d436c9f40c7698742f64ae1ad8c906b3b127926027f5198a25",
     "currentProposalKind": "same_run_serialized_reload",
-    "frozenRc2BaselineSha256": "15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf",
-    "generatedProposalSha256": "27bb22ae48d11239cff66f79a016de9ce1d8fb069bcb87f5bf64a5ee6a080a57",
+    "frozenRc2BaselineSha256": "12c6276c12ba62d7f93987e3d4097d732ab05ded1432621a5895aa7527e5be87",
+    "generatedProposalSha256": "2ffe9413b09a795edc50b15e9564716f9fcf51d916f13368b416d2b22088fb85",
     "machineProposalFrozenSha256": "068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6",
-    "reviewedTruthSha256": "b53fc19a8316f88896b7f9564a8e2d2d0dd8b08c9e05868a7b427140f47e1127",
+    "reviewedTruthSha256": "af93a39a0b874377efe88648f6f4538c2454c9e8dcceae66086681b4a336f75c",
     "sourceExtractionSha256": "7031b49bf70d541679788e65f74efef09921712a506a0ba4aa28d0b0bcd98747"
   },
   "topRepeatedSpans": [
@@ -9173,6 +9173,6 @@
     }
   ],
   "totalEvents": 174,
-  "traceVersion": "rc3-current-false-support-taxonomy-v1",
+  "traceVersion": "rc3-audited-v2-false-support-taxonomy-v1",
   "uniqueSourceSpanCount": 12
 }

--- a/docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json
@@ -8931,8 +8931,9 @@
   "schemaVersion": "vm0007-rc3-false-support-taxonomy-v2",
   "source": {
     "auditExecutionSha256": "770b05a6e82757d436c9f40c7698742f64ae1ad8c906b3b127926027f5198a25",
+    "auditedV2BaselineSha256": "12c6276c12ba62d7f93987e3d4097d732ab05ded1432621a5895aa7527e5be87",
     "currentProposalKind": "same_run_serialized_reload",
-    "frozenRc2BaselineSha256": "12c6276c12ba62d7f93987e3d4097d732ab05ded1432621a5895aa7527e5be87",
+    "frozenRc2BaselineSha256": "15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf",
     "generatedProposalSha256": "2ffe9413b09a795edc50b15e9564716f9fcf51d916f13368b416d2b22088fb85",
     "machineProposalFrozenSha256": "068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6",
     "reviewedTruthSha256": "af93a39a0b874377efe88648f6f4538c2454c9e8dcceae66086681b4a336f75c",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "preverif:rc3:diagnostic": "tsx scripts/preverif/generate-vm0007-rc3-diagnostic.ts",
     "preverif:rc3:same-run-handoff": "tsx scripts/preverif/generate-vm0007-rc3-same-run-handoff.ts",
     "preverif:rc3:current-comparison": "tsx scripts/preverif/generate-vm0007-rc3-current-comparison.ts",
+    "preverif:rc3:false-support-taxonomy": "tsx scripts/preverif/generate-vm0007-rc3-false-support-taxonomy.ts",
     "preverif:rc3:selected-match-subtaxonomy": "tsx scripts/preverif/generate-vm0007-rc3-selected-match-subtaxonomy.ts",
     "preverif:rc3:audited-pre-fix-baseline": "tsx scripts/preverif/generate-vm0007-rc3-audited-pre-fix-baseline.ts",
     "preverif:rc3:baseline-registry": "tsx scripts/preverif/generate-vm0007-rc3-baseline-registry.ts",

--- a/scripts/preverif/generate-vm0007-rc3-baseline-registry.ts
+++ b/scripts/preverif/generate-vm0007-rc3-baseline-registry.ts
@@ -26,6 +26,7 @@ const auditedDiagnostic = JSON.parse(fs.readFileSync(file("RC3_AUDITED_DIAGNOSTI
 const auditedSelectedMatch = JSON.parse(fs.readFileSync(file("RC3_AUDITED_SELECTED_MATCH_SUBTAXONOMY.json"), "utf8"));
 const auditedHandoff = JSON.parse(fs.readFileSync(file("RC3_AUDITED_SAME_RUN_HANDOFF_TRACE.json"), "utf8"));
 const auditedComparison = JSON.parse(fs.readFileSync(file("RC3_AUDITED_CURRENT_COMPARISON.json"), "utf8"));
+const falseSupportTaxonomy = file("RC3_FALSE_SUPPORT_TAXONOMY.json");
 
 const historicalArtifacts = [
   file("RC2_BASELINE.json"), file("RC2_BASELINE.md"), file("RC3_DIAGNOSTIC.json"),
@@ -64,25 +65,16 @@ const registry = {
       productionExecution: { auditExecutionSha256: auditedBaseline.productionExecution.auditExecutionSha256 },
       generatedSameRunProposal: ref(path.join(artifactDir, "RC3_AUDITED_PRE_FIX_PROPOSAL.json")),
       baselineArtifacts: [ref(file("RC3_AUDITED_PRE_FIX_BASELINE.json"))],
-      diagnosticArtifacts: auditedArtifacts.filter((artifact) => artifact.path.includes("DIAGNOSTIC") || artifact.path.includes("SUBTAXONOMY") || artifact.path.includes("HANDOFF") || artifact.path.includes("COMPARISON")),
+      diagnosticArtifacts: [
+        ...auditedArtifacts.filter((artifact) => artifact.path.includes("DIAGNOSTIC") || artifact.path.includes("SUBTAXONOMY") || artifact.path.includes("HANDOFF") || artifact.path.includes("COMPARISON")),
+        ref(falseSupportTaxonomy),
+      ],
       manifestArtifact: ref(file("RC3_AUDITED_PRE_FIX_BASELINE_MANIFEST.json")),
       counts: auditedManifest.counts,
       createdByThisPr: true,
       immutable: true,
     },
   ],
-  provisional: {
-    logicalLabel: "rc3-5",
-    status: "provisional",
-    sourcePr: "#1046",
-    purpose: "existing false-support taxonomy pending audited-baseline regeneration",
-    officialFrozenBaseline: false,
-    mustRegenerateAfter: "PR 2",
-    artifactIsNotIndexedAsFrozen: true,
-    sourceBranch: "roadmap/rc3-5-false-support-taxonomy",
-    sourceArtifactPath: "docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json",
-    note: "The provisional PR #1046 artifact is not present on main and is intentionally excluded from v2 until PR 3 regenerates it against the audited truth.",
-  },
   reproduction: {
     auditedCommand: "npm run preverif:rc3:audited-pre-fix-baseline",
     registryCommand: "npm run preverif:rc3:baseline-registry",
@@ -93,4 +85,4 @@ const registry = {
 };
 
 fs.writeFileSync(outputPath, `${canonicalJsonStringify(registry)}\n`, "utf8");
-console.log(`Wrote RC3 baseline registry: ${registry.versions.length} frozen versions; provisional=${registry.provisional.sourcePr}.`);
+console.log(`Wrote RC3 baseline registry: ${registry.versions.length} frozen versions; audited diagnostics=${registry.versions[1].diagnosticArtifacts.length}.`);

--- a/scripts/preverif/generate-vm0007-rc3-false-support-taxonomy.ts
+++ b/scripts/preverif/generate-vm0007-rc3-false-support-taxonomy.ts
@@ -8,7 +8,7 @@ import { auditEvidence } from "../../src/lib/preverif/evidenceAudit";
 import { buildVm0007EvidenceMapDraft } from "../../src/lib/preverif/vm0007EvidenceMapDraft";
 import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "../../src/lib/preverif/vm0007EvidenceContracts";
 import { type Vm0007EvidenceBenchmarkMachineRow, type Vm0007EvidenceBenchmarkReviewedRow } from "../../src/lib/preverif/vm0007EvidenceBenchmark";
-import { buildVm0007Rc3FalseSupportTaxonomy, serializeVm0007Rc3FalseSupportTaxonomy } from "../../src/lib/preverif/vm0007Rc3FalseSupportTaxonomy";
+import { assertAuditedV2Identities, AUDITED_V2_IDENTITIES, buildVm0007Rc3FalseSupportTaxonomy, serializeVm0007Rc3FalseSupportTaxonomy } from "../../src/lib/preverif/vm0007Rc3FalseSupportTaxonomy";
 
 const root = process.cwd();
 const artifactDir = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp");
@@ -17,6 +17,8 @@ const richRulesPath = path.join(root, "public/methodologies/Verra/AFOLU/VM0007/v
 const machinePath = path.join(fixtureDir, "machine-proposal.json");
 const reviewedPath = path.join(fixtureDir, "gold.json");
 const extractionPath = path.join(fixtureDir, "raw-document-extraction.json");
+const auditedBaselinePath = path.join(artifactDir, "RC3_AUDITED_PRE_FIX_BASELINE.json");
+const auditedProposalPath = path.join(artifactDir, "RC3_AUDITED_PRE_FIX_PROPOSAL.json");
 const outputPath = path.join(artifactDir, "RC3_FALSE_SUPPORT_TAXONOMY.json");
 const read = (filePath: string) => JSON.parse(fs.readFileSync(filePath, "utf8")) as any;
 const digest = (filePath: string) => crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
@@ -24,6 +26,15 @@ const digest = (filePath: string) => crypto.createHash("sha256").update(fs.readF
 const machine = read(machinePath);
 const reviewed = read(reviewedPath);
 const extraction = read(extractionPath);
+const auditedBaseline = read(auditedBaselinePath);
+const auditedProposalBytes = fs.readFileSync(auditedProposalPath, "utf8");
+const auditedTruthSha256 = digest(reviewedPath);
+const sourceExtractionSha256 = digest(extractionPath);
+const auditedBaselineSha256 = digest(auditedBaselinePath);
+if (auditedTruthSha256 !== AUDITED_V2_IDENTITIES.reviewedTruthSha256) throw new Error("False-support taxonomy requires audited V2 reviewed truth");
+if (sourceExtractionSha256 !== AUDITED_V2_IDENTITIES.sourceExtractionSha256) throw new Error("False-support taxonomy source extraction identity changed");
+if (auditedBaselineSha256 !== AUDITED_V2_IDENTITIES.auditedBaselineSha256) throw new Error("Audited V2 baseline identity changed");
+if (auditedBaseline.truth?.sha256 !== AUDITED_V2_IDENTITIES.reviewedTruthSha256 || auditedBaseline.generatedProposal?.sha256 !== AUDITED_V2_IDENTITIES.generatedProposalSha256 || auditedBaseline.productionExecution?.auditExecutionSha256 !== AUDITED_V2_IDENTITIES.productionExecutionSha256) throw new Error("Audited V2 baseline manifest identities do not match");
 const rules = read(richRulesPath).map((rule: Record<string, unknown>) => ({
   id: String(rule.id), title: String(rule.title ?? ""), summary: String(rule.summary ?? ""), logic: String(rule.logic ?? ""), text: String(rule.text ?? ""), type: String(rule.type ?? ""),
 }));
@@ -40,14 +51,16 @@ const audit = auditEvidence({
   versionContext: { methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8" },
 });
 const draft = buildVm0007EvidenceMapDraft({
-  auditId: "rc3-current-same-run-comparison-vm0007-v18",
+  auditId: "rc3-audited-pre-fix-baseline-marcondes-vm0007-v18",
   generatedAt: "1970-01-01T00:00:00.000Z",
   rules: rules.map((rule: any) => ({ ...rule, snippet: rule.text, tags: [] })),
   audit,
   sourceDocument: { documentId: context.evidenceDocument.docId, documentName: "5953-Marcondes-Brazil-pdd.pdf", contentSha256: machine.sourceDocument.contentSha256 },
 });
 if (!draft.ok) throw new Error(`False-support taxonomy draft build blocked: ${draft.blockedBy.join(", ")}`);
-const serializedProposal = JSON.stringify(draft.package);
+const serializedProposal = canonicalJsonStringify(draft.package);
+if (serializedProposal !== auditedProposalBytes) throw new Error("Generated audited V2 proposal differs from frozen audited proposal");
+if (digest(auditedProposalPath) !== AUDITED_V2_IDENTITIES.generatedProposalSha256) throw new Error("Audited V2 proposal identity changed");
 const reloadedProposal = JSON.parse(serializedProposal) as typeof draft.package;
 if (reloadedProposal.rows.length !== 58) throw new Error("False-support taxonomy proposal does not contain all 58 rules");
 const taxonomy = buildVm0007Rc3FalseSupportTaxonomy({
@@ -58,15 +71,17 @@ const taxonomy = buildVm0007Rc3FalseSupportTaxonomy({
   draft: draft.package,
   reloadedDraft: reloadedProposal,
 });
+const auditExecutionSha256 = crypto.createHash("sha256").update(canonicalJsonStringify(audit), "utf8").digest("hex");
+assertAuditedV2Identities({ reviewedTruthSha256: auditedTruthSha256, sourceExtractionSha256, productionExecutionSha256: auditExecutionSha256, generatedProposalSha256: digest(auditedProposalPath), auditedBaselineSha256 });
 const artifact = {
   ...taxonomy,
   source: {
     currentProposalKind: "same_run_serialized_reload",
-    generatedProposalSha256: crypto.createHash("sha256").update(serializedProposal, "utf8").digest("hex"),
-    auditExecutionSha256: crypto.createHash("sha256").update(JSON.stringify(audit), "utf8").digest("hex"),
-    sourceExtractionSha256: digest(extractionPath),
-    frozenRc2BaselineSha256: "15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf",
-    reviewedTruthSha256: digest(reviewedPath),
+    generatedProposalSha256: AUDITED_V2_IDENTITIES.generatedProposalSha256,
+    auditExecutionSha256,
+    sourceExtractionSha256,
+    frozenRc2BaselineSha256: auditedBaselineSha256,
+    reviewedTruthSha256: auditedTruthSha256,
     machineProposalFrozenSha256: digest(machinePath),
   },
   fixtureProtection: { reviewedTruthUnchanged: true, machineProposalUnchanged: true, rc2BaselineUnchanged: true },

--- a/scripts/preverif/generate-vm0007-rc3-false-support-taxonomy.ts
+++ b/scripts/preverif/generate-vm0007-rc3-false-support-taxonomy.ts
@@ -8,7 +8,7 @@ import { auditEvidence } from "../../src/lib/preverif/evidenceAudit";
 import { buildVm0007EvidenceMapDraft } from "../../src/lib/preverif/vm0007EvidenceMapDraft";
 import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "../../src/lib/preverif/vm0007EvidenceContracts";
 import { type Vm0007EvidenceBenchmarkMachineRow, type Vm0007EvidenceBenchmarkReviewedRow } from "../../src/lib/preverif/vm0007EvidenceBenchmark";
-import { assertAuditedV2Identities, AUDITED_V2_IDENTITIES, buildVm0007Rc3FalseSupportTaxonomy, serializeVm0007Rc3FalseSupportTaxonomy } from "../../src/lib/preverif/vm0007Rc3FalseSupportTaxonomy";
+import { assertAuditedV2Identities, AUDITED_V2_IDENTITIES, buildVm0007Rc3FalseSupportTaxonomy } from "../../src/lib/preverif/vm0007Rc3FalseSupportTaxonomy";
 
 const root = process.cwd();
 const artifactDir = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp");
@@ -17,6 +17,7 @@ const richRulesPath = path.join(root, "public/methodologies/Verra/AFOLU/VM0007/v
 const machinePath = path.join(fixtureDir, "machine-proposal.json");
 const reviewedPath = path.join(fixtureDir, "gold.json");
 const extractionPath = path.join(fixtureDir, "raw-document-extraction.json");
+const frozenRc2BaselinePath = path.join(artifactDir, "RC2_BASELINE.json");
 const auditedBaselinePath = path.join(artifactDir, "RC3_AUDITED_PRE_FIX_BASELINE.json");
 const auditedProposalPath = path.join(artifactDir, "RC3_AUDITED_PRE_FIX_PROPOSAL.json");
 const outputPath = path.join(artifactDir, "RC3_FALSE_SUPPORT_TAXONOMY.json");
@@ -31,9 +32,11 @@ const auditedProposalBytes = fs.readFileSync(auditedProposalPath, "utf8");
 const auditedTruthSha256 = digest(reviewedPath);
 const sourceExtractionSha256 = digest(extractionPath);
 const auditedBaselineSha256 = digest(auditedBaselinePath);
+const frozenRc2BaselineSha256 = digest(frozenRc2BaselinePath);
 if (auditedTruthSha256 !== AUDITED_V2_IDENTITIES.reviewedTruthSha256) throw new Error("False-support taxonomy requires audited V2 reviewed truth");
 if (sourceExtractionSha256 !== AUDITED_V2_IDENTITIES.sourceExtractionSha256) throw new Error("False-support taxonomy source extraction identity changed");
 if (auditedBaselineSha256 !== AUDITED_V2_IDENTITIES.auditedBaselineSha256) throw new Error("Audited V2 baseline identity changed");
+if (frozenRc2BaselineSha256 !== "15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf") throw new Error("Frozen RC2 baseline identity changed");
 if (auditedBaseline.truth?.sha256 !== AUDITED_V2_IDENTITIES.reviewedTruthSha256 || auditedBaseline.generatedProposal?.sha256 !== AUDITED_V2_IDENTITIES.generatedProposalSha256 || auditedBaseline.productionExecution?.auditExecutionSha256 !== AUDITED_V2_IDENTITIES.productionExecutionSha256) throw new Error("Audited V2 baseline manifest identities do not match");
 const rules = read(richRulesPath).map((rule: Record<string, unknown>) => ({
   id: String(rule.id), title: String(rule.title ?? ""), summary: String(rule.summary ?? ""), logic: String(rule.logic ?? ""), text: String(rule.text ?? ""), type: String(rule.type ?? ""),
@@ -80,7 +83,8 @@ const artifact = {
     generatedProposalSha256: AUDITED_V2_IDENTITIES.generatedProposalSha256,
     auditExecutionSha256,
     sourceExtractionSha256,
-    frozenRc2BaselineSha256: auditedBaselineSha256,
+    frozenRc2BaselineSha256,
+    auditedV2BaselineSha256: auditedBaselineSha256,
     reviewedTruthSha256: auditedTruthSha256,
     machineProposalFrozenSha256: digest(machinePath),
   },

--- a/scripts/preverif/generate-vm0007-rc3-false-support-taxonomy.ts
+++ b/scripts/preverif/generate-vm0007-rc3-false-support-taxonomy.ts
@@ -1,0 +1,75 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { getStructuredQueryContext } from "../../src/lib/chat/quickCheckReviewQuestion";
+import { canonicalJsonStringify } from "../../src/lib/export/canonicalJson";
+import { auditEvidence } from "../../src/lib/preverif/evidenceAudit";
+import { buildVm0007EvidenceMapDraft } from "../../src/lib/preverif/vm0007EvidenceMapDraft";
+import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "../../src/lib/preverif/vm0007EvidenceContracts";
+import { type Vm0007EvidenceBenchmarkMachineRow, type Vm0007EvidenceBenchmarkReviewedRow } from "../../src/lib/preverif/vm0007EvidenceBenchmark";
+import { buildVm0007Rc3FalseSupportTaxonomy, serializeVm0007Rc3FalseSupportTaxonomy } from "../../src/lib/preverif/vm0007Rc3FalseSupportTaxonomy";
+
+const root = process.cwd();
+const artifactDir = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp");
+const fixtureDir = path.join(root, "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
+const richRulesPath = path.join(root, "public/methodologies/Verra/AFOLU/VM0007/v1-8/rules.rich.json");
+const machinePath = path.join(fixtureDir, "machine-proposal.json");
+const reviewedPath = path.join(fixtureDir, "gold.json");
+const extractionPath = path.join(fixtureDir, "raw-document-extraction.json");
+const outputPath = path.join(artifactDir, "RC3_FALSE_SUPPORT_TAXONOMY.json");
+const read = (filePath: string) => JSON.parse(fs.readFileSync(filePath, "utf8")) as any;
+const digest = (filePath: string) => crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+
+const machine = read(machinePath);
+const reviewed = read(reviewedPath);
+const extraction = read(extractionPath);
+const rules = read(richRulesPath).map((rule: Record<string, unknown>) => ({
+  id: String(rule.id), title: String(rule.title ?? ""), summary: String(rule.summary ?? ""), logic: String(rule.logic ?? ""), text: String(rule.text ?? ""), type: String(rule.type ?? ""),
+}));
+const expectedStableRuleIds = read(path.join(root, "public/methodologies/Verra/AFOLU/VM0007/v1-8/rules.json")).rules.map((rule: { stable_id: string }) => rule.stable_id);
+const context = getStructuredQueryContext(extraction.text);
+const audit = auditEvidence({
+  rules,
+  evidenceDocument: context.evidenceDocument,
+  getContract: getVm0007EvidenceContract,
+  normalizeRuleId: normalizeVm0007RuleId,
+  sections: context.documentStructure.sections,
+  rawText: extraction.text,
+  diagnosticTrace: true,
+  versionContext: { methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8" },
+});
+const draft = buildVm0007EvidenceMapDraft({
+  auditId: "rc3-current-same-run-comparison-vm0007-v18",
+  generatedAt: "1970-01-01T00:00:00.000Z",
+  rules: rules.map((rule: any) => ({ ...rule, snippet: rule.text, tags: [] })),
+  audit,
+  sourceDocument: { documentId: context.evidenceDocument.docId, documentName: "5953-Marcondes-Brazil-pdd.pdf", contentSha256: machine.sourceDocument.contentSha256 },
+});
+if (!draft.ok) throw new Error(`False-support taxonomy draft build blocked: ${draft.blockedBy.join(", ")}`);
+const serializedProposal = JSON.stringify(draft.package);
+const reloadedProposal = JSON.parse(serializedProposal) as typeof draft.package;
+if (reloadedProposal.rows.length !== 58) throw new Error("False-support taxonomy proposal does not contain all 58 rules");
+const taxonomy = buildVm0007Rc3FalseSupportTaxonomy({
+  currentRows: reloadedProposal.rows as unknown as Vm0007EvidenceBenchmarkMachineRow[],
+  reviewedRows: reviewed.rows as Vm0007EvidenceBenchmarkReviewedRow[],
+  expectedStableRuleIds,
+  audit,
+  draft: draft.package,
+  reloadedDraft: reloadedProposal,
+});
+const artifact = {
+  ...taxonomy,
+  source: {
+    currentProposalKind: "same_run_serialized_reload",
+    generatedProposalSha256: crypto.createHash("sha256").update(serializedProposal, "utf8").digest("hex"),
+    auditExecutionSha256: crypto.createHash("sha256").update(JSON.stringify(audit), "utf8").digest("hex"),
+    sourceExtractionSha256: digest(extractionPath),
+    frozenRc2BaselineSha256: "15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf",
+    reviewedTruthSha256: digest(reviewedPath),
+    machineProposalFrozenSha256: digest(machinePath),
+  },
+  fixtureProtection: { reviewedTruthUnchanged: true, machineProposalUnchanged: true, rc2BaselineUnchanged: true },
+};
+fs.writeFileSync(outputPath, `${canonicalJsonStringify(artifact)}\n`, "utf8");
+console.log(`Wrote false-support taxonomy: ${taxonomy.totalEvents} events; ${taxonomy.affectedRuleCount} rules.`);

--- a/src/lib/preverif/vm0007Rc3CurrentComparison.ts
+++ b/src/lib/preverif/vm0007Rc3CurrentComparison.ts
@@ -93,7 +93,7 @@ function metric(current: number, frozenRc2: number): MetricResult {
   return { current, frozenRc2, delta, percentageDelta: frozenRc2 === 0 ? null : delta / frozenRc2, direction: delta < 0 ? "improved" : delta > 0 ? "regressed" : "unchanged" };
 }
 
-function canonicalEvidenceIdentity(stableRuleId: string, record: { quote: unknown; provenance: unknown }): string {
+export function canonicalEvidenceIdentity(stableRuleId: string, record: { quote: unknown; provenance: unknown }): string {
   const provenance = record.provenance as Record<string, unknown>;
   return canonicalJsonStringify({
     stableRuleId,

--- a/src/lib/preverif/vm0007Rc3FalseSupportTaxonomy.ts
+++ b/src/lib/preverif/vm0007Rc3FalseSupportTaxonomy.ts
@@ -12,8 +12,21 @@ import {
 } from "./vm0007EvidenceBenchmark";
 import { canonicalEvidenceIdentity } from "./vm0007Rc3CurrentComparison";
 
-export const VM0007_RC3_FALSE_SUPPORT_TAXONOMY_SCHEMA_VERSION = "vm0007-rc3-false-support-taxonomy-v1" as const;
-export const VM0007_RC3_FALSE_SUPPORT_TAXONOMY_TRACE_VERSION = "rc3-current-false-support-taxonomy-v1" as const;
+export const VM0007_RC3_FALSE_SUPPORT_TAXONOMY_SCHEMA_VERSION = "vm0007-rc3-false-support-taxonomy-v2" as const;
+export const VM0007_RC3_FALSE_SUPPORT_TAXONOMY_TRACE_VERSION = "rc3-audited-v2-false-support-taxonomy-v1" as const;
+export const AUDITED_V2_IDENTITIES = {
+  reviewedTruthSha256: "af93a39a0b874377efe88648f6f4538c2454c9e8dcceae66086681b4a336f75c",
+  sourceExtractionSha256: "7031b49bf70d541679788e65f74efef09921712a506a0ba4aa28d0b0bcd98747",
+  productionExecutionSha256: "770b05a6e82757d436c9f40c7698742f64ae1ad8c906b3b127926027f5198a25",
+  generatedProposalSha256: "2ffe9413b09a795edc50b15e9564716f9fcf51d916f13368b416d2b22088fb85",
+  auditedBaselineSha256: "12c6276c12ba62d7f93987e3d4097d732ab05ded1432621a5895aa7527e5be87",
+} as const;
+
+export function assertAuditedV2Identities(input: Readonly<typeof AUDITED_V2_IDENTITIES>): void {
+  for (const key of Object.keys(AUDITED_V2_IDENTITIES) as (keyof typeof AUDITED_V2_IDENTITIES)[]) {
+    if (input[key] !== AUDITED_V2_IDENTITIES[key]) throw new Error(`Audited V2 identity mismatch: ${key}`);
+  }
+}
 
 export const FALSE_SUPPORT_PRIMARY_SUBTYPES = [
   "broad_span_contains_reviewed_quote_same_rule",

--- a/src/lib/preverif/vm0007Rc3FalseSupportTaxonomy.ts
+++ b/src/lib/preverif/vm0007Rc3FalseSupportTaxonomy.ts
@@ -1,0 +1,311 @@
+import crypto from "node:crypto";
+
+import { canonicalJsonStringify } from "@/lib/export/canonicalJson";
+import type { MethodologyEvidenceAuditResult, MethodologyEvidenceAuditSummary } from "./evidenceAudit";
+import type { Vm0007EvidenceMapDraftPackage, Vm0007EvidenceMapDraftRow } from "./vm0007EvidenceMapDraft";
+import {
+  evaluateVm0007EvidenceBenchmark,
+  normalizeEvidenceQuote,
+  type EvidenceBenchmarkRecord,
+  type Vm0007EvidenceBenchmarkMachineRow,
+  type Vm0007EvidenceBenchmarkReviewedRow,
+} from "./vm0007EvidenceBenchmark";
+import { canonicalEvidenceIdentity } from "./vm0007Rc3CurrentComparison";
+
+export const VM0007_RC3_FALSE_SUPPORT_TAXONOMY_SCHEMA_VERSION = "vm0007-rc3-false-support-taxonomy-v1" as const;
+export const VM0007_RC3_FALSE_SUPPORT_TAXONOMY_TRACE_VERSION = "rc3-current-false-support-taxonomy-v1" as const;
+
+export const FALSE_SUPPORT_PRIMARY_SUBTYPES = [
+  "broad_span_contains_reviewed_quote_same_rule",
+  "machine_fragment_of_reviewed_quote_same_rule",
+  "quote_reviewed_under_different_rule",
+  "duplicated_across_multiple_rules",
+  "accepted_methodology_boilerplate",
+  "accepted_module_or_tool_declaration",
+  "accepted_incomplete_or_noisy",
+  "accepted_project_specific_but_unmatched",
+  "unresolved",
+] as const;
+export type FalseSupportPrimarySubtype = (typeof FALSE_SUPPORT_PRIMARY_SUBTYPES)[number];
+
+type EvidenceLike = EvidenceBenchmarkRecord & { quote: string; provenance: Record<string, unknown>; evidenceType?: string };
+type MatchBasis = "exact_span_and_quote" | "normalized_quote_fallback" | "none";
+type StagePresence = Readonly<{ present: boolean; matchBasis: MatchBasis; spanId: string | null }>;
+
+export type FalseSupportTaxonomyEvent = Readonly<{
+  eventId: string;
+  stableRuleId: string;
+  normalizedQuote: string;
+  provenance: Readonly<Record<string, unknown>>;
+  evidenceType: string | null;
+  score: number | null;
+  isBestMainCandidate: boolean;
+  isComplementarySelectedEvidence: boolean;
+  acceptedInAuditResult: boolean;
+  auditStage: Readonly<{
+    retrievalCandidate: boolean;
+    postFilterCandidate: boolean;
+    selectedCandidate: boolean;
+    acceptedEvidenceRecord: boolean;
+    stageWhereAccepted: "auditEvidence.result.evidence" | "not_found";
+  }>;
+  draftMapping: StagePresence;
+  serializedReload: StagePresence;
+  primarySubtype: FalseSupportPrimarySubtype;
+  secondaryFlags: Readonly<{
+    broadSpanMatch: boolean;
+    fragmentMatch: boolean;
+    crossRuleMatch: boolean;
+    reusedAcrossRules: boolean;
+    bestCandidate: boolean;
+    complementaryCandidate: boolean;
+    projectSpecificScope: boolean;
+    projectSpecificImplementation: boolean;
+    boilerplate: boolean;
+    noisy: boolean;
+    moduleDeclaration: boolean;
+  }>;
+}>;
+
+export type Vm0007Rc3FalseSupportTaxonomy = Readonly<{
+  schemaVersion: typeof VM0007_RC3_FALSE_SUPPORT_TAXONOMY_SCHEMA_VERSION;
+  traceVersion: typeof VM0007_RC3_FALSE_SUPPORT_TAXONOMY_TRACE_VERSION;
+  primarySubtypePrecedence: readonly string[];
+  totalEvents: number;
+  primarySubtypeCounts: Readonly<Record<FalseSupportPrimarySubtype, number>>;
+  primarySubtypePercentages: Readonly<Record<FalseSupportPrimarySubtype, number>>;
+  uniqueSourceSpanCount: number;
+  repeatedEmissionCount: number;
+  affectedRuleCount: number;
+  topRepeatedSpans: readonly Readonly<{ sourceSpan: string; emissionCount: number; eventIds: readonly string[] }>[];
+  bestMainCount: number;
+  complementaryCount: number;
+  evidenceTypeDistribution: Readonly<Record<string, number>>;
+  auditAcceptance: Readonly<{ acceptedInAuditResult: number; draftPreserved: number; serializedPreserved: number; draftInvented: number; serializationInvented: number }>;
+  events: readonly FalseSupportTaxonomyEvent[];
+}>;
+
+const PRECEDENCE = [...FALSE_SUPPORT_PRIMARY_SUBTYPES];
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function recordProvenance(record: EvidenceLike): Record<string, unknown> {
+  return {
+    docId: record.provenance.docId,
+    page: record.provenance.page,
+    sectionPath: record.provenance.sectionPath,
+    spanId: record.provenance.spanId,
+    sectionHeading: record.provenance.sectionHeading,
+    sourceType: record.provenance.sourceType,
+  };
+}
+
+function eventSpan(record: EvidenceLike): string {
+  return canonicalJsonStringify({
+    docId: record.provenance.docId,
+    page: record.provenance.page,
+    sectionPath: record.provenance.sectionPath,
+    spanId: record.provenance.spanId,
+  });
+}
+
+function auditEvidenceRecord(result: MethodologyEvidenceAuditResult, record: { quote: string; page: number | null; section: string | null; span: string; evidenceType?: string }): EvidenceLike {
+  return {
+    quote: record.quote,
+    provenance: {
+      docId: "quick-check-review-question",
+      page: record.page,
+      sectionPath: record.section ? [record.section] : [],
+      spanId: record.span,
+      sectionHeading: record.section,
+      sourceType: "PDD",
+    },
+    ...(record.evidenceType === undefined ? {} : { evidenceType: record.evidenceType }),
+  };
+}
+
+function normalized(value: unknown): string {
+  return normalizeEvidenceQuote(String(value ?? ""));
+}
+
+function containsMatch(machine: string, reviewed: string): "broad" | "fragment" | "exact" | null {
+  if (!machine || !reviewed) return null;
+  if (machine === reviewed) return "exact";
+  if (machine.includes(reviewed)) return "broad";
+  if (reviewed.includes(machine)) return "fragment";
+  return null;
+}
+
+function sameIdentity(left: EvidenceLike, right: EvidenceLike): StagePresence {
+  const leftSpan = typeof left.provenance.spanId === "string" ? left.provenance.spanId.trim() : "";
+  const rightSpan = typeof right.provenance.spanId === "string" ? right.provenance.spanId.trim() : "";
+  if (leftSpan && rightSpan) return { present: leftSpan === rightSpan && normalized(left.quote) === normalized(right.quote), matchBasis: leftSpan === rightSpan && normalized(left.quote) === normalized(right.quote) ? "exact_span_and_quote" : "none", spanId: rightSpan || null };
+  const quoteMatches = normalized(left.quote) !== "" && normalized(left.quote) === normalized(right.quote);
+  return { present: quoteMatches, matchBasis: quoteMatches ? "normalized_quote_fallback" : "none", spanId: rightSpan || null };
+}
+
+function anyDraftIdentity(row: Vm0007EvidenceMapDraftRow | undefined, record: EvidenceLike): StagePresence {
+  if (!row) return { present: false, matchBasis: "none", spanId: null };
+  const candidates: EvidenceLike[] = [
+    ...(row.acceptedEvidence ?? []) as unknown as EvidenceLike[],
+    ...(row.proposedAcceptedEvidence ? [row.proposedAcceptedEvidence as unknown as EvidenceLike] : []),
+    ...(row.rejectedEvidence ?? []) as unknown as EvidenceLike[],
+    ...(row.proposedRejectedEvidence ? [row.proposedRejectedEvidence as unknown as EvidenceLike] : []),
+    ...(row.quote && row.provenance ? [{ quote: row.quote, provenance: row.provenance } as unknown as EvidenceLike] : []),
+    ...(row.spanId && row.provenance ? [{ quote: row.quote ?? "", provenance: { ...row.provenance, spanId: row.spanId } } as unknown as EvidenceLike] : []),
+  ];
+  const matches = candidates.map((candidate) => sameIdentity(record, candidate)).filter((match) => match.present);
+  return matches.find((match) => match.matchBasis === "exact_span_and_quote") ?? matches[0] ?? { present: false, matchBasis: "none", spanId: null };
+}
+
+function auditPresence(result: MethodologyEvidenceAuditResult | undefined, record: EvidenceLike): StagePresence {
+  if (!result) return { present: false, matchBasis: "none", spanId: null };
+  const candidates = (result.evidence ?? []).map((item) => auditEvidenceRecord(result, item));
+  const matches = candidates.map((candidate) => sameIdentity(record, candidate)).filter((match) => match.present);
+  return matches.find((match) => match.matchBasis === "exact_span_and_quote") ?? matches[0] ?? { present: false, matchBasis: "none", spanId: null };
+}
+
+function selectedTrace(trace: MethodologyEvidenceAuditSummary["diagnosticTrace"], stableRuleId: string, record: EvidenceLike) {
+  const item = trace?.find((candidate) => candidate.stableId === stableRuleId);
+  const candidate = item?.retrievalCandidates.find((value) => value.spanId === record.provenance.spanId)
+    ?? item?.postFilterCandidates.find((value) => value.spanId === record.provenance.spanId)
+    ?? item?.selectedCandidates.find((value) => value.spanId === record.provenance.spanId);
+  return {
+    retrievalCandidate: Boolean(item?.retrievalCandidates.some((value) => value.spanId === record.provenance.spanId)),
+    postFilterCandidate: Boolean(item?.postFilterCandidates.some((value) => value.spanId === record.provenance.spanId)),
+    selectedCandidate: Boolean(item?.selectedCandidates.some((value) => value.spanId === record.provenance.spanId)),
+    score: candidate?.score ?? null,
+  };
+}
+
+function occurrenceEventId(identity: string, occurrence: number): string {
+  return `accepted:false_support:${sha256(identity)}:${occurrence}`;
+}
+
+function primarySubtype(input: Readonly<{ sameRuleMatch: "broad" | "fragment" | "exact" | null; crossRuleMatch: boolean; reusedAcrossRules: boolean; evidenceType: string | null; projectSpecific: boolean }>): FalseSupportPrimarySubtype {
+  if (input.sameRuleMatch === "broad") return "broad_span_contains_reviewed_quote_same_rule";
+  if (input.sameRuleMatch === "fragment") return "machine_fragment_of_reviewed_quote_same_rule";
+  if (input.crossRuleMatch) return "quote_reviewed_under_different_rule";
+  if (input.reusedAcrossRules) return "duplicated_across_multiple_rules";
+  if (input.evidenceType === "methodology_boilerplate") return "accepted_methodology_boilerplate";
+  if (input.evidenceType === "module_or_tool_declaration") return "accepted_module_or_tool_declaration";
+  if (input.evidenceType === "incomplete_or_noisy") return "accepted_incomplete_or_noisy";
+  if (input.projectSpecific) return "accepted_project_specific_but_unmatched";
+  return "unresolved";
+}
+
+export function buildVm0007Rc3FalseSupportTaxonomy(input: Readonly<{
+  currentRows: readonly Vm0007EvidenceBenchmarkMachineRow[];
+  reviewedRows: readonly Vm0007EvidenceBenchmarkReviewedRow[];
+  expectedStableRuleIds: readonly string[];
+  audit: MethodologyEvidenceAuditSummary;
+  draft: Vm0007EvidenceMapDraftPackage;
+  reloadedDraft: Vm0007EvidenceMapDraftPackage;
+}>): Vm0007Rc3FalseSupportTaxonomy {
+  const benchmark = evaluateVm0007EvidenceBenchmark({ machineRows: input.currentRows, reviewedRows: input.reviewedRows, expectedStableRuleIds: input.expectedStableRuleIds });
+  const reviewedByRule = new Map(input.reviewedRows.map((row) => [row.ruleId, row]));
+  const auditByRule = new Map(input.audit.results.map((result) => [result.stableId, result]));
+  const draftByRule = new Map(input.draft.rows.map((row) => [row.stableRuleId, row]));
+  const reloadedByRule = new Map(input.reloadedDraft.rows.map((row) => [row.stableRuleId, row]));
+  const records = benchmark.rows.flatMap((row) => row.accepted.falsePositiveRecords.map((record) => ({ stableRuleId: row.stableRuleId, record: record as EvidenceLike, identity: canonicalEvidenceIdentity(row.stableRuleId, record as EvidenceLike) })));
+  const sorted = records.sort((left, right) => left.identity.localeCompare(right.identity));
+  const occurrences = new Map<string, number>();
+  const baseSourceSpanRules = new Map<string, Set<string>>();
+  for (const item of sorted) {
+    const key = eventSpan(item.record);
+    (baseSourceSpanRules.get(key) ?? (baseSourceSpanRules.set(key, new Set()), baseSourceSpanRules.get(key)!)).add(item.stableRuleId);
+  }
+  const reviewedAll = input.reviewedRows.flatMap((row) => (Array.isArray(row.acceptedEvidence) ? row.acceptedEvidence : []).map((record) => ({ ruleId: row.ruleId, record: record as unknown as EvidenceLike })));
+  const events: FalseSupportTaxonomyEvent[] = [];
+  for (const item of sorted) {
+    const occurrence = (occurrences.get(item.identity) ?? 0) + 1;
+    occurrences.set(item.identity, occurrence);
+    const record = item.record;
+    const sameRuleReviewed = (Array.isArray(reviewedByRule.get(item.stableRuleId)?.acceptedEvidence) ? reviewedByRule.get(item.stableRuleId)!.acceptedEvidence! : []) as unknown as EvidenceLike[];
+    const sameRuleMatches = sameRuleReviewed.map((reviewed) => containsMatch(normalized(record.quote), normalized(reviewed.quote))).filter(Boolean) as ("broad" | "fragment" | "exact")[];
+    const sameRuleMatch = sameRuleMatches.includes("broad") ? "broad" : sameRuleMatches.includes("fragment") ? "fragment" : sameRuleMatches.includes("exact") ? "exact" : null;
+    const crossRuleMatch = reviewedAll.some((reviewed) => reviewed.ruleId !== item.stableRuleId && containsMatch(normalized(record.quote), normalized(reviewed.record.quote)) !== null);
+    const reusedAcrossRules = (baseSourceSpanRules.get(eventSpan(record))?.size ?? 0) > 1;
+    const evidenceType = typeof record.evidenceType === "string" ? record.evidenceType : null;
+    const projectSpecific = evidenceType === "project_specific_scope" || evidenceType === "project_specific_implementation";
+    const trace = selectedTrace(input.audit.diagnosticTrace, item.stableRuleId, record);
+    const auditResult = auditByRule.get(item.stableRuleId);
+    const auditMatch = auditPresence(auditResult, record);
+    const draftMatch = anyDraftIdentity(draftByRule.get(item.stableRuleId), record);
+    const reloadedMatch = anyDraftIdentity(reloadedByRule.get(item.stableRuleId), record);
+    const bestMain = Boolean(auditResult?.span && auditResult.span === record.provenance.spanId);
+    const broad = sameRuleMatch === "broad";
+    const fragment = sameRuleMatch === "fragment";
+    const event: FalseSupportTaxonomyEvent = {
+      eventId: occurrenceEventId(item.identity, occurrence),
+      stableRuleId: item.stableRuleId,
+      normalizedQuote: normalized(record.quote),
+      provenance: recordProvenance(record),
+      evidenceType,
+      score: trace.score,
+      isBestMainCandidate: bestMain,
+      isComplementarySelectedEvidence: !bestMain,
+      acceptedInAuditResult: auditMatch.present,
+      auditStage: {
+        retrievalCandidate: trace.retrievalCandidate,
+        postFilterCandidate: trace.postFilterCandidate,
+        selectedCandidate: trace.selectedCandidate,
+        acceptedEvidenceRecord: auditMatch.present,
+        stageWhereAccepted: auditMatch.present ? "auditEvidence.result.evidence" : "not_found",
+      },
+      draftMapping: draftMatch,
+      serializedReload: reloadedMatch,
+      primarySubtype: primarySubtype({ sameRuleMatch, crossRuleMatch, reusedAcrossRules, evidenceType, projectSpecific }),
+      secondaryFlags: {
+        broadSpanMatch: broad,
+        fragmentMatch: fragment,
+        crossRuleMatch,
+        reusedAcrossRules,
+        bestCandidate: bestMain,
+        complementaryCandidate: !bestMain,
+        projectSpecificScope: evidenceType === "project_specific_scope",
+        projectSpecificImplementation: evidenceType === "project_specific_implementation",
+        boilerplate: evidenceType === "methodology_boilerplate",
+        noisy: evidenceType === "incomplete_or_noisy",
+        moduleDeclaration: evidenceType === "module_or_tool_declaration",
+      },
+    };
+    events.push(event);
+  }
+  if (events.length !== benchmark.aggregate.accepted.falsePositiveCount) throw new Error("False-support taxonomy event count mismatch");
+  const primarySubtypeCounts = Object.fromEntries(FALSE_SUPPORT_PRIMARY_SUBTYPES.map((subtype) => [subtype, events.filter((event) => event.primarySubtype === subtype).length])) as Record<FalseSupportPrimarySubtype, number>;
+  const primarySubtypePercentages = Object.fromEntries(FALSE_SUPPORT_PRIMARY_SUBTYPES.map((subtype) => [subtype, events.length ? primarySubtypeCounts[subtype] / events.length : 0])) as Record<FalseSupportPrimarySubtype, number>;
+  const spanEvents = new Map<string, string[]>();
+  for (const event of events) (spanEvents.get(eventSpan(event as unknown as EvidenceLike)) ?? (spanEvents.set(eventSpan(event as unknown as EvidenceLike), []), spanEvents.get(eventSpan(event as unknown as EvidenceLike))!)).push(event.eventId);
+  const topRepeatedSpans = [...spanEvents.entries()].filter(([, eventIds]) => eventIds.length > 1).map(([sourceSpan, eventIds]) => ({ sourceSpan, emissionCount: eventIds.length, eventIds: [...eventIds].sort() })).sort((left, right) => right.emissionCount - left.emissionCount || left.sourceSpan.localeCompare(right.sourceSpan));
+  const evidenceTypeDistribution = Object.fromEntries([...new Set(events.map((event) => event.evidenceType ?? "unknown"))].sort().map((type) => [type, events.filter((event) => (event.evidenceType ?? "unknown") === type).length]));
+  return {
+    schemaVersion: VM0007_RC3_FALSE_SUPPORT_TAXONOMY_SCHEMA_VERSION,
+    traceVersion: VM0007_RC3_FALSE_SUPPORT_TAXONOMY_TRACE_VERSION,
+    primarySubtypePrecedence: PRECEDENCE,
+    totalEvents: events.length,
+    primarySubtypeCounts,
+    primarySubtypePercentages,
+    uniqueSourceSpanCount: spanEvents.size,
+    repeatedEmissionCount: events.length - spanEvents.size,
+    affectedRuleCount: new Set(events.map((event) => event.stableRuleId)).size,
+    topRepeatedSpans,
+    bestMainCount: events.filter((event) => event.isBestMainCandidate).length,
+    complementaryCount: events.filter((event) => event.isComplementarySelectedEvidence).length,
+    evidenceTypeDistribution,
+    auditAcceptance: {
+      acceptedInAuditResult: events.filter((event) => event.acceptedInAuditResult).length,
+      draftPreserved: events.filter((event) => event.draftMapping.present).length,
+      serializedPreserved: events.filter((event) => event.serializedReload.present).length,
+      draftInvented: events.filter((event) => !event.acceptedInAuditResult && event.draftMapping.present).length,
+      serializationInvented: events.filter((event) => !event.draftMapping.present && event.serializedReload.present).length,
+    },
+    events: events.sort((left, right) => left.eventId.localeCompare(right.eventId)),
+  };
+}
+
+export function serializeVm0007Rc3FalseSupportTaxonomy(value: Vm0007Rc3FalseSupportTaxonomy): string {
+  return `${canonicalJsonStringify(value)}\n`;
+}

--- a/tests/lib/preverif/marcondesAuditedRc3PreFixBaseline.test.ts
+++ b/tests/lib/preverif/marcondesAuditedRc3PreFixBaseline.test.ts
@@ -136,7 +136,7 @@ describe("audited RC3 pre-fix baseline", () => {
     expect(comparison.currentProposalSource.generatedProposalSha256).toBe(proposalSha);
   });
 
-  it("indexes frozen v1/v2 artifacts deterministically and keeps RC3-5 provisional", () => {
+  it("indexes frozen v1/v2 artifacts deterministically and finalizes RC3-5 under v2 diagnostics", () => {
     expect(registryArtifact.schemaVersion).toBe("vm0007-rc3-baseline-registry-v1");
     expect(new Set(registryArtifact.versions.map((version: { logicalVersion: string }) => version.logicalVersion)).size).toBe(registryArtifact.versions.length);
     expect(registryArtifact.versions.filter((version: { status: string }) => version.status === "frozen_current")).toHaveLength(1);
@@ -147,8 +147,12 @@ describe("audited RC3 pre-fix baseline", () => {
     expect(v1.reviewedTruth.path).toContain("gold.rc2-rc3.json");
     expect(v1.reviewedTruth.path).not.toContain("gold.json");
     expect(v2.reviewedTruth.path).toContain("gold.json");
-    expect(registryArtifact.provisional).toMatchObject({ status: "provisional", sourcePr: "#1046", officialFrozenBaseline: false, artifactIsNotIndexedAsFrozen: true });
-    expect(registryArtifact.provisional.sourceArtifactPath).toContain("RC3_FALSE_SUPPORT_TAXONOMY.json");
+    expect(registryArtifact.provisional).toBeUndefined();
+    expect(registryArtifact.versions.filter((version: { logicalVersion: string }) => version.logicalVersion === "v3")).toHaveLength(0);
+    const taxonomyEntries = v2.diagnosticArtifacts.filter((artifact: { path: string }) => artifact.path === "docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json");
+    expect(taxonomyEntries).toHaveLength(1);
+    expect(taxonomyEntries[0].sha256).toBe("32181d976bea24d01884c6c1d8586afd5e858ea40eb708a7f5156f2c71e11865");
+    expect(taxonomyEntries[0].sha256).toBe(sha256(path.join(artifactDir, "RC3_FALSE_SUPPORT_TAXONOMY.json")));
     expect(registryArtifact.reproduction.diagnosticOutputsAreProductionOutputs).toBe(false);
     for (const version of [v1, v2]) {
       const refs = [version.reviewedTruth, version.frozenMachineProposal, version.extraction, version.generatedSameRunProposal, version.manifestArtifact, ...(version.baselineArtifacts ?? []), ...(version.diagnosticArtifacts ?? [])].filter(Boolean);

--- a/tests/lib/preverif/vm0007Rc3FalseSupportTaxonomy.test.ts
+++ b/tests/lib/preverif/vm0007Rc3FalseSupportTaxonomy.test.ts
@@ -3,11 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { canonicalJsonStringify } from "@/lib/export/canonicalJson";
-import { buildVm0007Rc3FalseSupportTaxonomy, serializeVm0007Rc3FalseSupportTaxonomy } from "@/lib/preverif/vm0007Rc3FalseSupportTaxonomy";
+import { assertAuditedV2Identities, AUDITED_V2_IDENTITIES, buildVm0007Rc3FalseSupportTaxonomy, serializeVm0007Rc3FalseSupportTaxonomy } from "@/lib/preverif/vm0007Rc3FalseSupportTaxonomy";
 
 const root = process.cwd();
 const artifactPath = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json");
-const comparisonPath = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp/RC3_CURRENT_COMPARISON.json");
+const comparisonPath = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp/RC3_AUDITED_CURRENT_COMPARISON.json");
 const goldPath = path.join(root, "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json");
 const machinePath = path.join(root, "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/machine-proposal.json");
 const baselinePath = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp/RC2_BASELINE.json");
@@ -31,11 +31,22 @@ describe("RC3-5 false-support taxonomy", () => {
   it("classifies all current false-support events exactly once and preserves canonical IDs", () => {
     const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
     const comparison = JSON.parse(fs.readFileSync(comparisonPath, "utf8"));
-    expect(artifact.totalEvents).toBe(174);
-    expect(artifact.events).toHaveLength(174);
-    expect(new Set(artifact.events.map((event: any) => event.eventId)).size).toBe(174);
-    expect(artifact.events.map((event: any) => event.eventId).sort()).toEqual(comparison.regressedEventIds.acceptedEvidenceFalseSupport.slice().sort());
-    expect(Object.values(artifact.primarySubtypeCounts).reduce((sum: number, count: any) => sum + count, 0)).toBe(174);
+    const auditedComparison = JSON.parse(fs.readFileSync(comparisonPath, "utf8"));
+    const auditedFalseSupportCount = auditedComparison.metrics.acceptedEvidenceFalseSupport.current;
+    expect(artifact.totalEvents).toBe(auditedFalseSupportCount);
+    expect(artifact.events).toHaveLength(auditedFalseSupportCount);
+    expect(new Set(artifact.events.map((event: any) => event.eventId)).size).toBe(auditedFalseSupportCount);
+    expect(artifact.events.map((event: any) => event.eventId).sort()).toEqual(auditedComparison.regressedEventIds.acceptedEvidenceFalseSupport.slice().sort());
+    expect(Object.values(artifact.primarySubtypeCounts).reduce((sum: number, count: any) => sum + count, 0)).toBe(auditedFalseSupportCount);
+    expect(artifact.schemaVersion).toBe("vm0007-rc3-false-support-taxonomy-v2");
+    expect(artifact.traceVersion).toBe("rc3-audited-v2-false-support-taxonomy-v1");
+    expect(artifact.source).toMatchObject({
+      reviewedTruthSha256: AUDITED_V2_IDENTITIES.reviewedTruthSha256,
+      sourceExtractionSha256: AUDITED_V2_IDENTITIES.sourceExtractionSha256,
+      auditExecutionSha256: AUDITED_V2_IDENTITIES.productionExecutionSha256,
+      generatedProposalSha256: AUDITED_V2_IDENTITIES.generatedProposalSha256,
+      frozenRc2BaselineSha256: AUDITED_V2_IDENTITIES.auditedBaselineSha256,
+    });
   });
 
   it("applies deterministic precedence for broad, fragment, cross-rule and duplicate evidence", () => {
@@ -87,8 +98,32 @@ describe("RC3-5 false-support taxonomy", () => {
   });
 
   it("protects reviewed truth, machine proposal and RC2 baseline", () => {
-    expect(crypto.createHash("sha256").update(fs.readFileSync(goldPath)).digest("hex")).toBe("b53fc19a8316f88896b7f9564a8e2d2d0dd8b08c9e05868a7b427140f47e1127");
+    expect(crypto.createHash("sha256").update(fs.readFileSync(goldPath)).digest("hex")).toBe(AUDITED_V2_IDENTITIES.reviewedTruthSha256);
     expect(crypto.createHash("sha256").update(fs.readFileSync(machinePath)).digest("hex")).toBe("068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6");
     expect(crypto.createHash("sha256").update(fs.readFileSync(baselinePath)).digest("hex")).toBe("15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf");
+    const frozen = {
+      "RC2_BASELINE.md": "e8d1bc1d7172865f9709d31588887d8906b8520b76f31d47df2b3ced70c4816b",
+      "RC3_DIAGNOSTIC.json": "a4964f1f8aec6a11c35ec07e2fcc1a8e9a1d31e0661811b9cf70d4e77d32c737",
+      "RC3_SELECTED_MATCH_SUBTAXONOMY.json": "583ca35f70c9c51a924f777d2a26062b83bb7b63d54380435f1dbdd3e45e5910",
+      "RC3_SAME_RUN_HANDOFF_TRACE.json": "9e0959845029152506663e6c8ffb52051a17b4b8e8f69c983c84ea078acd2ab4",
+      "RC3_CURRENT_COMPARISON.json": "3e10f733f9a0630f2540e736295fdeb77d829911550bc2366361736ff9cdc964",
+      "RC3_AUDITED_PRE_FIX_BASELINE.json": "12c6276c12ba62d7f93987e3d4097d732ab05ded1432621a5895aa7527e5be87",
+      "RC3_AUDITED_PRE_FIX_BASELINE_MANIFEST.json": "5b41f5650ad975757f4376c8ec7ff29dd1eb6738310637cf2eddb2191c436f8f",
+      "RC3_AUDITED_DIAGNOSTIC.json": "3dc8f4616eae03b1bfbc44e2a872f7177d56c06766c0524e22571573b6b298bd",
+      "RC3_AUDITED_SELECTED_MATCH_SUBTAXONOMY.json": "e36325c78ea3e998e71b97adb1bb9f5a8e7c3e43fd1946c38003188e041da490",
+      "RC3_AUDITED_SAME_RUN_HANDOFF_TRACE.json": "21bbd255153d524896517e48b58a6bb40425d9c37168605ab593c9ccf5a99c74",
+      "RC3_AUDITED_CURRENT_COMPARISON.json": "f12754ca3e4c1eec6c9330139da46a3777276959c0b0dda569f6f93f023af329",
+      "gold.rc2-rc3.json": "b53fc19a8316f88896b7f9564a8e2d2d0dd8b08c9e05868a7b427140f47e1127",
+    };
+    for (const [name, expected] of Object.entries(frozen)) {
+      const file = name.startsWith("gold") ? path.join(root, "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map", name) : path.join(root, "docs/roadmaps/interactive-evidence-review-mvp", name);
+      expect(crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex")).toBe(expected);
+    }
+  });
+
+  it("rejects historical or mismatched audited V2 identities", () => {
+    expect(() => assertAuditedV2Identities({ ...AUDITED_V2_IDENTITIES, reviewedTruthSha256: "b53fc19a8316f88896b7f9564a8e2d2d0dd8b08c9e05868a7b427140f47e1127" })).toThrow("reviewedTruthSha256");
+    expect(() => assertAuditedV2Identities({ ...AUDITED_V2_IDENTITIES, generatedProposalSha256: "27bb22ae48d11239cff66f79a016de9ce1d8fb069bcb87f5bf64a5ee6a080a57" })).toThrow("generatedProposalSha256");
+    expect(() => assertAuditedV2Identities({ ...AUDITED_V2_IDENTITIES, productionExecutionSha256: "c35eb8957a068ca791bde8b0851a8f884b313309d6b30353719f60b946ba7c2b" })).toThrow("productionExecutionSha256");
   });
 });

--- a/tests/lib/preverif/vm0007Rc3FalseSupportTaxonomy.test.ts
+++ b/tests/lib/preverif/vm0007Rc3FalseSupportTaxonomy.test.ts
@@ -1,0 +1,94 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { canonicalJsonStringify } from "@/lib/export/canonicalJson";
+import { buildVm0007Rc3FalseSupportTaxonomy, serializeVm0007Rc3FalseSupportTaxonomy } from "@/lib/preverif/vm0007Rc3FalseSupportTaxonomy";
+
+const root = process.cwd();
+const artifactPath = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json");
+const comparisonPath = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp/RC3_CURRENT_COMPARISON.json");
+const goldPath = path.join(root, "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json");
+const machinePath = path.join(root, "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/machine-proposal.json");
+const baselinePath = path.join(root, "docs/roadmaps/interactive-evidence-review-mvp/RC2_BASELINE.json");
+const ids = Array.from({ length: 58 }, (_, index) => `rule-${String(index + 1).padStart(2, "0")}`);
+const provenance = (spanId: string) => ({ docId: "doc", page: 1, sectionPath: ["S"], spanId, sectionHeading: "S", sourceType: "PDD" });
+const evidence = (quote: string, spanId: string, evidenceType?: string) => ({ quote, provenance: provenance(spanId), ...(evidenceType ? { evidenceType } : {}) });
+
+function synthetic(rows: readonly any[], reviewed = ids.map((ruleId) => ({ ruleId, acceptedEvidence: [], rejectedEvidence: [] }))) {
+  const completeReviewed = reviewed.map((row) => ({ finalEvidenceState: "MISSING", applicability: "APPLICABLE", reviewerOutcome: "CONFORMS", contradictionState: "NONE_IDENTIFIED", draftFindingCandidate: null, clientAction: "retain", ...row }));
+  const completeRows = rows.map((row, index) => ({ stableRuleId: ids[index], upstreamStatus: "FOUND", proposedApplicability: "APPLICABLE", reviewerOutcome: "CONFORMS", contradictionState: "NONE_IDENTIFIED", draftFindingCandidate: null, clientAction: "retain", acceptedEvidence: [], rejectedEvidence: [], ...row }));
+  const audit = {
+    results: ids.map((stableId, index) => ({ stableId, evidence: completeRows[index].acceptedEvidence, rejectedEvidence: [], span: completeRows[index].acceptedEvidence[0]?.provenance?.spanId ?? null, bestEvidenceQuote: completeRows[index].acceptedEvidence[0]?.quote ?? null })),
+    diagnosticTrace: ids.map((stableId, index) => ({ stableId, retrievalCandidates: completeRows[index].acceptedEvidence.map((item: any) => ({ spanId: item.provenance.spanId, quote: item.quote, page: 1, score: 20, evidenceType: item.evidenceType ?? "project_specific_implementation", rejectionReason: null })), postFilterCandidates: [], selectedCandidates: completeRows[index].acceptedEvidence.map((item: any) => ({ spanId: item.provenance.spanId, quote: item.quote, page: 1, score: 20, evidenceType: item.evidenceType ?? "project_specific_implementation", rejectionReason: null })), cutoffPosition: 6 })),
+  };
+  const draftRows = ids.map((stableRuleId, index) => ({ stableRuleId, acceptedEvidence: completeRows[index].acceptedEvidence, rejectedEvidence: [], proposedAcceptedEvidence: completeRows[index].acceptedEvidence[0] ?? null, proposedRejectedEvidence: null, quote: completeRows[index].acceptedEvidence[0]?.quote ?? null, spanId: completeRows[index].acceptedEvidence[0]?.provenance?.spanId ?? null, provenance: completeRows[index].acceptedEvidence[0]?.provenance ?? null }));
+  const packageValue = { rows: draftRows } as any;
+  return buildVm0007Rc3FalseSupportTaxonomy({ currentRows: completeRows as any, reviewedRows: completeReviewed as any, expectedStableRuleIds: ids, audit: audit as any, draft: packageValue, reloadedDraft: JSON.parse(JSON.stringify(packageValue)) });
+}
+
+describe("RC3-5 false-support taxonomy", () => {
+  it("classifies all current false-support events exactly once and preserves canonical IDs", () => {
+    const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+    const comparison = JSON.parse(fs.readFileSync(comparisonPath, "utf8"));
+    expect(artifact.totalEvents).toBe(174);
+    expect(artifact.events).toHaveLength(174);
+    expect(new Set(artifact.events.map((event: any) => event.eventId)).size).toBe(174);
+    expect(artifact.events.map((event: any) => event.eventId).sort()).toEqual(comparison.regressedEventIds.acceptedEvidenceFalseSupport.slice().sort());
+    expect(Object.values(artifact.primarySubtypeCounts).reduce((sum: number, count: any) => sum + count, 0)).toBe(174);
+  });
+
+  it("applies deterministic precedence for broad, fragment, cross-rule and duplicate evidence", () => {
+    const rows = ids.map(() => ({ acceptedEvidence: [] }));
+    const reviewed = ids.map((ruleId) => ({ ruleId, acceptedEvidence: [], rejectedEvidence: [] }));
+    reviewed[0].acceptedEvidence = [evidence("alpha beta", "reviewed-0")];
+    reviewed[1].acceptedEvidence = [evidence("alpha beta", "reviewed-1")];
+    reviewed[5].acceptedEvidence = [evidence("cross rule quote", "reviewed-5")];
+    rows[0].acceptedEvidence = [evidence("alpha beta extra", "broad")];
+    rows[1].acceptedEvidence = [evidence("alpha", "fragment")];
+    rows[2].acceptedEvidence = [evidence("cross rule quote", "cross")];
+    rows[3].acceptedEvidence = [evidence("duplicate", "duplicate")];
+    rows[4].acceptedEvidence = [evidence("duplicate", "duplicate")];
+    const value = synthetic(rows, reviewed);
+    const byRule = new Map(value.events.map((event) => [event.stableRuleId, event]));
+    expect(byRule.get(ids[0])?.primarySubtype).toBe("broad_span_contains_reviewed_quote_same_rule");
+    expect(byRule.get(ids[1])?.primarySubtype).toBe("machine_fragment_of_reviewed_quote_same_rule");
+    expect(byRule.get(ids[2])?.primarySubtype).toBe("quote_reviewed_under_different_rule");
+    expect(byRule.get(ids[3])?.primarySubtype).toBe("duplicated_across_multiple_rules");
+    expect(byRule.get(ids[4])?.primarySubtype).toBe("duplicated_across_multiple_rules");
+    expect(byRule.get(ids[0])?.secondaryFlags.broadSpanMatch).toBe(true);
+    expect(byRule.get(ids[1])?.secondaryFlags.fragmentMatch).toBe(true);
+    expect(byRule.get(ids[2])?.secondaryFlags.crossRuleMatch).toBe(true);
+    expect(byRule.get(ids[3])?.secondaryFlags.reusedAcrossRules).toBe(true);
+  });
+
+  it("classifies evidence-type subtypes and proves downstream preservation", () => {
+    const rows = ids.map(() => ({ acceptedEvidence: [] }));
+    rows[0].acceptedEvidence = [evidence("methodology", "type-0", "methodology_boilerplate")];
+    rows[1].acceptedEvidence = [evidence("module", "type-1", "module_or_tool_declaration")];
+    rows[2].acceptedEvidence = [evidence("noise", "type-2", "incomplete_or_noisy")];
+    rows[3].acceptedEvidence = [evidence("project scope", "type-3", "project_specific_scope")];
+    rows[4].acceptedEvidence = [evidence("project implementation", "type-4", "project_specific_implementation")];
+    const value = synthetic(rows);
+    expect(value.primarySubtypeCounts.accepted_methodology_boilerplate).toBe(1);
+    expect(value.primarySubtypeCounts.accepted_module_or_tool_declaration).toBe(1);
+    expect(value.primarySubtypeCounts.accepted_incomplete_or_noisy).toBe(1);
+    expect(value.primarySubtypeCounts.accepted_project_specific_but_unmatched).toBe(2);
+    expect(value.auditAcceptance).toEqual({ acceptedInAuditResult: 5, draftPreserved: 5, serializedPreserved: 5, draftInvented: 0, serializationInvented: 0 });
+  });
+
+  it("serializes independently built equivalent taxonomy values byte-identically", () => {
+    const rows = ids.map(() => ({ acceptedEvidence: [] }));
+    rows[0].acceptedEvidence = [evidence("same", "same")];
+    const first = synthetic(rows);
+    const second = synthetic(JSON.parse(JSON.stringify(rows)));
+    expect(serializeVm0007Rc3FalseSupportTaxonomy(first)).toBe(serializeVm0007Rc3FalseSupportTaxonomy(second));
+    expect(canonicalJsonStringify(first)).toBe(canonicalJsonStringify(second));
+  });
+
+  it("protects reviewed truth, machine proposal and RC2 baseline", () => {
+    expect(crypto.createHash("sha256").update(fs.readFileSync(goldPath)).digest("hex")).toBe("b53fc19a8316f88896b7f9564a8e2d2d0dd8b08c9e05868a7b427140f47e1127");
+    expect(crypto.createHash("sha256").update(fs.readFileSync(machinePath)).digest("hex")).toBe("068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6");
+    expect(crypto.createHash("sha256").update(fs.readFileSync(baselinePath)).digest("hex")).toBe("15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf");
+  });
+});

--- a/tests/lib/preverif/vm0007Rc3FalseSupportTaxonomy.test.ts
+++ b/tests/lib/preverif/vm0007Rc3FalseSupportTaxonomy.test.ts
@@ -30,7 +30,6 @@ function synthetic(rows: readonly any[], reviewed = ids.map((ruleId) => ({ ruleI
 describe("RC3-5 false-support taxonomy", () => {
   it("classifies all current false-support events exactly once and preserves canonical IDs", () => {
     const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
-    const comparison = JSON.parse(fs.readFileSync(comparisonPath, "utf8"));
     const auditedComparison = JSON.parse(fs.readFileSync(comparisonPath, "utf8"));
     const auditedFalseSupportCount = auditedComparison.metrics.acceptedEvidenceFalseSupport.current;
     expect(artifact.totalEvents).toBe(auditedFalseSupportCount);
@@ -45,7 +44,8 @@ describe("RC3-5 false-support taxonomy", () => {
       sourceExtractionSha256: AUDITED_V2_IDENTITIES.sourceExtractionSha256,
       auditExecutionSha256: AUDITED_V2_IDENTITIES.productionExecutionSha256,
       generatedProposalSha256: AUDITED_V2_IDENTITIES.generatedProposalSha256,
-      frozenRc2BaselineSha256: AUDITED_V2_IDENTITIES.auditedBaselineSha256,
+      frozenRc2BaselineSha256: "15c0497eae4d128c3828fe951e204ff46db0aa282b711877b7556ecabe8787cf",
+      auditedV2BaselineSha256: AUDITED_V2_IDENTITIES.auditedBaselineSha256,
     });
   });
 

--- a/tests/lib/preverif/vm0007Rc3FalseSupportTaxonomy.test.ts
+++ b/tests/lib/preverif/vm0007Rc3FalseSupportTaxonomy.test.ts
@@ -37,6 +37,12 @@ describe("RC3-5 false-support taxonomy", () => {
     expect(new Set(artifact.events.map((event: any) => event.eventId)).size).toBe(auditedFalseSupportCount);
     expect(artifact.events.map((event: any) => event.eventId).sort()).toEqual(auditedComparison.regressedEventIds.acceptedEvidenceFalseSupport.slice().sort());
     expect(Object.values(artifact.primarySubtypeCounts).reduce((sum: number, count: any) => sum + count, 0)).toBe(auditedFalseSupportCount);
+    expect(artifact.primarySubtypeCounts).toMatchObject({
+      quote_reviewed_under_different_rule: 109,
+      broad_span_contains_reviewed_quote_same_rule: 34,
+      duplicated_across_multiple_rules: 29,
+      accepted_project_specific_but_unmatched: 2,
+    });
     expect(artifact.schemaVersion).toBe("vm0007-rc3-false-support-taxonomy-v2");
     expect(artifact.traceVersion).toBe("rc3-audited-v2-false-support-taxonomy-v1");
     expect(artifact.source).toMatchObject({


### PR DESCRIPTION
## Summary

Finalize the RC3-5 accepted-evidence false-support taxonomy registry against the audited V2 baseline. This amendment is diagnostic-only.

- The taxonomy is indexed exactly once under V2 `diagnosticArtifacts`.
- The obsolete provisional PR #1046 registry metadata has been removed.
- No V3 baseline was created.
- Taxonomy classifications and counts are unchanged:
  - total: 174
  - quote_reviewed_under_different_rule: 109
  - broad_span_contains_reviewed_quote_same_rule: 34
  - duplicated_across_multiple_rules: 29
  - accepted_project_specific_but_unmatched: 2

Registry artifact SHA: `ab5a62d39d44913962b5379183654aaa27a919a3cfc4649626a6bf453a15c6ba`

Registered V2 diagnostic artifact:

`docs/roadmaps/interactive-evidence-review-mvp/RC3_FALSE_SUPPORT_TAXONOMY.json`

Taxonomy SHA: `32181d976bea24d01884c6c1d8586afd5e858ea40eb708a7f5156f2c71e11865`

Frozen identities remain unchanged, including the V1 RC2 baseline and V2 audited pre-fix baseline. No production behavior, reviewed truth, fixtures, benchmark rules, or frozen V1/V2 artifacts changed.

## Validation

- `npm run preverif:rc3:baseline-registry`
- focused Jest: 2 suites, 14 tests passed
- `npm run typecheck`
- `git diff --check`
- registry generated twice with byte-identical output
- frozen artifact integrity check: passed

### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC3: in_progress

PR remains draft and is not merged.