### PR TITLE
chore(roadmap): complete RC4 after PR #1065

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -143,7 +143,7 @@ Details: `docs/roadmaps/interactive-evidence-review-mvp/PLAN.md`
 2) RC1 — Readable interactive workspace: Done
 3) RC2 — Accuracy benchmark: Done
 4) RC3 — Generic accuracy improvements: Done
-5) RC4 — Guided reviewer interaction: Active
+5) RC4 — Guided reviewer interaction: Done
 6) RC5 — Unseen-PDD validation: Planned
 7) RC6 — Stellar MVP release: Planned
 

--- a/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
@@ -22,7 +22,7 @@
     },
     "phase_4_guided_reviewer_interaction": {
       "title": "Guided reviewer interaction",
-      "status": "active"
+      "status": "done"
     },
     "phase_5_unseen_pdd_validation": {
       "title": "Unseen-PDD validation",

--- a/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
@@ -1,6 +1,6 @@
 {
   "RC0": "done",
-  "RC4": "active",
+  "RC4": "done",
   "currentPhase": "RC4",
   "name": "Interactive Evidence Review MVP",
   "phases": {


### PR DESCRIPTION
## Summary

Replays the failed post-merge roadmap update for merged PR #1065 using the corrected directive status.

### Roadmap-Update
- slug: interactive-evidence-review-mvp
- ack: human
- items:
  - RC4: done

## Changes

- Marks guided reviewer interaction phase 4 as done.
- Regenerates the roadmap summary with RC4 marked Done.
- Leaves RC5 Planned and unimplemented.

No production behavior changed.