### PR TITLE
feat: guide reviewers through unresolved evidence rules

### DIFF
--- a/src/components/preverif/Vm0007EvidenceMapDraftPage.tsx
+++ b/src/components/preverif/Vm0007EvidenceMapDraftPage.tsx
@@ -15,6 +15,7 @@ import {
   finalizeVm0007EvidenceMap,
   rejectVm0007EvidenceRecord,
   reopenVm0007EvidenceMapRow,
+  vm0007EvidenceMapRowRequiresAttention,
   type Vm0007EvidenceMapEdit,
 } from "@/lib/preverif/vm0007EvidenceMapReview";
 import { matchesReviewedEvidenceMapCase } from "@/lib/preverif/reviewedEvidenceMapRegistry";
@@ -85,8 +86,21 @@ export default function Vm0007EvidenceMapDraftPage({
         : reopenVm0007EvidenceMapRow(pkg, rowId, "reviewer:local", note);
     if (!result.ok) return `Review action blocked: ${result.reason}`;
     setPkg(result.package);
-    setMessage(`Row ${rowId} is now ${result.row.reviewState}.`);
-    setReviewRowId(null);
+    if (action === "approve") {
+      const approvedIndex = result.package.rows.findIndex((row) => row.rowId === rowId);
+      const next = result.package.rows.slice(approvedIndex + 1).find(vm0007EvidenceMapRowRequiresAttention)
+        ?? result.package.rows.slice(0, approvedIndex).find(vm0007EvidenceMapRowRequiresAttention);
+      if (next) {
+        setReviewRowId(next.rowId);
+        setMessage(`Row ${rowId} approved. Moved to the next unresolved rule, ${next.ruleReference}.`);
+      } else {
+        setReviewRowId(null);
+        setMessage(`Row ${rowId} approved. All rules are complete.`);
+      }
+    } else {
+      setReviewRowId(null);
+      setMessage(`Row ${rowId} is now ${result.row.reviewState}.`);
+    }
     return null;
   };
   const edit = (

--- a/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
+++ b/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
@@ -19,8 +19,10 @@ import {
   buildReviewedEvidenceMapPresentation,
   EMPTY_PRESENTATION_FILTERS,
   filterEvidenceMapPresentation,
-  hasPresentationFilters,
   summarizeEvidenceMapPresentation,
+  hasPresentationFilters,
+  summarizeEvidenceMapWorkflow,
+  findEvidenceMapNavigationTarget,
   type EvidenceMapMode,
   type EvidenceMapPresentationFilters,
   type EvidenceMapPresentationRow,
@@ -333,14 +335,18 @@ function RuleDetails({
 }
 
 function Summary({ rows }: { rows: readonly EvidenceMapPresentationRow[] }) {
-  const summary = summarizeEvidenceMapPresentation(rows);
+  const summary = summarizeEvidenceMapWorkflow(rows);
+  const legacy = summarizeEvidenceMapPresentation(rows);
   const items = [
     ["Total rules", summary.total],
-    ["Found", summary.found],
-    ["Unclear", summary.unclear],
-    ["Missing", summary.missing],
-    ["Not applicable", summary.notApplicable],
-    ["Action required", summary.actionRequired],
+    ["Complete", summary.complete],
+    ["Unresolved", summary.unresolved],
+    ["Blocked / stale", summary.blocked],
+    ["Found", legacy.found],
+    ["Unclear", legacy.unclear],
+    ["Missing", legacy.missing],
+    ["Not applicable", legacy.notApplicable],
+    ["Action required", legacy.actionRequired],
   ] as const;
   return (
     <nav
@@ -386,6 +392,7 @@ export default function EvidenceMapWorkspace({
   );
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
   const presentation = useMemo(
     () =>
       mode === "reviewed" && reviewedSnapshot
@@ -405,6 +412,7 @@ export default function EvidenceMapWorkspace({
   );
   const toggle = (rowId: string) =>
     setExpanded((current) => {
+      setSelectedRowId(rowId);
       const next = new Set(current);
       if (next.has(rowId)) next.delete(rowId);
       else next.add(rowId);
@@ -415,6 +423,22 @@ export default function EvidenceMapWorkspace({
     setExpanded(new Set());
     onModeChange(next);
   };
+  const selectedIndex = rows.findIndex((row) => row.rowId === selectedRowId);
+  const effectiveIndex = selectedIndex >= 0 ? selectedIndex : (rows.length ? 0 : -1);
+  const navigate = (target: "previous" | "next" | "unresolved" | "blocker") => {
+    const navigationRows = target === "unresolved" || target === "blocker" ? presentation.rows : rows;
+    const current = selectedRowId ?? navigationRows[0]?.rowId ?? null;
+    const destination = findEvidenceMapNavigationTarget(navigationRows, current, target);
+    if (!destination) return;
+    if (!rows.some((row) => row.rowId === destination.rowId)) {
+      setFilters(EMPTY_PRESENTATION_FILTERS);
+    }
+    setSelectedRowId(destination.rowId);
+    setExpanded((currentExpanded) => new Set(currentExpanded).add(destination.rowId));
+    const machineRow = pkg?.rows.find((row) => row.rowId === destination.rowId);
+    if (machineRow) onReview(machineRow);
+  };
+  const workflow = summarizeEvidenceMapWorkflow(presentation.rows);
   const reviewerOutcomes = [
     ...new Set(presentation.rows.map((row) => row.reviewerOutcome)),
   ];
@@ -497,6 +521,13 @@ export default function EvidenceMapWorkspace({
             : "Machine proposal. Live proposal fields are shown unchanged; switch modes to compare reviewed truth."}
         </div>
         <Summary rows={presentation.rows} />
+        {!presentation.readOnly ? <nav aria-label="Evidence Map rule navigation" className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+          <span className="mr-auto text-xs text-slate-500">{effectiveIndex >= 0 ? `Rule ${effectiveIndex + 1} of ${rows.length}` : "No rules"}</span>
+          <button type="button" onClick={() => navigate("previous")} disabled={effectiveIndex <= 0} aria-label="Previous rule" className="min-h-10 rounded-lg border border-slate-300 px-3 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-40">Previous</button>
+          <button type="button" onClick={() => navigate("next")} disabled={effectiveIndex < 0 || effectiveIndex >= rows.length - 1} aria-label="Next rule" className="min-h-10 rounded-lg border border-slate-300 px-3 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-40">Next</button>
+          <button type="button" onClick={() => navigate("unresolved")} disabled={!workflow.unresolved} aria-label="Next unresolved rule" className="min-h-10 rounded-lg border border-blue-300 px-3 text-sm font-semibold text-blue-800 disabled:cursor-not-allowed disabled:opacity-40">Next unresolved</button>
+          <button type="button" onClick={() => navigate("blocker")} disabled={!workflow.blocked} aria-label="Next blocked or stale rule" className="min-h-10 rounded-lg border border-amber-300 px-3 text-sm font-semibold text-amber-900 disabled:cursor-not-allowed disabled:opacity-40">Next blocker</button>
+        </nav> : null}
         <section aria-label="Search and filters" className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
           <div className="flex flex-wrap gap-2">
             <label className="relative min-w-64 flex-1">
@@ -575,6 +606,7 @@ export default function EvidenceMapWorkspace({
                   className={expanded.has(row.rowId) ? "rotate-180" : ""}
                 />
               </button>
+              {row.blockerReasons.length ? <p className="border-t border-amber-100 bg-amber-50/60 px-4 py-2 text-xs text-amber-900 sm:px-6"><strong>Needs attention:</strong> {row.blockerReasons.join(" · ")}</p> : null}
               {expanded.has(row.rowId) ? (
                 <RuleDetails
                   row={row}

--- a/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
+++ b/src/components/preverif/evidence-map/EvidenceMapWorkspace.tsx
@@ -427,7 +427,7 @@ export default function EvidenceMapWorkspace({
   const effectiveIndex = selectedIndex >= 0 ? selectedIndex : (rows.length ? 0 : -1);
   const navigate = (target: "previous" | "next" | "unresolved" | "blocker") => {
     const navigationRows = target === "unresolved" || target === "blocker" ? presentation.rows : rows;
-    const current = selectedRowId ?? navigationRows[0]?.rowId ?? null;
+    const current = selectedRowId ?? (target === "previous" || target === "next" ? navigationRows[0]?.rowId ?? null : null);
     const destination = findEvidenceMapNavigationTarget(navigationRows, current, target);
     if (!destination) return;
     if (!rows.some((row) => row.rowId === destination.rowId)) {

--- a/src/components/preverif/evidence-map/evidenceMapPresentationModel.ts
+++ b/src/components/preverif/evidence-map/evidenceMapPresentationModel.ts
@@ -1,5 +1,5 @@
 import type { Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
-import { vm0007EvidenceMapRowBlockers } from "@/lib/preverif/vm0007EvidenceMapReview";
+import { vm0007EvidenceMapRowWorkflowState } from "@/lib/preverif/vm0007EvidenceMapReview";
 import type {
   ReviewedEvidenceMapSnapshot,
   ReviewedEvidenceRecord,
@@ -83,7 +83,9 @@ export function buildMachineEvidenceMapPresentation(
   return {
     mode: "machine",
     readOnly: false,
-    rows: pkg.rows.map((row) => ({
+    rows: pkg.rows.map((row) => {
+      const workflow = vm0007EvidenceMapRowWorkflowState(row);
+      return {
       rowId: row.rowId,
       stableRuleId: row.stableRuleId,
       ruleReference: row.ruleReference,
@@ -108,9 +110,10 @@ export function buildMachineEvidenceMapPresentation(
       missingComponents: row.missingComponents ?? null,
       reasonSelected: row.reasonSelected ?? null,
       reviewHistory: row.reviewHistory,
-      unresolved: vm0007EvidenceMapRowBlockers(row).length > 0,
-      blockerReasons: vm0007EvidenceMapRowBlockers(row),
-    })),
+      unresolved: workflow.unresolved,
+      blockerReasons: workflow.blockerReasons,
+      };
+    }),
   };
 }
 

--- a/src/components/preverif/evidence-map/evidenceMapPresentationModel.ts
+++ b/src/components/preverif/evidence-map/evidenceMapPresentationModel.ts
@@ -1,4 +1,5 @@
 import type { Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import { vm0007EvidenceMapRowBlockers } from "@/lib/preverif/vm0007EvidenceMapReview";
 import type {
   ReviewedEvidenceMapSnapshot,
   ReviewedEvidenceRecord,
@@ -31,6 +32,8 @@ export type EvidenceMapPresentationRow = Readonly<{
   missingComponents: readonly string[] | null;
   reasonSelected: string | null;
   reviewHistory: Vm0007EvidenceMapDraftPackage["rows"][number]["reviewHistory"];
+  unresolved: boolean;
+  blockerReasons: readonly string[];
 }>;
 
 export type EvidenceMapPresentation = Readonly<{
@@ -105,6 +108,8 @@ export function buildMachineEvidenceMapPresentation(
       missingComponents: row.missingComponents ?? null,
       reasonSelected: row.reasonSelected ?? null,
       reviewHistory: row.reviewHistory,
+      unresolved: vm0007EvidenceMapRowBlockers(row).length > 0,
+      blockerReasons: vm0007EvidenceMapRowBlockers(row),
     })),
   };
 }
@@ -141,6 +146,8 @@ export function buildReviewedEvidenceMapPresentation(
       missingComponents: null,
       reasonSelected: null,
       reviewHistory: [],
+      unresolved: false,
+      blockerReasons: [],
     })),
   };
 }
@@ -222,4 +229,26 @@ export function hasPresentationFilters(
       ([key, value]) => key !== "query" && value !== "ALL",
     )
   );
+}
+
+export type EvidenceMapNavigationTarget = "previous" | "next" | "unresolved" | "blocker";
+
+/** Navigation always consumes the current canonical visible order and stable row IDs. */
+export function findEvidenceMapNavigationTarget(
+  rows: readonly EvidenceMapPresentationRow[],
+  currentRowId: string | null,
+  target: EvidenceMapNavigationTarget,
+): EvidenceMapPresentationRow | null {
+  if (!rows.length) return null;
+  const index = currentRowId ? rows.findIndex((row) => row.rowId === currentRowId) : -1;
+  if (target === "previous") return index > 0 ? rows[index - 1] : null;
+  if (target === "next") return index >= 0 && index < rows.length - 1 ? rows[index + 1] : null;
+  const candidates = target === "unresolved" ? rows.filter((row) => row.unresolved) : rows.filter((row) => row.blockerReasons.length > 0);
+  const after = index >= 0 ? rows.slice(index + 1).find((row) => candidates.some((candidate) => candidate.rowId === row.rowId)) : undefined;
+  return after ?? candidates.find((row) => row.rowId !== currentRowId) ?? null;
+}
+
+export function summarizeEvidenceMapWorkflow(rows: readonly EvidenceMapPresentationRow[]) {
+  const unresolved = rows.filter((row) => row.unresolved).length;
+  return { total: rows.length, complete: rows.length - unresolved, unresolved, blocked: rows.filter((row) => row.blockerReasons.length > 0).length };
 }

--- a/src/lib/preverif/vm0007EvidenceMapReview.ts
+++ b/src/lib/preverif/vm0007EvidenceMapReview.ts
@@ -111,6 +111,7 @@ export type Vm0007EvidenceMapRowWorkflowState = Readonly<{
 export function vm0007EvidenceMapRowWorkflowState(row: Vm0007EvidenceMapDraftRow): Vm0007EvidenceMapRowWorkflowState {
   const blockers: string[] = [];
   if (!row.assessment) blockers.push("canonical assessment missing");
+  else if (row.assessment.evidenceMapRowId !== row.rowId) blockers.push("canonical assessment invalid");
   else if (row.assessment.rowVersion !== (row.rowVersion ?? 1)) blockers.push("canonical assessment stale");
   else {
     const validation = validateProjectEvidenceMapAssessment(toEvidenceMapRow(row, now(), "reviewer:validation"), row.assessment);

--- a/src/lib/preverif/vm0007EvidenceMapReview.ts
+++ b/src/lib/preverif/vm0007EvidenceMapReview.ts
@@ -103,6 +103,23 @@ function currentAssessment(row: Vm0007EvidenceMapDraftRow): boolean {
   const canonicalRow = toEvidenceMapRow(row, now(), "reviewer:validation");
   return validateProjectEvidenceMapAssessment(canonicalRow, row.assessment).valid;
 }
+
+/** The single reviewer-attention/blocker derivation used by guided review UI. */
+export function vm0007EvidenceMapRowBlockers(row: Vm0007EvidenceMapDraftRow): readonly string[] {
+  const blockers: string[] = [];
+  if (row.reviewState !== "approved") blockers.push(`${row.reviewState ?? "pending review"} review`);
+  if (!row.assessment) blockers.push("canonical assessment missing");
+  else if (row.assessment.rowVersion !== (row.rowVersion ?? 1)) blockers.push("canonical assessment stale");
+  else {
+    const validation = validateProjectEvidenceMapAssessment(toEvidenceMapRow(row, now(), "reviewer:validation"), row.assessment);
+    if (!validation.valid) blockers.push(validation.reason.replaceAll("-", " "));
+  }
+  return Array.from(new Set(blockers));
+}
+
+export function vm0007EvidenceMapRowRequiresAttention(row: Vm0007EvidenceMapDraftRow): boolean {
+  return vm0007EvidenceMapRowBlockers(row).length > 0;
+}
 function eventFor(input: { reviewerIdentity: string; currentState: ReviewerWorkflowState; nextState: ReviewerWorkflowState; note: string; timestamp?: string }): ReviewerWorkflowEvent | null {
   const event: ReviewerWorkflowEvent = {
     reviewerIdentity: reviewerRef(input.reviewerIdentity),

--- a/src/lib/preverif/vm0007EvidenceMapReview.ts
+++ b/src/lib/preverif/vm0007EvidenceMapReview.ts
@@ -99,26 +99,35 @@ function rowFor(pkg: Vm0007EvidenceMapDraftPackage, rowId: string): Vm0007Eviden
   return pkg.rows.find((row) => row.rowId === rowId) ?? null;
 }
 function currentAssessment(row: Vm0007EvidenceMapDraftRow): boolean {
-  if (row.assessment === undefined || row.assessment.evidenceMapRowId !== row.rowId || row.assessment.rowVersion !== (row.rowVersion ?? 1)) return false;
-  const canonicalRow = toEvidenceMapRow(row, now(), "reviewer:validation");
-  return validateProjectEvidenceMapAssessment(canonicalRow, row.assessment).valid;
+  return vm0007EvidenceMapRowWorkflowState(row).blockerReasons.length === 0;
 }
 
+export type Vm0007EvidenceMapRowWorkflowState = Readonly<{
+  unresolved: boolean;
+  blockerReasons: readonly string[];
+}>;
+
 /** The single reviewer-attention/blocker derivation used by guided review UI. */
-export function vm0007EvidenceMapRowBlockers(row: Vm0007EvidenceMapDraftRow): readonly string[] {
+export function vm0007EvidenceMapRowWorkflowState(row: Vm0007EvidenceMapDraftRow): Vm0007EvidenceMapRowWorkflowState {
   const blockers: string[] = [];
-  if (row.reviewState !== "approved") blockers.push(`${row.reviewState ?? "pending review"} review`);
   if (!row.assessment) blockers.push("canonical assessment missing");
   else if (row.assessment.rowVersion !== (row.rowVersion ?? 1)) blockers.push("canonical assessment stale");
   else {
     const validation = validateProjectEvidenceMapAssessment(toEvidenceMapRow(row, now(), "reviewer:validation"), row.assessment);
     if (!validation.valid) blockers.push(validation.reason.replaceAll("-", " "));
   }
-  return Array.from(new Set(blockers));
+  return {
+    unresolved: row.reviewState !== "approved" || blockers.length > 0,
+    blockerReasons: Array.from(new Set(blockers)),
+  };
+}
+
+export function vm0007EvidenceMapRowBlockers(row: Vm0007EvidenceMapDraftRow): readonly string[] {
+  return vm0007EvidenceMapRowWorkflowState(row).blockerReasons;
 }
 
 export function vm0007EvidenceMapRowRequiresAttention(row: Vm0007EvidenceMapDraftRow): boolean {
-  return vm0007EvidenceMapRowBlockers(row).length > 0;
+  return vm0007EvidenceMapRowWorkflowState(row).unresolved;
 }
 function eventFor(input: { reviewerIdentity: string; currentState: ReviewerWorkflowState; nextState: ReviewerWorkflowState; note: string; timestamp?: string }): ReviewerWorkflowEvent | null {
   const event: ReviewerWorkflowEvent = {

--- a/tests/components/evidenceMapGuidedWorkflow.test.ts
+++ b/tests/components/evidenceMapGuidedWorkflow.test.ts
@@ -1,0 +1,26 @@
+import {
+  findEvidenceMapNavigationTarget,
+  summarizeEvidenceMapWorkflow,
+  type EvidenceMapPresentationRow,
+} from "@/components/preverif/evidence-map/evidenceMapPresentationModel";
+
+function row(rowId: string, unresolved = false, blockerReasons: readonly string[] = unresolved ? ["needs review"] : []): EvidenceMapPresentationRow {
+  return {
+    rowId, stableRuleId: rowId, ruleReference: rowId, ruleTitle: rowId, requirementText: "Requirement",
+    evidenceState: "MISSING", applicability: "APPLICABLE", reviewerOutcome: "NONE", reviewState: "pending review",
+    acceptedEvidence: [], rejectedEvidence: [], draftFindingCandidate: null, contradictionState: null,
+    clientAction: "", gap: "", rawAuditStatus: null, confidence: null, assessmentReason: null,
+    notApplicable: false, actionRequired: unresolved, supportedComponents: null, missingComponents: null,
+    reasonSelected: null, reviewHistory: [], unresolved, blockerReasons,
+  };
+}
+
+test("guided progress is derived from row data and navigation follows stable canonical order", () => {
+  const rows = [row("R-1"), row("R-2", true, ["canonical assessment stale"]), row("R-3", true, ["canonical assessment missing"]), row("R-4")];
+  expect(summarizeEvidenceMapWorkflow(rows)).toEqual({ total: 4, complete: 2, unresolved: 2, blocked: 2 });
+  expect(findEvidenceMapNavigationTarget(rows, "R-1", "next").rowId).toBe("R-2");
+  expect(findEvidenceMapNavigationTarget(rows, "R-1", "unresolved").rowId).toBe("R-2");
+  expect(findEvidenceMapNavigationTarget(rows, "R-2", "blocker").rowId).toBe("R-3");
+  expect(findEvidenceMapNavigationTarget(rows, "R-1", "previous")).toBeNull();
+  expect(findEvidenceMapNavigationTarget(rows, "R-4", "next")).toBeNull();
+});

--- a/tests/components/evidenceMapGuidedWorkflow.test.ts
+++ b/tests/components/evidenceMapGuidedWorkflow.test.ts
@@ -23,4 +23,8 @@ test("guided progress is derived from row data and navigation follows stable can
   expect(findEvidenceMapNavigationTarget(rows, "R-2", "blocker").rowId).toBe("R-3");
   expect(findEvidenceMapNavigationTarget(rows, "R-1", "previous")).toBeNull();
   expect(findEvidenceMapNavigationTarget(rows, "R-4", "next")).toBeNull();
+  expect(findEvidenceMapNavigationTarget(rows, null, "unresolved").rowId).toBe("R-2");
+  expect(findEvidenceMapNavigationTarget(rows, null, "blocker").rowId).toBe("R-2");
+  expect(findEvidenceMapNavigationTarget([row("only", true)], null, "unresolved")?.rowId).toBe("only");
+  expect(findEvidenceMapNavigationTarget(rows, "R-3", "unresolved").rowId).toBe("R-2");
 });

--- a/tests/lib/preverif/vm0007EvidenceMapReview.test.ts
+++ b/tests/lib/preverif/vm0007EvidenceMapReview.test.ts
@@ -10,6 +10,7 @@ import {
   reopenVm0007EvidenceMapRow,
   vm0007EvidenceIdentity,
   vm0007FinalizedEvidenceId,
+  vm0007EvidenceMapRowWorkflowState,
 } from "@/lib/preverif/vm0007EvidenceMapReview";
 import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import { loadQuickCheckReadinessPayload } from "@/lib/evidence/quickCheckReadinessPayload";
@@ -82,6 +83,18 @@ function buildProductionDraft(): Vm0007EvidenceMapDraftPackage {
 
 describe("VM0007 persisted Evidence Map reviewer workflow", () => {
   beforeEach(() => localStorage.clear());
+
+  test("derives unresolved and canonical blockers separately from real draft rows", () => {
+    const base = makePackage().rows[0];
+    const current = { ...base, reviewState: "approved" as const };
+    expect(vm0007EvidenceMapRowWorkflowState(current)).toEqual({ unresolved: false, blockerReasons: [] });
+    expect(vm0007EvidenceMapRowWorkflowState({ ...current, reviewState: "pending review" })).toEqual({ unresolved: true, blockerReasons: [] });
+    expect(vm0007EvidenceMapRowWorkflowState({ ...current, reviewState: "edited" })).toEqual({ unresolved: true, blockerReasons: [] });
+    expect(vm0007EvidenceMapRowWorkflowState({ ...current, reviewState: "reopened" })).toEqual({ unresolved: true, blockerReasons: [] });
+    expect(vm0007EvidenceMapRowWorkflowState({ ...current, assessment: undefined })).toMatchObject({ unresolved: true, blockerReasons: ["canonical assessment missing"] });
+    expect(vm0007EvidenceMapRowWorkflowState({ ...current, rowVersion: 2 })).toMatchObject({ unresolved: true, blockerReasons: ["canonical assessment stale"] });
+    expect(vm0007EvidenceMapRowWorkflowState({ ...current, assessment: assessmentFor(current.rowId, { conformance: { ...assessmentFor(current.rowId).conformance, contradictionAssessment: "BLOCKING" } }) })).toMatchObject({ unresolved: true, blockerReasons: ["contradiction unresolved"] });
+  });
 
   test("draft opens with 58 pending rows and approval/edit survive save and reload", () => {
     const pkg = makePackage();


### PR DESCRIPTION
## Summary

Implements RC4-3 guided review for the Interactive Evidence Review MVP:

- derives compact progress counts from current Evidence Map rows;
- adds previous, next, next unresolved, and next blocker navigation;
- exposes canonical blocker reasons from the existing assessment validator;
- automatically advances only after successful approval;
- safely clears presentation filters when guided navigation targets a filtered-out canonical row.

No review truth, persistence contracts, parser/router logic, readiness semantics, or downstream report semantics changed.

## Validation

- Focused Jest suites for the Evidence Map workspace, presentation model, guided workflow, review domain, and readiness report
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run roadmap:check`
- `git diff --check`

### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC4: active

RC4-4 is not started.
