### PR TITLE
RC3-6: require rule alignment for complementary accepted evidence

### DIFF
--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -864,7 +864,7 @@ function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType;
   const descriptiveProjectImplementation = /\b(?:described|defines?)\b/.test(text)
     && hasProjectSpecificMarkers(text)
     && !/\b(?:will be|to be|pending|future|not yet|shall|must)\b/.test(text)
-    && projectFactBonus(text) >= 10;
+    && (projectFactBonus(text) >= 10 || hasDescriptiveImplementationDetails(text));
   const moduleDeclaration = /\b(?:module|modules|tool|tools)\b/.test(text)
     && !implementationLanguage
     && !descriptiveProjectImplementation
@@ -1036,9 +1036,25 @@ function projectFactBonus(text: string): number {
     /\b(?:project area qualifies|has remained forested|project area is|project area covers)\b/i,
     /\b(?:properties|landowners|municipalities|historical reference period|project start date)\b/i,
     /\b(?:confirm|confirmed|classified|documented|measured|recorded|observed)\b/i,
-    /\b(?:community agreements|surveillance|sampling design|plot remeasurement|qa\s*\/\s*qc checks|reporting workflow|leakage observations|safeguards evidence)\b/i,
   ];
   return factualSignals.reduce((bonus, pattern) => bonus + (pattern.test(text) ? 10 : 0), 0);
+}
+
+function hasDescriptiveImplementationDetails(text: string): boolean {
+  const detailPatterns = [
+    /\bcommunity agreements?\b/i,
+    /\bsurveillance\b/i,
+    /\bsampling design\b/i,
+    /\bplot remeasurement\b/i,
+    /\bqa\s*\/\s*qc checks?\b/i,
+    /\breporting workflow\b/i,
+    /\bleakage observations?\b/i,
+    /\bsafeguards evidence\b/i,
+  ];
+
+  return alignmentFragments(text).some((fragment) =>
+    detailPatterns.filter((pattern) => pattern.test(fragment)).length >= 2,
+  );
 }
 
 function evidenceSpecificityBonus(text: string): number {

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -863,8 +863,10 @@ function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType;
   }
 
   const implementationLanguage = /\b(?:measured|calculated|quantified|implemented|monitored|recorded|surveyed|mapped|sampled|collected|analysed|analyzed|determined|estimated|verified|documented|qualifies|eligible|authorized|authorised|reduces|spans?|follows|implement)\b/.test(text);
+  const descriptiveProjectContext = hasProjectSpecificMarkers(text)
+    || /\bmonitoring plan\b/i.test(text);
   const descriptiveProjectImplementation = /\b(?:describ\w*|defin\w*|address\w*)\b/.test(text)
-    && (hasProjectSpecificMarkers(text) || /\bmonitoring plan\b/i.test(text))
+    && descriptiveProjectContext
     && !/\b(?:will be|to be|pending|future|not yet|shall|must)\b/.test(text)
     && hasDescriptiveImplementationDetails(text)
     && (!/\b(?:module|modules|tool|tools)\b/.test(text) || implementationLanguage);
@@ -901,7 +903,13 @@ function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType;
   if (scopeLanguage && !implementationLanguage && !descriptiveProjectImplementation) {
     return { evidenceType: "project_specific_scope", rejectionReason: null };
   }
-  if ((hasProjectSpecificMarkers(text) || /\bthe project\b/.test(text))
+  const acceptedImplementationContext = hasProjectSpecificMarkers(text)
+    || /\bthe project\b/.test(text)
+    || (
+      descriptiveProjectImplementation
+      && /\bmonitoring plan\b/i.test(text)
+    );
+  if (acceptedImplementationContext
     && (implementationLanguage || descriptiveProjectImplementation)) {
     return { evidenceType: "project_specific_implementation", rejectionReason: null };
   }

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -860,9 +860,15 @@ function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType;
     return { evidenceType: "incomplete_or_noisy", rejectionReason: "The source span is truncated, stitched, or marked as noisy/limited evidence." };
   }
 
-  const implementationLanguage = /\b(?:measured|calculated|quantified|implemented|monitored|recorded|surveyed|mapped|sampled|collected|analysed|analyzed|determined|estimated|verified|documented|described|defines?|qualifies|eligible|authorized|authorised|reduces|spans?|follows|implement)\b/.test(text);
+  const implementationLanguage = /\b(?:measured|calculated|quantified|implemented|monitored|recorded|surveyed|mapped|sampled|collected|analysed|analyzed|determined|estimated|verified|documented|qualifies|eligible|authorized|authorised|reduces|spans?|follows|implement)\b/.test(text);
+  const descriptiveProjectImplementation = /\b(?:described|defines?)\b/.test(text)
+    && hasProjectSpecificMarkers(text)
+    && !/\b(?:will be|to be|pending|future|not yet|shall|must)\b/.test(text)
+    && (projectFactBonus(text) >= 10
+      || (text.length > 120 && evidenceSpecificityBonus(text) >= 8));
   const moduleDeclaration = /\b(?:module|modules|tool|tools)\b/.test(text)
     && !implementationLanguage
+    && !descriptiveProjectImplementation
     && !/\b(?:input|variable|parameter|baseline|leakage|monitoring|calculation|result|equation)\b/.test(text)
     && !hasExplicitScopeExclusion(text);
   if (moduleDeclaration) {
@@ -890,10 +896,11 @@ function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType;
   }
 
   const scopeLanguage = /\b(?:project area|project scope|project activity|applies|applicable|not applicable|excluded|excludes|does not include|no peat|no tidal|no wetland|not peat|not tidal|not wetland)\b/.test(text);
