### PR TITLE
RC4-1: add individual evidence decision contract

### DIFF
--- a/docs/roadmaps/interactive-evidence-review-mvp/PLAN.md
+++ b/docs/roadmaps/interactive-evidence-review-mvp/PLAN.md
@@ -117,6 +117,13 @@ Make correction and approval work efficient for the reviewer.
 - Require reasons for corrections.
 - Preserve save, approve, reopen, history, and finalization semantics.
 
+**RC4 implementation sequence**
+
+- RC4-1 — Evidence decision contract
+- RC4-2 — Complete reviewer editing UI
+- RC4-3 — Guided 58-rule workflow
+- RC4-4 — Full workflow gate
+
 **Gate**
 
 - A reviewer can complete all 58 decisions without leaving the Evidence Map.

--- a/src/lib/preverif/vm0007EvidenceMapDraftStore.ts
+++ b/src/lib/preverif/vm0007EvidenceMapDraftStore.ts
@@ -21,6 +21,24 @@ export function normalizeVm0007EvidenceMapDraftPackage(pkg: Vm0007EvidenceMapDra
     finalizationBasis: pkg.finalizationBasis ?? null,
     rows: pkg.rows.map((row) => ({
       ...row,
+      // v1 drafts may have only the singular machine proposal fields. Keep
+      // those proposals untouched while materializing the reviewer working
+      // collections used by the review contract.
+      acceptedEvidence: row.acceptedEvidence ?? (row.proposedAcceptedEvidence ? [{
+        quote: row.proposedAcceptedEvidence.quote,
+        page: row.proposedAcceptedEvidence.provenance.page,
+        section: row.proposedAcceptedEvidence.provenance.sectionHeading,
+        spanId: row.proposedAcceptedEvidence.provenance.spanId,
+        provenance: row.proposedAcceptedEvidence.provenance,
+      }] : []),
+      rejectedEvidence: row.rejectedEvidence ?? (row.proposedRejectedEvidence ? [{
+        quote: row.proposedRejectedEvidence.quote,
+        page: row.proposedRejectedEvidence.provenance.page,
+        section: row.proposedRejectedEvidence.provenance.sectionHeading,
+        spanId: row.proposedRejectedEvidence.provenance.spanId,
+        rejectionReason: row.proposedRejectedEvidence.reason,
+        provenance: row.proposedRejectedEvidence.provenance,
+      }] : []),
       reviewState: (row.reviewState ?? "pending review") as ReviewerWorkflowState,
       reviewHistory: row.reviewHistory ?? [],
       rowVersion: row.rowVersion ?? 1,

--- a/src/lib/preverif/vm0007EvidenceMapReview.ts
+++ b/src/lib/preverif/vm0007EvidenceMapReview.ts
@@ -51,6 +51,26 @@ export function vm0007EvidenceIdentity(record: Pick<Vm0007EvidenceMapDraftEviden
   ]);
 }
 
+/**
+ * Compact deterministic non-cryptographic hash for public finalized IDs.
+ * Two independent 32-bit lanes keep this synchronous in browser and server
+ * callers while avoiding quote/provenance disclosure in the ID itself.
+ */
+export function compactEvidenceIdentityHash(identity: string): string {
+  let first = 0x811c9dc5;
+  let second = 0x9e3779b9;
+  for (let index = 0; index < identity.length; index += 1) {
+    const code = identity.charCodeAt(index);
+    first = Math.imul(first ^ code, 0x01000193) >>> 0;
+    second = Math.imul(second ^ (code + index), 0x85ebca6b) >>> 0;
+  }
+  return `${first.toString(16).padStart(8, "0")}${second.toString(16).padStart(8, "0")}`;
+}
+
+export function vm0007FinalizedEvidenceId(rowId: string, classification: "accepted" | "rejected", evidenceIdentity: string): string {
+  return `${rowId}:${classification}:${compactEvidenceIdentityHash(evidenceIdentity)}`;
+}
+
 function evidenceRecords(row: Vm0007EvidenceMapDraftRow, rejected: boolean): readonly Vm0007EvidenceMapDraftEvidenceRecord[] {
   if (rejected) {
     return row.rejectedEvidence ?? (row.proposedRejectedEvidence ? [{
@@ -214,8 +234,8 @@ export function reopenVm0007EvidenceMapRow(pkg: Vm0007EvidenceMapDraftPackage, r
 function toEvidenceMapRow(row: Vm0007EvidenceMapDraftRow, finalizedAt: string, reviewerIdentity: string): EvidenceMapRow {
   const acceptedRecords = evidenceRecords(row, false);
   const rejectedRecords = evidenceRecords(row, true);
-  const acceptedEvidence = acceptedRecords.map((record) => ({ evidenceId: `${row.rowId}:accepted:${vm0007EvidenceIdentity(record)}`, quote: record.quote, provenance: record.provenance }));
-  const rejectedEvidence = rejectedRecords.map((record) => ({ evidenceId: `${row.rowId}:rejected:${vm0007EvidenceIdentity(record)}`, quote: record.quote, rejectionReason: record.rejectionReason!, provenance: record.provenance }));
+  const acceptedEvidence = acceptedRecords.map((record) => ({ evidenceId: vm0007FinalizedEvidenceId(row.rowId, "accepted", vm0007EvidenceIdentity(record)), quote: record.quote, provenance: record.provenance }));
+  const rejectedEvidence = rejectedRecords.map((record) => ({ evidenceId: vm0007FinalizedEvidenceId(row.rowId, "rejected", vm0007EvidenceIdentity(record)), quote: record.quote, rejectionReason: record.rejectionReason!, provenance: record.provenance }));
   const evidenceProvenance = [...acceptedEvidence, ...rejectedEvidence].map((item) => item.provenance);
   return {
     rowId: row.rowId,

--- a/src/lib/preverif/vm0007EvidenceMapReview.ts
+++ b/src/lib/preverif/vm0007EvidenceMapReview.ts
@@ -17,6 +17,7 @@ import {
 } from "./vm0007EvidenceMapDraftStore";
 import type {
   Vm0007EvidenceMapDraftPackage,
+  Vm0007EvidenceMapDraftEvidenceRecord,
   Vm0007EvidenceMapDraftRow,
 } from "./vm0007EvidenceMapDraft";
 
@@ -25,7 +26,7 @@ export const VM0007_REVIEW_POLICY_VERSION = "policy-v1";
 export type Vm0007EvidenceMapEdit = Readonly<Partial<Pick<
   Vm0007EvidenceMapDraftRow,
   "assessmentReason" | "clientAction" | "proposedApplicability" | "proposedAcceptedEvidence" | "proposedRejectedEvidence"
-  | "assessment"
+  | "acceptedEvidence" | "rejectedEvidence" | "assessment"
 >>>;
 
 export type Vm0007ReviewResult =
@@ -38,6 +39,42 @@ export type Vm0007FinalizeResult =
 
 function now(): string { return new Date().toISOString(); }
 function reviewerRef(value: string): string { return value.trim(); }
+
+/** Stable identity for one evidence record; mutable array position is never used. */
+export function vm0007EvidenceIdentity(record: Pick<Vm0007EvidenceMapDraftEvidenceRecord, "quote" | "provenance">): string {
+  return JSON.stringify([
+    record.provenance.docId,
+    record.provenance.page,
+    record.provenance.sectionPath,
+    record.provenance.spanId,
+    record.quote,
+  ]);
+}
+
+function evidenceRecords(row: Vm0007EvidenceMapDraftRow, rejected: boolean): readonly Vm0007EvidenceMapDraftEvidenceRecord[] {
+  if (rejected) {
+    return row.rejectedEvidence ?? (row.proposedRejectedEvidence ? [{
+      quote: row.proposedRejectedEvidence.quote,
+      page: row.proposedRejectedEvidence.provenance.page,
+      section: row.proposedRejectedEvidence.provenance.sectionHeading,
+      spanId: row.proposedRejectedEvidence.provenance.spanId,
+      rejectionReason: row.proposedRejectedEvidence.reason,
+      provenance: row.proposedRejectedEvidence.provenance,
+    }] : []);
+  }
+  return row.acceptedEvidence ?? (row.proposedAcceptedEvidence ? [{
+    quote: row.proposedAcceptedEvidence.quote,
+    page: row.proposedAcceptedEvidence.provenance.page,
+    section: row.proposedAcceptedEvidence.provenance.sectionHeading,
+    spanId: row.proposedAcceptedEvidence.provenance.spanId,
+    provenance: row.proposedAcceptedEvidence.provenance,
+  }] : []);
+}
+
+function evidenceMatch(records: readonly Vm0007EvidenceMapDraftEvidenceRecord[], identity: string): { record: Vm0007EvidenceMapDraftEvidenceRecord; index: number } | null {
+  const matches = records.flatMap((record, index) => vm0007EvidenceIdentity(record) === identity ? [{ record, index }] : []);
+  return matches.length === 1 ? matches[0] : null;
+}
 function rowFor(pkg: Vm0007EvidenceMapDraftPackage, rowId: string): Vm0007EvidenceMapDraftRow | null {
   return pkg.rows.find((row) => row.rowId === rowId) ?? null;
 }
@@ -114,6 +151,48 @@ function applyTransition(pkgInput: Vm0007EvidenceMapDraftPackage, rowId: string,
   return { ok: true, package: updated, row: updatedRow };
 }
 
+function decideEvidence(input: {
+  pkg: Vm0007EvidenceMapDraftPackage;
+  rowId: string;
+  evidenceIdentity: string;
+  reviewerIdentity: string;
+  note: string;
+  reject: boolean;
+  timestamp?: string;
+}): Vm0007ReviewResult {
+  const pkg = normalizeVm0007EvidenceMapDraftPackage(input.pkg);
+  const row = rowFor(pkg, input.rowId);
+  if (!row) return { ok: false, reason: "row-not-found" };
+  if (!reviewerRef(input.reviewerIdentity) || !input.note.trim()) return { ok: false, reason: "reviewer-metadata-required" };
+  if (!input.evidenceIdentity.trim()) return { ok: false, reason: "evidence-identity-required" };
+
+  const from = evidenceRecords(row, !input.reject);
+  const target = evidenceMatch(from, input.evidenceIdentity);
+  if (!target) return { ok: false, reason: "unknown-or-ambiguous-evidence-identity" };
+  const other = evidenceRecords(row, input.reject);
+  if (other.some((record) => vm0007EvidenceIdentity(record) === input.evidenceIdentity)) return { ok: false, reason: "duplicate-evidence-identity" };
+
+  const moved = input.reject
+    ? { ...target.record, rejectionReason: input.note.trim() }
+    : (() => {
+      const accepted = { ...target.record };
+      delete accepted.rejectionReason;
+      return accepted;
+    })();
+  const edit: Vm0007EvidenceMapEdit = input.reject
+    ? { acceptedEvidence: from.filter((_, index) => index !== target.index), rejectedEvidence: [...other, moved] }
+    : { acceptedEvidence: [...other, moved], rejectedEvidence: from.filter((_, index) => index !== target.index) };
+  return applyTransition(pkg, input.rowId, { reviewerIdentity: input.reviewerIdentity, action: "edit", note: input.note, timestamp: input.timestamp, edit });
+}
+
+export function rejectVm0007EvidenceRecord(pkg: Vm0007EvidenceMapDraftPackage, rowId: string, evidenceIdentity: string, reviewerIdentity: string, reason: string, timestamp?: string): Vm0007ReviewResult {
+  return decideEvidence({ pkg, rowId, evidenceIdentity, reviewerIdentity, note: reason, reject: true, timestamp });
+}
+
+export function acceptVm0007EvidenceRecord(pkg: Vm0007EvidenceMapDraftPackage, rowId: string, evidenceIdentity: string, reviewerIdentity: string, note: string, timestamp?: string): Vm0007ReviewResult {
+  return decideEvidence({ pkg, rowId, evidenceIdentity, reviewerIdentity, note, reject: false, timestamp });
+}
+
 export function approveVm0007EvidenceMapRow(pkg: Vm0007EvidenceMapDraftPackage, rowId: string, reviewerIdentity: string, note = "Reviewed and approved.", timestamp?: string): Vm0007ReviewResult {
   return applyTransition(pkg, rowId, { reviewerIdentity, action: "approve", note, timestamp });
 }
@@ -133,8 +212,10 @@ export function reopenVm0007EvidenceMapRow(pkg: Vm0007EvidenceMapDraftPackage, r
 }
 
 function toEvidenceMapRow(row: Vm0007EvidenceMapDraftRow, finalizedAt: string, reviewerIdentity: string): EvidenceMapRow {
-  const acceptedEvidence = row.proposedAcceptedEvidence ? [{ evidenceId: `${row.rowId}:accepted`, quote: row.proposedAcceptedEvidence.quote, provenance: row.proposedAcceptedEvidence.provenance }] : [];
-  const rejectedEvidence = row.proposedRejectedEvidence ? [{ evidenceId: `${row.rowId}:rejected`, quote: row.proposedRejectedEvidence.quote, rejectionReason: row.proposedRejectedEvidence.reason, provenance: row.proposedRejectedEvidence.provenance }] : [];
+  const acceptedRecords = evidenceRecords(row, false);
+  const rejectedRecords = evidenceRecords(row, true);
+  const acceptedEvidence = acceptedRecords.map((record) => ({ evidenceId: `${row.rowId}:accepted:${vm0007EvidenceIdentity(record)}`, quote: record.quote, provenance: record.provenance }));
+  const rejectedEvidence = rejectedRecords.map((record) => ({ evidenceId: `${row.rowId}:rejected:${vm0007EvidenceIdentity(record)}`, quote: record.quote, rejectionReason: record.rejectionReason!, provenance: record.provenance }));
   const evidenceProvenance = [...acceptedEvidence, ...rejectedEvidence].map((item) => item.provenance);
   return {
     rowId: row.rowId,

--- a/tests/lib/preverif/vm0007EvidenceMapReview.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapReview.test.ts
@@ -2,9 +2,12 @@
 
 import {
   approveVm0007EvidenceMapRow,
+  acceptVm0007EvidenceRecord,
   editVm0007EvidenceMapRow,
   finalizeVm0007EvidenceMap,
+  rejectVm0007EvidenceRecord,
   reopenVm0007EvidenceMapRow,
+  vm0007EvidenceIdentity,
 } from "@/lib/preverif/vm0007EvidenceMapReview";
 import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import { loadQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessPayload";
@@ -207,5 +210,72 @@ describe("VM0007 persisted Evidence Map reviewer workflow", () => {
     expect(loadQuickCheckReadinessPayload(result.package.auditId)).toBeNull();
     expect(reopened.row.assessment?.reviewState).toBe("REOPENED");
     expect(approveVm0007EvidenceMapRow(reopened.package, reopened.row.rowId, "reviewer-1").ok).toBe(false);
+  });
+
+  test("rejects one accepted record by stable identity and preserves the other record", () => {
+    const first = { quote: "Accepted source quote", page: 3, section: "Evidence", spanId: "span-1", evidenceType: "project_specific_scope" as const, provenance };
+    const second = { ...first, quote: "Second accepted quote", page: 4, spanId: "span-2", provenance: { ...provenance, page: 4, spanId: "span-2" } };
+    const pkg = makePackage({ rows: makePackage().rows.map((row, index) => index === 0 ? { ...row, acceptedEvidence: [first, second], rejectedEvidence: [] } : row) });
+    const result = rejectVm0007EvidenceRecord(pkg, pkg.rows[0].rowId, vm0007EvidenceIdentity(first), "reviewer-1", "This record is boilerplate.", "2026-07-12T04:00:00.000Z");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.acceptedEvidence).toEqual([second]);
+    expect(result.row.rejectedEvidence).toEqual([{ ...first, rejectionReason: "This record is boilerplate." }]);
+    expect(result.row.rowVersion).toBe(2);
+    expect(result.row.reviewState).toBe("edited");
+    expect(result.row.reviewHistory).toHaveLength(1);
+    expect(result.package.finalizationState).toBe("draft");
+  });
+
+  test("requires reviewer identity and a rejection reason", () => {
+    const pkg = makePackage({ rows: makePackage().rows.map((row, index) => index === 0 ? { ...row, acceptedEvidence: [{ quote: "Evidence", page: 1, section: "S", spanId: "s", provenance }] } : row) });
+    const identity = vm0007EvidenceIdentity(pkg.rows[0].acceptedEvidence![0]);
+    expect(rejectVm0007EvidenceRecord(pkg, pkg.rows[0].rowId, identity, "reviewer-1", "   ")).toEqual({ ok: false, reason: "reviewer-metadata-required" });
+    expect(rejectVm0007EvidenceRecord(pkg, pkg.rows[0].rowId, identity, "   ", "Reason")).toEqual({ ok: false, reason: "reviewer-metadata-required" });
+  });
+
+  test("accepts one rejected record, removes its reason, and persists the decision", () => {
+    const rejected = { quote: "Rejected source quote", page: 7, section: "Methodology", spanId: "span-rejected", evidenceType: "methodology_boilerplate" as const, rejectionReason: "Not project evidence.", provenance: { ...provenance, page: 7, sectionPath: ["Methodology"], sectionHeading: "Methodology", spanId: "span-rejected" } };
+    const other = { ...rejected, quote: "Other rejected quote", spanId: "span-other", provenance: { ...rejected.provenance, spanId: "span-other" } };
+    const pkg = makePackage({ rows: makePackage().rows.map((row, index) => index === 0 ? { ...row, acceptedEvidence: [], rejectedEvidence: [rejected, other] } : row) });
+    const result = acceptVm0007EvidenceRecord(pkg, pkg.rows[0].rowId, vm0007EvidenceIdentity(rejected), "reviewer-1", "Reinstated after source review.", "2026-07-12T04:01:00.000Z");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.row.acceptedEvidence).toEqual([{ ...rejected, rejectionReason: undefined }].map(({ rejectionReason: _reason, ...record }) => record));
+    expect(result.row.rejectedEvidence).toEqual([other]);
+    expect(result.row.acceptedEvidence?.[0]).toEqual(expect.objectContaining({ quote: rejected.quote, page: 7, section: "Methodology", spanId: "span-rejected", evidenceType: rejected.evidenceType, provenance: rejected.provenance }));
+    expect(result.row.rowVersion).toBe(2);
+    expect(loadVm0007EvidenceMapDraft(pkg.auditId)?.rows[0].acceptedEvidence).toHaveLength(1);
+  });
+
+  test("fails safely for unknown, duplicate, and repeated evidence identities", () => {
+    const evidence = { quote: "Duplicate", page: 2, section: "Evidence", spanId: "same", provenance };
+    const pkg = makePackage({ rows: makePackage().rows.map((row, index) => index === 0 ? { ...row, acceptedEvidence: [evidence, evidence], rejectedEvidence: [] } : row) });
+    const identity = vm0007EvidenceIdentity(evidence);
+    expect(rejectVm0007EvidenceRecord(pkg, pkg.rows[0].rowId, identity, "reviewer-1", "Reject duplicate.")).toEqual({ ok: false, reason: "unknown-or-ambiguous-evidence-identity" });
+    expect(rejectVm0007EvidenceRecord(pkg, pkg.rows[0].rowId, "unknown", "reviewer-1", "Reject unknown.")).toEqual({ ok: false, reason: "unknown-or-ambiguous-evidence-identity" });
+    const moved = rejectVm0007EvidenceRecord({ ...pkg, rows: pkg.rows.map((row, index) => index === 0 ? { ...row, acceptedEvidence: [evidence] } : row) }, pkg.rows[0].rowId, identity, "reviewer-1", "Reject once.");
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    expect(rejectVm0007EvidenceRecord(moved.package, moved.row.rowId, identity, "reviewer-1", "Reject twice.")).toEqual({ ok: false, reason: "unknown-or-ambiguous-evidence-identity" });
+    expect(moved.row.acceptedEvidence).toHaveLength(0);
+    expect(moved.row.rejectedEvidence).toHaveLength(1);
+  });
+
+  test("finalization emits every reviewed accepted and rejected record with unique deterministic IDs", () => {
+    const accepted = [1, 2].map((page) => ({ quote: `Accepted ${page}`, page, section: "Evidence", spanId: `accepted-${page}`, provenance: { ...provenance, page, spanId: `accepted-${page}` } }));
+    const rejected = [3, 4].map((page) => ({ quote: `Rejected ${page}`, page, section: "Evidence", spanId: `rejected-${page}`, rejectionReason: "Insufficient project support.", provenance: { ...provenance, page, spanId: `rejected-${page}` } }));
+    const pkg = makePackage({ rows: makePackage().rows.map((row, index) => index === 0 ? { ...row, acceptedEvidence: accepted, rejectedEvidence: rejected } : row) });
+    const result = finalizeVm0007EvidenceMap(approveAll(pkg), "reviewer-1", "2026-07-12T05:00:00.000Z");
+    expect(result.ok).toBe(true);
+    const presentations = loadQuickCheckReadinessPayload(pkg.auditId)?.gateResult.presentations[0];
+    expect(presentations?.acceptedEvidence).toHaveLength(2);
+    expect(presentations?.rejectedEvidence).toHaveLength(2);
+    expect(new Set([...(presentations?.acceptedEvidence ?? []), ...(presentations?.rejectedEvidence ?? [])].map((item) => item.evidenceId)).size).toBe(4);
+    expect(presentations?.acceptedEvidence.map((item) => item.provenance.spanId)).toEqual(["accepted-1", "accepted-2"]);
+    expect(presentations?.rejectedEvidence.map((item) => item.provenance.spanId)).toEqual(["rejected-3", "rejected-4"]);
+    const changed = rejectVm0007EvidenceRecord(result.ok ? result.package : pkg, pkg.rows[0].rowId, vm0007EvidenceIdentity(accepted[0]), "reviewer-1", "Correction after finalization.");
+    expect(changed.ok).toBe(true);
+    expect(loadQuickCheckReadinessPayload(pkg.auditId)).toBeNull();
   });
 });

--- a/tests/lib/preverif/vm0007EvidenceMapReview.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapReview.test.ts
@@ -3,11 +3,13 @@
 import {
   approveVm0007EvidenceMapRow,
   acceptVm0007EvidenceRecord,
+  compactEvidenceIdentityHash,
   editVm0007EvidenceMapRow,
   finalizeVm0007EvidenceMap,
   rejectVm0007EvidenceRecord,
   reopenVm0007EvidenceMapRow,
   vm0007EvidenceIdentity,
+  vm0007FinalizedEvidenceId,
 } from "@/lib/preverif/vm0007EvidenceMapReview";
 import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import { loadQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessPayload";
@@ -269,11 +271,22 @@ describe("VM0007 persisted Evidence Map reviewer workflow", () => {
     const result = finalizeVm0007EvidenceMap(approveAll(pkg), "reviewer-1", "2026-07-12T05:00:00.000Z");
     expect(result.ok).toBe(true);
     const presentations = loadQuickCheckReadinessPayload(pkg.auditId)?.gateResult.presentations[0];
+    const repeated = finalizeVm0007EvidenceMap(approveAll(pkg), "reviewer-1", "2026-07-12T05:00:00.000Z");
+    expect(repeated.ok).toBe(true);
+    const repeatedPresentations = repeated.ok ? repeated.pipeline.presentations[0] : null;
     expect(presentations?.acceptedEvidence).toHaveLength(2);
     expect(presentations?.rejectedEvidence).toHaveLength(2);
     expect(new Set([...(presentations?.acceptedEvidence ?? []), ...(presentations?.rejectedEvidence ?? [])].map((item) => item.evidenceId)).size).toBe(4);
     expect(presentations?.acceptedEvidence.map((item) => item.provenance.spanId)).toEqual(["accepted-1", "accepted-2"]);
     expect(presentations?.rejectedEvidence.map((item) => item.provenance.spanId)).toEqual(["rejected-3", "rejected-4"]);
+    expect(presentations?.acceptedEvidence.map((item) => item.evidenceId)).toEqual(repeatedPresentations?.acceptedEvidence.map((item) => item.evidenceId));
+    expect(presentations?.rejectedEvidence.map((item) => item.evidenceId)).toEqual(repeatedPresentations?.rejectedEvidence.map((item) => item.evidenceId));
+    const allEvidence = [...(presentations?.acceptedEvidence ?? []), ...(presentations?.rejectedEvidence ?? [])];
+    expect(allEvidence.every((item) => !item.evidenceId.includes(item.quote))).toBe(true);
+    expect(allEvidence.every((item) => !item.evidenceId.includes(JSON.stringify(item.provenance)))).toBe(true);
+    expect(allEvidence.every((item) => /:((accepted)|(rejected)):[a-f0-9]{16}$/.test(item.evidenceId))).toBe(true);
+    expect(vm0007FinalizedEvidenceId(pkg.rows[0].rowId, "accepted", "same-identity")).not.toBe(vm0007FinalizedEvidenceId(pkg.rows[0].rowId, "rejected", "same-identity"));
+    expect(compactEvidenceIdentityHash("same-identity")).toBe(compactEvidenceIdentityHash("same-identity"));
     const changed = rejectVm0007EvidenceRecord(result.ok ? result.package : pkg, pkg.rows[0].rowId, vm0007EvidenceIdentity(accepted[0]), "reviewer-1", "Correction after finalization.");
     expect(changed.ok).toBe(true);
     expect(loadQuickCheckReadinessPayload(pkg.auditId)).toBeNull();


### PR DESCRIPTION
## Summary

Adds the backward-compatible RC4-1 reviewer contract for individual VM0007 Evidence Map evidence decisions.

- Materializes legacy singular proposals into reviewer working collections without changing machine proposal fields.
- Adds identity-safe accept/reinstate and reject operations routed through the existing reviewer workflow.
- Invalidates assessments, finalization, review readiness payloads, and persists history/version changes through the existing path.
- Finalization now emits all accepted and rejected reviewed evidence records with deterministic unique IDs and full provenance.
- No React evidence controls are included; RC4-2 remains separate.

### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC4: active

## Validation

- `npx jest tests/lib/preverif/vm0007EvidenceMapDraft.test.ts tests/lib/preverif/vm0007EvidenceMapDraftStore.test.ts tests/lib/preverif/vm0007EvidenceMapReview.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run roadmap:check`
- `git diff --check`

Do not merge.