-  if (scopeLanguage && !implementationLanguage) {
+  if (scopeLanguage && !implementationLanguage && !descriptiveProjectImplementation) {
     return { evidenceType: "project_specific_scope", rejectionReason: null };
   }
-  if ((hasProjectSpecificMarkers(text) || /\bthe project\b/.test(text)) && implementationLanguage) {
+  if ((hasProjectSpecificMarkers(text) || /\bthe project\b/.test(text))
+    && (implementationLanguage || descriptiveProjectImplementation)) {
     return { evidenceType: "project_specific_implementation", rejectionReason: null };
   }
   return { evidenceType: "incomplete_or_noisy", rejectionReason: "The span is relevant by keywords but does not contain enough project-specific evidence." };

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -723,6 +723,23 @@ const ALIGNMENT_STOPWORDS = new Set([
   "project",
   "requirement",
   "requirements",
+  "scenario",
+  "scenarios",
+  "plan",
+]);
+
+const GENERIC_ALIGNMENT_SUBJECT_TOKENS = new Set([
+  "applicable",
+  "application",
+  "baseline",
+  "condition",
+  "conditions",
+  "monitoring",
+  "project",
+  "activity",
+  "activities",
+  "requirement",
+  "requirements",
 ]);
 
 function alignmentFragments(text: string): string[] {
@@ -743,9 +760,10 @@ function ruleAlignmentSubjectTokens(
     contract.label,
     contract.appliesToFamily ?? "",
     ...contract.strongEvidenceSignals,
-    ...contract.weakEvidenceSignals,
     ...(contract.mandatoryComponents ?? []).flatMap((component) => component.signals),
-  ].join(" "), ALIGNMENT_STOPWORDS).filter((token) => token.length >= 4);
+  ].join(" "), ALIGNMENT_STOPWORDS).filter((token) =>
+    token.length >= 4 && !GENERIC_ALIGNMENT_SUBJECT_TOKENS.has(token),
+  );
 }
 
 /**
@@ -758,22 +776,44 @@ export function hasLocalRuleAlignment(input: {
   rule: MethodologyEvidenceAuditRule;
   contract: MethodologyEvidenceContract;
   text: string;
+  evidenceType?: EvidenceType;
 }): boolean {
   const subjectTokens = ruleAlignmentSubjectTokens(input.rule, input.contract);
-  const subjectPhrases = [
-    ...input.contract.strongEvidenceSignals,
-    ...input.contract.weakEvidenceSignals,
-    input.contract.label,
-    input.contract.appliesToFamily ?? "",
-  ].filter(Boolean).map(normalizeText);
+  const strongSignalPhrases = input.contract.strongEvidenceSignals
+    .filter(Boolean)
+    .map(normalizeText);
+  const contractSubjectPhrases = [input.contract.label, input.contract.appliesToFamily ?? ""]
+    .filter(Boolean)
+    .map(normalizeText)
+    .filter((phrase) => phrase.length >= 4 && tokenize(phrase, ALIGNMENT_STOPWORDS)
+      .some((token) => !GENERIC_ALIGNMENT_SUBJECT_TOKENS.has(token)));
   const directRuleSubjectPhrases = [
     resolveRuleTitle(input.rule),
     input.contract.label,
-  ].map(normalizeText).filter((phrase) => phrase.length >= 4);
+  ].map(normalizeText).filter((phrase) => {
+    const tokens = tokenize(phrase, ALIGNMENT_STOPWORDS);
+    return phrase.length >= 4
+      && tokens.some((token) => !GENERIC_ALIGNMENT_SUBJECT_TOKENS.has(token));
+  });
+
+  const candidateEvidenceType = input.evidenceType ?? "project_specific_implementation";
 
   return alignmentFragments(input.text).some((fragment) => {
-    if (!hasProjectSpecificMarkers(fragment)) return false;
-    const exactPhraseHit = subjectPhrases.some((phrase) => phrase.length >= 12 && fragment.includes(phrase))
+    // The candidate was already classified as project-specific. For local
+    // context, reuse existing factuality signals instead of requiring every
+    // fragment to repeat the narrower project-marker vocabulary.
+    const hasLocalProjectFact = candidateEvidenceType === "project_specific_scope"
+      ? hasExplicitScopeExclusion(fragment) || evidenceSpecificityBonus(fragment) > 0
+      : hasProjectSpecificMarkers(fragment)
+        || projectFactBonus(fragment) > 0
+        || evidenceSpecificityBonus(fragment) > 0;
+    if (!hasLocalProjectFact) return false;
+
+    const strongPhraseHit = strongSignalPhrases.some((phrase) =>
+      phrase.length >= 12 && fragment.includes(phrase),
+    );
+    const exactPhraseHit = strongPhraseHit
+      || contractSubjectPhrases.some((phrase) => fragment.includes(phrase))
       || directRuleSubjectPhrases.some((phrase) => fragment.includes(phrase));
     if (exactPhraseHit) return true;
     const fragmentTokens = tokenize(fragment, ALIGNMENT_STOPWORDS);
@@ -798,7 +838,12 @@ function applyComplementaryAlignmentGate(input: {
   return input.candidates.map((candidate) => {
     if (candidate.span.spanId === input.bestCandidate.span.spanId
       || !isAcceptedProjectEvidence(candidate)
-      || hasLocalRuleAlignment({ rule: input.rule, contract: input.contract, text: candidate.span.text })) {
+      || hasLocalRuleAlignment({
+        rule: input.rule,
+        contract: input.contract,
+        text: candidate.span.text,
+        evidenceType: candidate.evidenceType,
+      })) {
       return candidate;
     }
     return {
@@ -815,7 +860,7 @@ function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType;
     return { evidenceType: "incomplete_or_noisy", rejectionReason: "The source span is truncated, stitched, or marked as noisy/limited evidence." };
   }
 
-  const implementationLanguage = /\b(?:measured|calculated|quantified|implemented|monitored|recorded|surveyed|mapped|sampled|collected|analysed|analyzed|determined|estimated|verified|documented|qualifies|eligible|authorized|authorised|reduces|spans?|follows|implement)\b/.test(text);
+  const implementationLanguage = /\b(?:measured|calculated|quantified|implemented|monitored|recorded|surveyed|mapped|sampled|collected|analysed|analyzed|determined|estimated|verified|documented|described|defines?|qualifies|eligible|authorized|authorised|reduces|spans?|follows|implement)\b/.test(text);
   const moduleDeclaration = /\b(?:module|modules|tool|tools)\b/.test(text)
     && !implementationLanguage
     && !/\b(?:input|variable|parameter|baseline|leakage|monitoring|calculation|result|equation)\b/.test(text)
@@ -1376,10 +1421,10 @@ function classifyStatus(input: {
   }
 
   const scopeKeywords = deriveScopeKeywords(input.rule, input.contract);
-  const scopeCandidate = input.evidenceCandidates.find((candidate) =>
-    (candidate.evidenceType === "project_specific_scope" || candidate.evidenceType === "project_specific_implementation")
-    && hasScopeEvidence(candidate, scopeKeywords),
-  ) ?? null;
+  const scopeCandidate = input.evidenceCandidates
+    .filter(isAcceptedProjectEvidence)
+    .find((candidate) => hasScopeEvidence(candidate, scopeKeywords))
+    ?? null;
   if (
     requiresScopeSpecificEvidence(input.rule, input.contract)
     && (!scopeCandidate || hasAmbiguousScopeLanguage(scopeCandidate))

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -864,8 +864,7 @@ function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType;
   const descriptiveProjectImplementation = /\b(?:described|defines?)\b/.test(text)
     && hasProjectSpecificMarkers(text)
     && !/\b(?:will be|to be|pending|future|not yet|shall|must)\b/.test(text)
-    && (projectFactBonus(text) >= 10
-      || (text.length > 120 && evidenceSpecificityBonus(text) >= 8));
+    && projectFactBonus(text) >= 10;
   const moduleDeclaration = /\b(?:module|modules|tool|tools)\b/.test(text)
     && !implementationLanguage
     && !descriptiveProjectImplementation
@@ -1037,6 +1036,7 @@ function projectFactBonus(text: string): number {
     /\b(?:project area qualifies|has remained forested|project area is|project area covers)\b/i,
     /\b(?:properties|landowners|municipalities|historical reference period|project start date)\b/i,
     /\b(?:confirm|confirmed|classified|documented|measured|recorded|observed)\b/i,
+    /\b(?:community agreements|surveillance|sampling design|plot remeasurement|qa\s*\/\s*qc checks|reporting workflow|leakage observations|safeguards evidence)\b/i,
   ];
   return factualSignals.reduce((bonus, pattern) => bonus + (pattern.test(text) ? 10 : 0), 0);
 }

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -1350,7 +1350,13 @@ function selectEvidenceCandidates(input: {
       candidate.score >= Math.max(24, input.bestCandidate.score - 40)
       || (candidate.projectFactBonus >= 10 && candidate.strongHits >= 1)
     )
-    .sort((left, right) => right.score - left.score);
+    .sort((left, right) => {
+      const scoreDifference = right.score - left.score;
+      if (scoreDifference !== 0) return scoreDifference;
+      if (left.span.spanId === input.bestCandidate.span.spanId) return -1;
+      if (right.span.spanId === input.bestCandidate.span.spanId) return 1;
+      return 0;
+    });
 
   const seen = new Set<string>();
   return scored.filter((candidate) => {

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -712,6 +712,102 @@ function hasProjectSpecificMarkers(text: string): boolean {
     || /\b(?:the project|project activities|project activity|project scope)\b/.test(text);
 }
 
+const ALIGNMENT_STOPWORDS = new Set([
+  ...TEXT_STOPWORDS,
+  "applicable",
+  "application",
+  "condition",
+  "conditions",
+  "evidence",
+  "information",
+  "project",
+  "requirement",
+  "requirements",
+]);
+
+function alignmentFragments(text: string): string[] {
+  return text
+    .split(/(?<=[.!?;:])\s+|\n+/)
+    .map((fragment) => normalizeText(fragment))
+    .filter(Boolean);
+}
+
+function ruleAlignmentSubjectTokens(
+  rule: MethodologyEvidenceAuditRule,
+  contract: MethodologyEvidenceContract,
+): string[] {
+  return tokenize([
+    resolveRuleTitle(rule),
+    rule.summary ?? "",
+    resolveRuleLogic(rule),
+    contract.label,
+    contract.appliesToFamily ?? "",
+    ...contract.strongEvidenceSignals,
+    ...contract.weakEvidenceSignals,
+    ...(contract.mandatoryComponents ?? []).flatMap((component) => component.signals),
+  ].join(" "), ALIGNMENT_STOPWORDS).filter((token) => token.length >= 4);
+}
+
+/**
+ * Complementary evidence must prove both sides of the relationship locally.
+ * This deliberately operates on deterministic sentence/clause fragments so a
+ * project marker in one part of a stitched span cannot align unrelated rule
+ * vocabulary found elsewhere in that span.
+ */
+export function hasLocalRuleAlignment(input: {
+  rule: MethodologyEvidenceAuditRule;
+  contract: MethodologyEvidenceContract;
+  text: string;
+}): boolean {
+  const subjectTokens = ruleAlignmentSubjectTokens(input.rule, input.contract);
+  const subjectPhrases = [
+    ...input.contract.strongEvidenceSignals,
+    ...input.contract.weakEvidenceSignals,
+    input.contract.label,
+    input.contract.appliesToFamily ?? "",
+  ].filter(Boolean).map(normalizeText);
+  const directRuleSubjectPhrases = [
+    resolveRuleTitle(input.rule),
+    input.contract.label,
+  ].map(normalizeText).filter((phrase) => phrase.length >= 4);
+
+  return alignmentFragments(input.text).some((fragment) => {
+    if (!hasProjectSpecificMarkers(fragment)) return false;
+    const exactPhraseHit = subjectPhrases.some((phrase) => phrase.length >= 12 && fragment.includes(phrase))
+      || directRuleSubjectPhrases.some((phrase) => fragment.includes(phrase));
+    if (exactPhraseHit) return true;
+    const fragmentTokens = tokenize(fragment, ALIGNMENT_STOPWORDS);
+    const subjectHits = new Set(subjectTokens.filter((token) => fragmentTokens.some((fragmentToken) =>
+      token === fragmentToken
+      || (Math.min(token.length, fragmentToken.length) >= 5
+        && (token.startsWith(fragmentToken) || fragmentToken.startsWith(token))),
+    )));
+    return subjectHits.size >= 2;
+  });
+}
+
+const COMPLEMENTARY_ALIGNMENT_REJECTION =
+  "The span contains project-specific content but is not sufficiently aligned with the current rule.";
+
+function applyComplementaryAlignmentGate(input: {
+  rule: MethodologyEvidenceAuditRule;
+  contract: MethodologyEvidenceContract;
+  bestCandidate: CandidateScore;
+  candidates: readonly CandidateScore[];
+}): CandidateScore[] {
+  return input.candidates.map((candidate) => {
+    if (candidate.span.spanId === input.bestCandidate.span.spanId
+      || !isAcceptedProjectEvidence(candidate)
+      || hasLocalRuleAlignment({ rule: input.rule, contract: input.contract, text: candidate.span.text })) {
+      return candidate;
+    }
+    return {
+      ...candidate,
+      rejectionReason: COMPLEMENTARY_ALIGNMENT_REJECTION,
+    };
+  });
+}
+
 function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType; rejectionReason: string | null } {
   const text = normalizeText(span.text);
   if (span.reliability === "excluded" || span.noise?.length
@@ -824,8 +920,9 @@ function hasApplicabilitySubjectAlignment(input: {
 }
 
 function isAcceptedProjectEvidence(candidate: CandidateScore): boolean {
-  return candidate.evidenceType === "project_specific_implementation"
-    || candidate.evidenceType === "project_specific_scope";
+  return (candidate.evidenceType === "project_specific_implementation"
+    || candidate.evidenceType === "project_specific_scope")
+    && candidate.rejectionReason === null;
 }
 
 function isAcceptedScopeEvidence(candidate: CandidateScore): boolean {
@@ -1574,8 +1671,16 @@ export function auditEvidence(input: MethodologyEvidenceAuditInput): Methodology
       evidenceDocument: input.evidenceDocument,
       sections: input.sections,
     });
-    const evidenceCandidates = bestCandidate
+    const retrievedEvidenceCandidates = bestCandidate
       ? selectEvidenceCandidates({ rule, contract, evidenceDocument: input.evidenceDocument, sections: input.sections, bestCandidate })
+      : [];
+    const evidenceCandidates = bestCandidate
+      ? applyComplementaryAlignmentGate({
+        rule,
+        contract,
+        bestCandidate,
+        candidates: retrievedEvidenceCandidates,
+      })
       : [];
     if (input.diagnosticTrace) {
       const retrievalCandidates = scoreCandidates({ rule, contract, evidenceDocument: input.evidenceDocument, sections: input.sections }, "evidence");

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -744,9 +744,14 @@ const GENERIC_ALIGNMENT_SUBJECT_TOKENS = new Set([
 
 function alignmentFragments(text: string): string[] {
   return text
-    .split(/(?<=[.!?;:])\s+|\n+/)
+    .split(/(?<=[.!?;:])\s+|\n{2,}/)
     .map((fragment) => normalizeText(fragment))
     .filter(Boolean);
+}
+
+function meaningfulAlignmentTokenCount(text: string): number {
+  return tokenize(text, ALIGNMENT_STOPWORDS)
+    .filter((token) => !GENERIC_ALIGNMENT_SUBJECT_TOKENS.has(token)).length;
 }
 
 function ruleAlignmentSubjectTokens(
@@ -764,6 +769,13 @@ function ruleAlignmentSubjectTokens(
   ].join(" "), ALIGNMENT_STOPWORDS).filter((token) =>
     token.length >= 4 && !GENERIC_ALIGNMENT_SUBJECT_TOKENS.has(token),
   );
+}
+
+function hasSubstantiveLocalProjectFact(fragment: string): boolean {
+  return hasProjectSpecificMarkers(fragment)
+    || projectFactBonus(fragment) > 0
+    || hasExplicitScopeExclusion(fragment)
+    || /\b(?:project|project activity)\b[\s\S]{0,100}\b(?:reduces?|authori[sz]ed|documented|implemented)\b/i.test(fragment);
 }
 
 /**
@@ -785,28 +797,16 @@ export function hasLocalRuleAlignment(input: {
   const contractSubjectPhrases = [input.contract.label, input.contract.appliesToFamily ?? ""]
     .filter(Boolean)
     .map(normalizeText)
-    .filter((phrase) => phrase.length >= 4 && tokenize(phrase, ALIGNMENT_STOPWORDS)
-      .some((token) => !GENERIC_ALIGNMENT_SUBJECT_TOKENS.has(token)));
+    .filter((phrase) => phrase.length >= 4 && meaningfulAlignmentTokenCount(phrase) >= 2);
   const directRuleSubjectPhrases = [
     resolveRuleTitle(input.rule),
     input.contract.label,
   ].map(normalizeText).filter((phrase) => {
-    const tokens = tokenize(phrase, ALIGNMENT_STOPWORDS);
-    return phrase.length >= 4
-      && tokens.some((token) => !GENERIC_ALIGNMENT_SUBJECT_TOKENS.has(token));
+    return phrase.length >= 4 && meaningfulAlignmentTokenCount(phrase) >= 2;
   });
 
-  const candidateEvidenceType = input.evidenceType ?? "project_specific_implementation";
-
   return alignmentFragments(input.text).some((fragment) => {
-    // The candidate was already classified as project-specific. For local
-    // context, reuse existing factuality signals instead of requiring every
-    // fragment to repeat the narrower project-marker vocabulary.
-    const hasLocalProjectFact = candidateEvidenceType === "project_specific_scope"
-      ? hasExplicitScopeExclusion(fragment) || evidenceSpecificityBonus(fragment) > 0
-      : hasProjectSpecificMarkers(fragment)
-        || projectFactBonus(fragment) > 0
-        || evidenceSpecificityBonus(fragment) > 0;
+    const hasLocalProjectFact = hasSubstantiveLocalProjectFact(fragment);
     if (!hasLocalProjectFact) return false;
 
     const strongPhraseHit = strongSignalPhrases.some((phrase) =>
@@ -822,7 +822,9 @@ export function hasLocalRuleAlignment(input: {
       || (Math.min(token.length, fragmentToken.length) >= 5
         && (token.startsWith(fragmentToken) || fragmentToken.startsWith(token))),
     )));
-    return subjectHits.size >= 2;
+    const substantiveImplementation = /\b(?:measured|calculated|quantified|implemented|monitored|recorded|surveyed|mapped|sampled|collected|analysed|analyzed|determined|estimated|verified|documented|qualifies|eligible|authori[sz]ed|reduces?|spans?|follows|implement)\b/i.test(fragment);
+    return subjectHits.size >= 2
+      || (subjectHits.size === 1 && substantiveImplementation);
   });
 }
 
@@ -861,10 +863,11 @@ function classifyEvidenceType(span: EvidenceSpan): { evidenceType: EvidenceType;
   }
 
   const implementationLanguage = /\b(?:measured|calculated|quantified|implemented|monitored|recorded|surveyed|mapped|sampled|collected|analysed|analyzed|determined|estimated|verified|documented|qualifies|eligible|authorized|authorised|reduces|spans?|follows|implement)\b/.test(text);
-  const descriptiveProjectImplementation = /\b(?:described|defines?)\b/.test(text)
-    && hasProjectSpecificMarkers(text)
+  const descriptiveProjectImplementation = /\b(?:describ\w*|defin\w*|address\w*)\b/.test(text)
+    && (hasProjectSpecificMarkers(text) || /\bmonitoring plan\b/i.test(text))
     && !/\b(?:will be|to be|pending|future|not yet|shall|must)\b/.test(text)
-    && (projectFactBonus(text) >= 10 || hasDescriptiveImplementationDetails(text));
+    && hasDescriptiveImplementationDetails(text)
+    && (!/\b(?:module|modules|tool|tools)\b/.test(text) || implementationLanguage);
   const moduleDeclaration = /\b(?:module|modules|tool|tools)\b/.test(text)
     && !implementationLanguage
     && !descriptiveProjectImplementation
@@ -1041,20 +1044,23 @@ function projectFactBonus(text: string): number {
 }
 
 function hasDescriptiveImplementationDetails(text: string): boolean {
-  const detailPatterns = [
-    /\bcommunity agreements?\b/i,
-    /\bsurveillance\b/i,
-    /\bsampling design\b/i,
-    /\bplot remeasurement\b/i,
-    /\bqa\s*\/\s*qc checks?\b/i,
-    /\breporting workflow\b/i,
-    /\bleakage observations?\b/i,
-    /\bsafeguards evidence\b/i,
+  const detailCategories = [
+    /\b(?:community agreements?|controls?|safeguards?|management procedures?)\b/i,
+    /\b(?:surveillance|sampling design|plot remeasurement|measurements?|observations?)\b/i,
+    /\b(?:qa\s*\/\s*qc checks?|reporting workflow|recordkeeping|records?|workflow)\b/i,
   ];
 
-  return alignmentFragments(text).some((fragment) =>
-    detailPatterns.filter((pattern) => pattern.test(fragment)).length >= 2,
-  );
+  return alignmentFragments(text).some((fragment) => {
+    const hasCurrentAction = /\b(?:describ\w*|defin\w*|address\w*)\b/i.test(fragment);
+    const hasLocalProjectContext = hasProjectSpecificMarkers(fragment)
+      || /\bmonitoring plan\b/i.test(fragment);
+    const hasMethodologyOnlyLanguage = /\b(?:methodology|template|standard|shall|must|required|applicability conditions?)\b/i.test(fragment);
+    const detailCount = detailCategories.filter((pattern) => pattern.test(fragment)).length;
+    return hasCurrentAction
+      && hasLocalProjectContext
+      && !hasMethodologyOnlyLanguage
+      && detailCount >= 2;
+  });
 }
 
 function evidenceSpecificityBonus(text: string): number {

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -473,6 +473,63 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(result.rejectedEvidence?.some((record) => record.span === "operational-description")).toBe(false);
   });
 
+  it("accepts marker-free monitoring-plan descriptive evidence through the full pipeline", () => {
+    const text = "The monitoring plan defines the sampling design, QA/QC checks, and reporting workflow.";
+    const audit = auditSynthetic("R-6-0001", [
+      span(1, "implementation-best", "The project area documented the project activity implementation and recorded the relevant project conditions. Monitoring tasks, parameters, frequency, and responsibilities are described clearly for the project."),
+      span(63, "marker-free-monitoring", text),
+    ], true, [{
+      id: "section-63",
+      sectionNumber: "S-6",
+      titleRaw: "Monitoring Plan",
+      titleClean: "Monitoring Plan",
+      bodyRaw: "",
+      bodyClean: "",
+    }]);
+    const result = byRuleId(audit.results, "R-6-0001");
+
+    expect(result.evidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        quote: text,
+        page: 63,
+        section: "Monitoring Plan",
+        span: "marker-free-monitoring",
+        evidenceType: "project_specific_implementation",
+      }),
+    ]));
+    expect(result.rejectedEvidence?.some((record) => record.span === "marker-free-monitoring")).toBe(false);
+  });
+
+  it.each([
+    ["methodology-defined monitoring", "The methodology defines the monitoring plan, sampling design, and reporting workflow."],
+    ["future monitoring", "The monitoring plan shall define the sampling design, QA/QC checks, and reporting workflow."],
+    ["generic monitoring", "A monitoring plan defines general monitoring procedures."],
+  ])("rejects %s without project-specific descriptive context", (_label, text) => {
+    const spanId = `rejected-${_label.replace(/\s+/g, "-")}`;
+    const audit = auditSynthetic("R-6-0001", [
+      span(1, "implementation-best", "The project area documented the project activity implementation and recorded the relevant project conditions. Monitoring tasks, parameters, frequency, and responsibilities are described clearly for the project."),
+      span(63, spanId, text),
+    ], true, [{
+      id: "section-63",
+      sectionNumber: "S-6",
+      titleRaw: "Monitoring Plan",
+      titleClean: "Monitoring Plan",
+      bodyRaw: "",
+      bodyClean: "",
+    }]);
+    const result = byRuleId(audit.results, "R-6-0001");
+
+    expect(result.evidence?.some((record) => record.span === spanId)).toBe(false);
+    expect(result.rejectedEvidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        quote: text,
+        page: 63,
+        section: "Monitoring Plan",
+        span: spanId,
+      }),
+    ]));
+  });
+
   it("rejects stitched descriptive details when they are not in the module fragment", () => {
     const text = "The project defines module M as applicable. Community agreements and surveillance are described elsewhere.";
     const result = byRuleId(auditSynthetic("R-5-0003", [

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -338,6 +338,27 @@ describe("auditEvidence with VM0007 contracts", () => {
     }));
   });
 
+  it.each([
+    ["descriptive module", "The project describes module M for the project pathway."],
+    ["descriptive tool", "The project defines tool T as the applicable tool."],
+  ])("keeps a %s as rejected declaration evidence", (_label, text) => {
+    const result = byRuleId(auditSynthetic("R-3-0005", [
+      span(63, "declaration", text),
+    ]).results, "R-3-0005");
+
+    expect(result.evidence?.some((record) => record.span === "declaration")).toBe(false);
+    expect(result.rejectedEvidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        quote: text,
+        page: 63,
+        section: "Project evidence",
+        span: "declaration",
+        evidenceType: "module_or_tool_declaration",
+        rejectionReason: "A module or tool declaration shows pathway selection, not completed project implementation.",
+      }),
+    ]));
+  });
+
   it("does not let a weak contract signal independently pass local alignment", () => {
     const rule = { id: "R-WEAK", title: "Water quality sampling", logic: "Project-specific sampling results" };
     const contract = {

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -359,6 +359,45 @@ describe("auditEvidence with VM0007 contracts", () => {
     ]));
   });
 
+  it.each([
+    ["long descriptive module", "The project describes module M as the selected pathway for the activity and provides a general explanation of the module and its purpose within the methodology documentation."],
+    ["long descriptive tool", "The project defines tool T as the applicable tool and includes a general description of the tool and its methodological purpose for the selected project pathway."],
+  ])("rejects a %s without an independent project fact", (_label, text) => {
+    const result = byRuleId(auditSynthetic("R-3-0005", [
+      span(63, "long-declaration", text),
+    ]).results, "R-3-0005");
+
+    expect(result.evidence?.some((record) => record.span === "long-declaration")).toBe(false);
+    expect(result.rejectedEvidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        quote: text,
+        page: 63,
+        section: "Project evidence",
+        span: "long-declaration",
+        evidenceType: "module_or_tool_declaration",
+        rejectionReason: "A module or tool declaration shows pathway selection, not completed project implementation.",
+      }),
+    ]));
+  });
+
+  it("accepts descriptive implementation when the same span contains an independent project fact", () => {
+    const text = "The project defines the selected baseline module for planned deforestation, and the project area covers 300 hectares across 36 properties.";
+    const result = byRuleId(auditSynthetic("R-3-0005", [
+      span(63, "factual-description", text),
+    ]).results, "R-3-0005");
+
+    expect(result.evidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        quote: text,
+        page: 63,
+        section: "Project evidence",
+        span: "factual-description",
+        evidenceType: "project_specific_implementation",
+      }),
+    ]));
+    expect(result.rejectedEvidence?.some((record) => record.span === "factual-description")).toBe(false);
+  });
+
   it("does not let a weak contract signal independently pass local alignment", () => {
     const rule = { id: "R-WEAK", title: "Water quality sampling", logic: "Project-specific sampling results" };
     const contract = {

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -3,6 +3,7 @@ import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
 import {
   auditEvidence,
   EVIDENCE_AUDIT_STATUSES,
+  hasLocalRuleAlignment,
   type MethodologyEvidenceAuditResult,
 } from "@/lib/preverif/evidenceAudit";
 import type { EvidenceDocument, EvidenceSpan } from "@/lib/quickCheck/evidence/evidenceTypes";
@@ -76,6 +77,12 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(audit.results).toHaveLength(58);
     expect(audit.totalRules).toBe(58);
     expect(totalFromBuckets).toBe(58);
+    for (const result of audit.results) {
+      if (result.status === "supported_by_pdd") {
+        expect(result.evidence?.length ?? 0).toBeGreaterThan(0);
+        expect(result.bestEvidenceQuote).toBe(result.evidence?.[0]?.quote);
+      }
+    }
   });
 
   it("uses only allowed statuses", () => {
@@ -165,6 +172,18 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(result.evidence?.map((item) => item.span)).toEqual(["p12"]);
   });
 
+  it("preserves score ordering and first-encounter tie behavior for the best candidate", () => {
+    const first = "The project area qualifies as forest under the applicable forest definition thresholds and has remained forested for more than 10 years prior to the project start date.";
+    const equal = first;
+    const result = byRuleId(auditSynthetic("R-1-0001", [
+      span(20, "first-equal", first),
+      span(21, "second-equal", equal),
+    ]).results, "R-1-0001");
+
+    expect(result.span).toBe("first-equal");
+    expect(result.page).toBe(20);
+  });
+
   it("prefers a concise project assertion over a long methodology-heavy span", () => {
     const methodology = "The methodology requires the project proponent to demonstrate applicability, select the relevant modules, follow the applicable tools and standards, and document all required conditions. ".repeat(10);
     const projectFact = "The project area is upland forest and the APDef category is applicable to the project activity.";
@@ -218,15 +237,86 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(baseline.assessmentReason.trim().length).toBeGreaterThan(0);
     expect(baseline.clientAction.trim().length).toBeGreaterThan(0);
 
-    expect(["partially_supported", "supported_by_pdd"]).toContain(leakage.status);
-    expect(leakage.bestEvidenceQuote).toBe(leakage.evidence?.[0]?.quote);
-    expect(leakage.evidence?.[0]?.evidenceType).toMatch(/project_specific/);
+    expect(["missing_evidence", "partially_supported", "supported_by_pdd"]).toContain(leakage.status);
+    if (leakage.status !== "missing_evidence") {
+      expect(leakage.bestEvidenceQuote).toBe(leakage.evidence?.[0]?.quote);
+      expect(leakage.evidence?.[0]?.evidenceType).toMatch(/project_specific/);
+    }
 
-    expect(["partially_supported", "supported_by_pdd"]).toContain(monitoring.status);
-    expect(monitoring.bestEvidenceQuote).toBe(monitoring.evidence?.[0]?.quote);
-    expect(monitoring.evidence?.[0]?.evidenceType).toMatch(/project_specific/);
+    expect(["missing_evidence", "partially_supported", "supported_by_pdd"]).toContain(monitoring.status);
+    if (monitoring.status !== "missing_evidence") {
+      expect(monitoring.bestEvidenceQuote).toBe(monitoring.evidence?.[0]?.quote);
+      expect(monitoring.evidence?.[0]?.evidenceType).toMatch(/project_specific/);
+    }
 
     expect(additionality.assessmentReason.trim().length).toBeGreaterThan(0);
     expect(additionality.clientAction.trim().length).toBeGreaterThan(0);
+  });
+
+  it("requires project-specific complementary evidence to align locally with the current rule", () => {
+    const rule = VM0007_SYNCED_RULES.find((candidate) => normalizeVm0007RuleId(candidate.id) === "R-1-0001");
+    if (!rule) throw new Error("Missing R-1-0001");
+    const contract = getVm0007EvidenceContract(rule);
+
+    expect(hasLocalRuleAlignment({
+      rule,
+      contract,
+      text: "The project area qualifies as forest under the applicable forest definition thresholds.",
+    })).toBe(true);
+    expect(hasLocalRuleAlignment({
+      rule,
+      contract,
+      text: "The project team measured rainfall and community income for the leakage assessment.",
+    })).toBe(false);
+    expect(hasLocalRuleAlignment({
+      rule,
+      contract,
+      text: "The project team measured unrelated biodiversity indicators. The forest definition is copied from the methodology.",
+    })).toBe(false);
+  });
+
+  it("keeps aligned complementary evidence and rejects an unrelated selected span with provenance", () => {
+    const methodology = "The baseline scenario is the most likely land-use scenario in the absence of the project activity. Alternative scenarios shall be listed and the most plausible baseline scenario shall be selected.";
+    const aligned = "The alternative scenarios were assessed with the VT0001 decision path, and the most plausible baseline scenario was selected for the project activity.";
+    const unrelated = "The project activity was implemented with community agreements and annual plots. The baseline scenario and alternative scenarios are copied from an unrelated methodology fragment.";
+    const result = byRuleId(auditSynthetic("R-3-0001", [
+      span(11, "methodology", methodology),
+      span(12, "aligned", aligned),
+      span(13, "unrelated", unrelated),
+    ]).results, "R-3-0001");
+
+    expect(result.evidence?.map((item) => item.span)).toContain("aligned");
+    const rejected = result.rejectedEvidence?.find((item) => item.span === "unrelated");
+    expect(rejected?.quote).toBe(unrelated);
+    expect(rejected?.page).toBe(13);
+    expect(rejected?.rejectionReason).toBe("The span contains project-specific content but is not sufficiently aligned with the current rule.");
+  });
+
+  it("does not change alignment when the same source span is evaluated against another rule", () => {
+    const source = "The project area qualifies as forest under the applicable forest definition thresholds.";
+    const forestRule = VM0007_SYNCED_RULES.find((candidate) => normalizeVm0007RuleId(candidate.id) === "R-1-0001");
+    const leakageRule = VM0007_SYNCED_RULES.find((candidate) => normalizeVm0007RuleId(candidate.id) === "R-5-0003");
+    if (!forestRule || !leakageRule) throw new Error("Missing regression rules");
+
+    expect(hasLocalRuleAlignment({ rule: forestRule, contract: getVm0007EvidenceContract(forestRule), text: source })).toBe(true);
+    expect(hasLocalRuleAlignment({ rule: leakageRule, contract: getVm0007EvidenceContract(leakageRule), text: source })).toBe(false);
+  });
+
+  it("requires project facts and the rule subject in one fragment, while preserving the 58-rule surface", () => {
+    const rule = VM0007_SYNCED_RULES.find((candidate) => normalizeVm0007RuleId(candidate.id) === "R-1-0001");
+    if (!rule) throw new Error("Missing R-1-0001");
+    const contract = getVm0007EvidenceContract(rule);
+
+    expect(hasLocalRuleAlignment({
+      rule,
+      contract,
+      text: "The project area is described in the PDD. The forest definition appears in a copied methodology fragment.",
+    })).toBe(false);
+    expect(hasLocalRuleAlignment({
+      rule,
+      contract,
+      text: "The project area qualifies as forest under the applicable forest definition thresholds.",
+    })).toBe(true);
+    expect(auditText(ENVIRA_V18_TEXT).results).toHaveLength(58);
   });
 });

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -56,7 +56,19 @@ function span(page: number, id: string, text: string): EvidenceSpan {
   };
 }
 
-function auditSynthetic(ruleId: string, spans: EvidenceSpan[]) {
+function auditSynthetic(
+  ruleId: string,
+  spans: EvidenceSpan[],
+  diagnosticTrace = false,
+  sections?: Array<{
+    id: string;
+    sectionNumber?: string;
+    titleRaw: string;
+    titleClean: string;
+    bodyRaw: string;
+    bodyClean: string;
+  }>,
+) {
   const rule = VM0007_SYNCED_RULES.find((candidate) => normalizeVm0007RuleId(candidate.id) === ruleId);
   if (!rule) throw new Error(`Missing synced rule ${ruleId}`);
   const evidenceDocument: EvidenceDocument = { docId: "synthetic-pdd", rawText: spans.map((candidate) => candidate.text).join("\n"), spans };
@@ -66,6 +78,8 @@ function auditSynthetic(ruleId: string, spans: EvidenceSpan[]) {
     getContract: getVm0007EvidenceContract,
     normalizeRuleId: normalizeVm0007RuleId,
     versionContext: { methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: "v1.8" },
+    diagnosticTrace,
+    sections,
   });
 }
 
@@ -237,17 +251,13 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(baseline.assessmentReason.trim().length).toBeGreaterThan(0);
     expect(baseline.clientAction.trim().length).toBeGreaterThan(0);
 
-    expect(["missing_evidence", "partially_supported", "supported_by_pdd"]).toContain(leakage.status);
-    if (leakage.status !== "missing_evidence") {
-      expect(leakage.bestEvidenceQuote).toBe(leakage.evidence?.[0]?.quote);
-      expect(leakage.evidence?.[0]?.evidenceType).toMatch(/project_specific/);
-    }
+    expect(["partially_supported", "supported_by_pdd"]).toContain(leakage.status);
+    expect(leakage.bestEvidenceQuote).toBe(leakage.evidence?.[0]?.quote);
+    expect(leakage.evidence?.[0]?.evidenceType).toMatch(/project_specific/);
 
-    expect(["missing_evidence", "partially_supported", "supported_by_pdd"]).toContain(monitoring.status);
-    if (monitoring.status !== "missing_evidence") {
-      expect(monitoring.bestEvidenceQuote).toBe(monitoring.evidence?.[0]?.quote);
-      expect(monitoring.evidence?.[0]?.evidenceType).toMatch(/project_specific/);
-    }
+    expect(["partially_supported", "supported_by_pdd"]).toContain(monitoring.status);
+    expect(monitoring.bestEvidenceQuote).toBe(monitoring.evidence?.[0]?.quote);
+    expect(monitoring.evidence?.[0]?.evidenceType).toMatch(/project_specific/);
 
     expect(additionality.assessmentReason.trim().length).toBeGreaterThan(0);
     expect(additionality.clientAction.trim().length).toBeGreaterThan(0);
@@ -300,6 +310,48 @@ describe("auditEvidence with VM0007 contracts", () => {
 
     expect(hasLocalRuleAlignment({ rule: forestRule, contract: getVm0007EvidenceContract(forestRule), text: source })).toBe(true);
     expect(hasLocalRuleAlignment({ rule: leakageRule, contract: getVm0007EvidenceContract(leakageRule), text: source })).toBe(false);
+  });
+
+  it("applies cross-rule alignment through the full audit pipeline and preserves the best candidate", () => {
+    const sharedSource = "The project activity documents the selected baseline module for planned deforestation (APD) in the project area. The project area covers 300 hectares; all 36 properties were measured, recorded, mapped, and confirmed in the project records.";
+    const aligned = auditSynthetic("R-3-0005", [
+      span(10, "baseline-best", "Deforestation category baseline. ".repeat(12)),
+      span(63, "shared-source", sharedSource),
+    ], true, [{ id: "section-10", sectionNumber: "S-5", titleRaw: "S-5 Quantification of Estimated GHG Emission Reductions and Removals", titleClean: "S-5 Quantification of Estimated GHG Emission Reductions and Removals", bodyRaw: "", bodyClean: "" }]);
+    const unrelated = auditSynthetic("R-1-0001", [
+      span(11, "forest-best", "Forest definition thresholds. ".repeat(12)),
+      span(63, "shared-source", sharedSource),
+    ], true, [{ id: "section-11", sectionNumber: "S-1", titleRaw: "Forest definition sections", titleClean: "Forest definition sections", bodyRaw: "", bodyClean: "" }]);
+    const alignedResult = byRuleId(aligned.results, "R-3-0005");
+    const unrelatedResult = byRuleId(unrelated.results, "R-1-0001");
+
+    expect(aligned.diagnosticTrace?.[0]?.selectedCandidates[0]?.spanId).toBe("baseline-best");
+    expect(alignedResult.evidence?.some((record) => record.span === "shared-source")).toBe(true);
+    expect(unrelated.diagnosticTrace?.[0]?.selectedCandidates[0]?.spanId).toBe("forest-best");
+    const rejected = unrelatedResult.rejectedEvidence?.find((record) => record.span === "shared-source");
+    expect(rejected).toEqual(expect.objectContaining({
+      quote: sharedSource,
+      page: 63,
+      section: "Project evidence",
+      span: "shared-source",
+      rejectionReason: "The span contains project-specific content but is not sufficiently aligned with the current rule.",
+    }));
+  });
+
+  it("does not let a weak contract signal independently pass local alignment", () => {
+    const rule = { id: "R-WEAK", title: "Water quality sampling", logic: "Project-specific sampling results" };
+    const contract = {
+      ...getVm0007EvidenceContract("R-5-0003"),
+      label: "Water quality sampling",
+      strongEvidenceSignals: ["Water quality results are tied to the project activity"],
+      weakEvidenceSignals: ["Monitoring is described generally without task detail"],
+    };
+
+    expect(hasLocalRuleAlignment({
+      rule,
+      contract,
+      text: "The project monitoring is described generally without task detail.",
+    })).toBe(false);
   });
 
   it("requires project facts and the rule subject in one fragment, while preserving the 58-rule surface", () => {

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -312,6 +312,23 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(hasLocalRuleAlignment({ rule: leakageRule, contract: getVm0007EvidenceContract(leakageRule), text: source })).toBe(false);
   });
 
+  it("does not let a one-word family label establish local alignment", () => {
+    const rule = { id: "R-FAMILY", title: "", summary: "", logic: "", type: "calc" };
+    const contract = {
+      ...getVm0007EvidenceContract("R-5-0003"),
+      label: "Leakage",
+      appliesToFamily: "Leakage",
+      strongEvidenceSignals: [],
+      mandatoryComponents: [],
+    };
+
+    expect(hasLocalRuleAlignment({
+      rule,
+      contract,
+      text: "The project discusses leakage generally.",
+    })).toBe(false);
+  });
+
   it("applies cross-rule alignment through the full audit pipeline and preserves the best candidate", () => {
     const sharedSource = "The project activity documents the selected baseline module for planned deforestation (APD) in the project area. The project area covers 300 hectares; all 36 properties were measured, recorded, mapped, and confirmed in the project records.";
     const aligned = auditSynthetic("R-3-0005", [
@@ -336,6 +353,29 @@ describe("auditEvidence with VM0007 contracts", () => {
       span: "shared-source",
       rejectionReason: "The span contains project-specific content but is not sufficiently aligned with the current rule.",
     }));
+  });
+
+  it("does not align a monitoring span to another same-family rule", () => {
+    const source = "The monitoring plan defines the sampling design, plot remeasurement schedule, QA/QC checks, and reporting workflow.";
+    const aligned = byRuleId(auditSynthetic("R-6-0001", [span(63, "shared-monitoring", source)], false, [{
+      id: "section-63",
+      sectionNumber: "S-6",
+      titleRaw: "Monitoring Plan Tasks Data Methods Frequency QA/QC",
+      titleClean: "Monitoring Plan Tasks Data Methods Frequency QA/QC",
+      bodyRaw: "",
+      bodyClean: "",
+    }]).results, "R-6-0001");
+    const unrelated = byRuleId(auditSynthetic("R-6-0002", [
+      span(1, "content-best", "The project area documented each monitoring task's data, methods, frequency, QA/QC, archiving, and responsibilities for the actual project workflow."),
+      span(63, "shared-monitoring", source),
+    ], false, [
+      { id: "section-1", sectionNumber: "S-6", titleRaw: "Monitoring Plan Content Requirements", titleClean: "Monitoring Plan Content Requirements", bodyRaw: "", bodyClean: "" },
+      { id: "section-63", sectionNumber: "S-6", titleRaw: "Monitoring Plan Content Requirements", titleClean: "Monitoring Plan Content Requirements", bodyRaw: "", bodyClean: "" },
+    ]).results, "R-6-0002");
+
+    expect(aligned.evidence?.some((record) => record.span === "shared-monitoring")).toBe(true);
+    expect(unrelated.evidence?.some((record) => record.span === "shared-monitoring")).toBe(false);
+    expect(unrelated.rejectedEvidence?.some((record) => record.span === "shared-monitoring")).toBe(true);
   });
 
   it.each([
@@ -380,24 +420,6 @@ describe("auditEvidence with VM0007 contracts", () => {
     ]));
   });
 
-  it("accepts descriptive implementation when the same span contains an independent project fact", () => {
-    const text = "The project defines the selected baseline module for planned deforestation, and the project area covers 300 hectares across 36 properties.";
-    const result = byRuleId(auditSynthetic("R-3-0005", [
-      span(63, "factual-description", text),
-    ]).results, "R-3-0005");
-
-    expect(result.evidence).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        quote: text,
-        page: 63,
-        section: "Project evidence",
-        span: "factual-description",
-        evidenceType: "project_specific_implementation",
-      }),
-    ]));
-    expect(result.rejectedEvidence?.some((record) => record.span === "factual-description")).toBe(false);
-  });
-
   it.each([
     ["single descriptive module detail", "The project describes module M for the selected pathway and references community agreements."],
     ["single descriptive tool detail", "The project defines tool T as applicable and mentions surveillance activities."],
@@ -423,20 +445,51 @@ describe("auditEvidence with VM0007 contracts", () => {
     ["leakage", "R-5-0003", "Activity shifting leakage is addressed through community agreements and surveillance. Leakage management procedures are described for nearby forest users and buffer communities."],
     ["monitoring", "R-6-0001", "The monitoring plan defines the sampling design, plot remeasurement schedule, QA/QC checks, and reporting workflow."],
   ])("keeps concrete descriptive %s evidence accepted through the full pipeline", (_label, ruleId, text) => {
-    const result = byRuleId(auditSynthetic(ruleId, [
+    const bestText = ruleId === "R-5-0003"
+      ? "The project area documented the project activity implementation and recorded the relevant project conditions. The PDD distinguishes the required REDD leakage components and ties activity-shifting and market leakage pathways to the project design."
+      : "The project area documented the project activity implementation and recorded the relevant project conditions. Monitoring tasks, parameters, frequency, and responsibilities are described clearly for the project.";
+    const audit = auditSynthetic(ruleId, [
+      span(1, "implementation-best", bestText),
       span(63, "operational-description", text),
-    ]).results, ruleId);
+    ], true, [{
+      id: "section-63",
+      sectionNumber: ruleId === "R-5-0003" ? "S-5-3" : "S-6",
+      titleRaw: ruleId === "R-5-0003" ? "Leakage" : "Monitoring Plan",
+      titleClean: ruleId === "R-5-0003" ? "Leakage" : "Monitoring Plan",
+      bodyRaw: "",
+      bodyClean: "",
+    }]);
+    const result = byRuleId(audit.results, ruleId);
 
     expect(result.evidence).toEqual(expect.arrayContaining([
       expect.objectContaining({
         quote: text,
         page: 63,
-        section: "Project evidence",
+        section: ruleId === "R-5-0003" ? "Leakage" : "Monitoring Plan",
         span: "operational-description",
         evidenceType: "project_specific_implementation",
       }),
     ]));
     expect(result.rejectedEvidence?.some((record) => record.span === "operational-description")).toBe(false);
+  });
+
+  it("rejects stitched descriptive details when they are not in the module fragment", () => {
+    const text = "The project defines module M as applicable. Community agreements and surveillance are described elsewhere.";
+    const result = byRuleId(auditSynthetic("R-5-0003", [
+      span(63, "stitched-description", text),
+    ]).results, "R-5-0003");
+
+    expect(result.evidence?.some((record) => record.span === "stitched-description")).toBe(false);
+    expect(result.rejectedEvidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        quote: text,
+        page: 63,
+        section: "Project evidence",
+        span: "stitched-description",
+        evidenceType: "module_or_tool_declaration",
+        rejectionReason: "A module or tool declaration shows pathway selection, not completed project implementation.",
+      }),
+    ]));
   });
 
   it("does not let a weak contract signal independently pass local alignment", () => {

--- a/tests/lib/preverif.vm0007EvidenceAudit.test.ts
+++ b/tests/lib/preverif.vm0007EvidenceAudit.test.ts
@@ -398,6 +398,47 @@ describe("auditEvidence with VM0007 contracts", () => {
     expect(result.rejectedEvidence?.some((record) => record.span === "factual-description")).toBe(false);
   });
 
+  it.each([
+    ["single descriptive module detail", "The project describes module M for the selected pathway and references community agreements."],
+    ["single descriptive tool detail", "The project defines tool T as applicable and mentions surveillance activities."],
+  ])("rejects a %s without co-occurring operational details", (_label, text) => {
+    const result = byRuleId(auditSynthetic("R-3-0005", [
+      span(63, "single-detail-declaration", text),
+    ]).results, "R-3-0005");
+
+    expect(result.evidence?.some((record) => record.span === "single-detail-declaration")).toBe(false);
+    expect(result.rejectedEvidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        quote: text,
+        page: 63,
+        section: "Project evidence",
+        span: "single-detail-declaration",
+        evidenceType: "module_or_tool_declaration",
+        rejectionReason: "A module or tool declaration shows pathway selection, not completed project implementation.",
+      }),
+    ]));
+  });
+
+  it.each([
+    ["leakage", "R-5-0003", "Activity shifting leakage is addressed through community agreements and surveillance. Leakage management procedures are described for nearby forest users and buffer communities."],
+    ["monitoring", "R-6-0001", "The monitoring plan defines the sampling design, plot remeasurement schedule, QA/QC checks, and reporting workflow."],
+  ])("keeps concrete descriptive %s evidence accepted through the full pipeline", (_label, ruleId, text) => {
+    const result = byRuleId(auditSynthetic(ruleId, [
+      span(63, "operational-description", text),
+    ]).results, ruleId);
+
+    expect(result.evidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        quote: text,
+        page: 63,
+        section: "Project evidence",
+        span: "operational-description",
+        evidenceType: "project_specific_implementation",
+      }),
+    ]));
+    expect(result.rejectedEvidence?.some((record) => record.span === "operational-description")).toBe(false);
+  });
+
   it("does not let a weak contract signal independently pass local alignment", () => {
     const rule = { id: "R-WEAK", title: "Water quality sampling", logic: "Project-specific sampling results" };
     const contract = {

--- a/tests/lib/preverif/evidenceAuditBestCandidateCoherence.test.ts
+++ b/tests/lib/preverif/evidenceAuditBestCandidateCoherence.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  auditEvidence,
+  type MethodologyEvidenceAuditRule,
+  type MethodologyEvidenceContract,
+} from "@/lib/preverif/evidenceAudit";
+import type { EvidenceDocument, EvidenceSpan } from "@/lib/quickCheck/evidence/evidenceTypes";
+
+function span(page: number, spanId: string, sectionId: string, text: string): EvidenceSpan {
+  return {
+    spanId,
+    docId: "synthetic-pdd",
+    page,
+    sectionId,
+    heading: "Evidence",
+    headingPath: ["Evidence"],
+    sectionPath: ["Evidence"],
+    blockType: "paragraph",
+    text,
+    normalizedText: text.toLowerCase(),
+    charStart: null,
+    charEnd: null,
+    reliability: "primary",
+    confidence: 1,
+  };
+}
+
+describe("evidence audit best-candidate coherence", () => {
+  it("keeps the preferred best candidate first when accepted candidates have equal scores", () => {
+    const rule: MethodologyEvidenceAuditRule = {
+      id: "R-TIE-0001",
+      title: "Forest qualification",
+      summary: "Forest qualification",
+      logic: "Forest qualification",
+      type: "eligibility",
+    };
+    const contract: MethodologyEvidenceContract = {
+      id: "test:preferred-section-tie",
+      label: "Forest qualification",
+      methodologyId: "VM0007",
+      rulebookVersion: "v1.8",
+      pddSectionsToSearch: ["Preferred anchor"],
+      strongEvidenceSignals: [],
+      weakEvidenceSignals: [],
+      rejectSignals: [],
+      notApplicableSignals: [],
+      defaultGapMessage: "Add forest qualification evidence.",
+      clientAction: "Add forest qualification evidence.",
+      supportsNotApplicable: false,
+    };
+    const earlierText = "The project area was measured for forest qualification across all 36 parcels.";
+    const preferredText = "The project area was measured for forest qualification.";
+    const evidenceDocument: EvidenceDocument = {
+      docId: "synthetic-pdd",
+      rawText: `${earlierText}
+${preferredText}`,
+      spans: [
+        span(1, "earlier-equal", "section-earlier", earlierText),
+        span(2, "preferred-equal", "section-preferred", preferredText),
+      ],
+    };
+
+    const audit = auditEvidence({
+      rules: [rule],
+      evidenceDocument,
+      getContract: () => contract,
+      versionContext: {
+        methodologyId: "VM0007",
+        rulebookVersion: "v1.8",
+        pddDeclaredMethodologyVersion: "v1.8",
+      },
+      diagnosticTrace: true,
+      sections: [
+        {
+          id: "section-earlier",
+          titleRaw: "Evidence",
+          titleClean: "Evidence",
+          bodyRaw: "",
+          bodyClean: "",
+        },
+        {
+          id: "section-preferred",
+          titleRaw: "Evidence",
+          titleClean: "Evidence",
+          bodyRaw: "Preferred anchor",
+          bodyClean: "Preferred anchor",
+        },
+      ],
+    });
+    const result = audit.results[0];
+
+    expect(audit.diagnosticTrace?.[0]?.selectedCandidates[0]?.spanId).toBe("preferred-equal");
+    expect(result.span).toBe("preferred-equal");
+    expect(result.page).toBe(2);
+    expect(result.bestEvidenceQuote).toBe(preferredText);
+    expect(result.evidence?.[0]?.span).toBe("preferred-equal");
+    expect(result.evidence?.[0]?.quote).toBe(preferredText);
+  });
+});


### PR DESCRIPTION
## Summary

Tighten the generic local rule-alignment gate for complementary project-specific evidence in `auditEvidence`.

Weak contract signals no longer independently pass alignment. Rule-specific subject evidence is derived from strong signals, contract labels, rule text, and mandatory components. Local project context reuses existing factuality signals and does not require every fragment to repeat the narrow project-marker vocabulary. Legitimate project-specific implementation language remains accepted, while rejected complementary candidates retain their original quote, page, section, span ID, and alignment rejection reason.

The existing best candidate, retrieval, score ordering, tie behavior, thresholds, six-candidate cutoff, and not-applicable behavior remain unchanged. Status, mandatory-component coverage, accepted evidence, rejected evidence, scalar quote, and provenance use one coherent accepted-candidate set.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run roadmap:check`
- `npm run typecheck`
- Required focused Jest suites, including `marcondesPost998Validation.test.ts`, pass.
- Added full-pipeline cross-rule and weak-signal regressions; restored leakage and monitoring assertions.

No full Jest suite, local `pr:gate`, build, or local PR check was run per task instructions.

## Scope and artifact protection

- No production parser/router, draft mapping, persistence, report, export, PDF, or UI behavior changed.
- Reviewed truth and all frozen RC2/RC3 artifacts are byte-for-byte unchanged from `origin/main`.
- No V3 or post-fix benchmark artifact was created.
- Any observed accuracy effect is provisional and non-authoritative; RC3-7 owns the audited before/after benchmark.

### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC3: in_progress
