### PR TITLE
test: add RC5 validation fixture contract

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -143,8 +143,8 @@ Details: `docs/roadmaps/interactive-evidence-review-mvp/PLAN.md`
 2) RC1 — Readable interactive workspace: Done
 3) RC2 — Accuracy benchmark: Done
 4) RC3 — Generic accuracy improvements: Done
-5) RC4 — Guided reviewer interaction: Active
-6) RC5 — Unseen-PDD validation: Planned
+5) RC4 — Guided reviewer interaction: Done
+6) RC5 — Unseen-PDD validation: Active
 7) RC6 — Stellar MVP release: Planned
 
 ## project-verification

--- a/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
@@ -1,7 +1,8 @@
 {
   "RC0": "done",
-  "RC4": "active",
-  "currentPhase": "RC4",
+  "RC4": "done",
+  "RC5": "active",
+  "currentPhase": "RC5",
   "name": "Interactive Evidence Review MVP",
   "phases": {
     "phase_0_roadmap_contract": {
@@ -22,11 +23,11 @@
     },
     "phase_4_guided_reviewer_interaction": {
       "title": "Guided reviewer interaction",
-      "status": "active"
+      "status": "done"
     },
     "phase_5_unseen_pdd_validation": {
       "title": "Unseen-PDD validation",
-      "status": "planned"
+      "status": "active"
     },
     "phase_6_stellar_mvp_release": {
       "title": "Stellar MVP release",

--- a/tests/fixtures/preverif/validation-fixture.schema.json
+++ b/tests/fixtures/preverif/validation-fixture.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://app.article6.test/schemas/preverif/validation-fixture.schema.json",
+  "title": "Pre-verification validation fixture",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["fixtureId", "caseType", "pdf", "methodology", "project"],
+  "properties": {
+    "fixtureId": { "type": "string", "minLength": 1 },
+    "caseType": { "const": "validation" },
+    "pdf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileName", "sourcePath", "sha256"],
+      "properties": {
+        "fileName": { "type": ["string", "null"] },
+        "sourcePath": { "type": ["string", "null"] },
+        "sha256": { "type": ["string", "null"], "pattern": "^[a-f0-9]{64}$" }
+      }
+    },
+    "methodology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 }
+      }
+    },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "region": { "type": "string", "minLength": 1 },
+        "registry": { "type": "string", "minLength": 1 },
+        "documentType": { "type": "string", "minLength": 1 }
+      }
+    },
+    "generatedRuleCount": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/tests/fixtures/preverif/validation-fixtures.json
+++ b/tests/fixtures/preverif/validation-fixtures.json
@@ -1,0 +1,27 @@
+[
+  {
+    "fixtureId": "maya-forest-corridor-redd-belize-validation",
+    "caseType": "validation",
+    "pdf": {
+      "fileName": "12-maya-forest-corridor-redd-belize.pdf",
+      "sourcePath": "tests/fixtures/quick-check/v2/maya-forest-corridor-redd-belize/source.pdf",
+      "sha256": "407caaa782e9d9e07b250999539fc809c2c41888b0f20a628a9e49dbeb977a5b"
+    },
+    "methodology": { "id": "VM0007", "version": "v1.8" },
+    "project": {
+      "id": "5294",
+      "name": "Maya Forest Corridor REDD Project",
+      "region": "Belize and Cayo Districts, Belize",
+      "registry": "VCS",
+      "documentType": "Project Description / PD"
+    },
+    "generatedRuleCount": 58
+  },
+  {
+    "fixtureId": "unseen-vm0007-v18-validation",
+    "caseType": "validation",
+    "pdf": { "fileName": null, "sourcePath": null, "sha256": null },
+    "methodology": { "id": "VM0007", "version": "v1.8" },
+    "project": {}
+  }
+]

--- a/tests/fixtures/preverif/validationFixtureContract.ts
+++ b/tests/fixtures/preverif/validationFixtureContract.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import { loadMethodRules, type RuleSummary } from "@/app/m/_lib/methodRules";
+
+export type ValidationFixture = Readonly<{
+  fixtureId: string;
+  caseType: "validation";
+  pdf: Readonly<{
+    fileName: string | null;
+    sourcePath: string | null;
+    sha256: string | null;
+  }>;
+  methodology: Readonly<{ id: string; version: string }>;
+  project: Readonly<{
+    id?: string;
+    name?: string;
+    region?: string;
+    registry?: string;
+    documentType?: string;
+  }>;
+  generatedRuleCount?: number;
+}>;
+
+const registryPath = path.join(process.cwd(), "tests/fixtures/preverif/validation-fixtures.json");
+
+export function loadValidationFixtures(): readonly ValidationFixture[] {
+  return JSON.parse(fs.readFileSync(registryPath, "utf8")) as ValidationFixture[];
+}
+
+export function getValidationFixture(fixtureId: string): ValidationFixture {
+  const fixture = loadValidationFixtures().find((candidate) => candidate.fixtureId === fixtureId);
+  if (!fixture) throw new Error(`Unknown validation fixture: ${fixtureId}`);
+  return fixture;
+}
+
+export async function generateValidationRules(fixture: ValidationFixture): Promise<{
+  rules: readonly RuleSummary[];
+  source: string;
+}> {
+  if (fixture.methodology.id !== "VM0007" || fixture.methodology.version !== "v1.8") {
+    throw new Error("RC5 validation fixtures require VM0007 v1.8.");
+  }
+  const result = await loadMethodRules(fixture.methodology.id, "v1-8");
+  return { rules: result.rules, source: result.source };
+}

--- a/tests/lib/preverif/vm0007Rc5ValidationFixture.test.ts
+++ b/tests/lib/preverif/vm0007Rc5ValidationFixture.test.ts
@@ -1,0 +1,74 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import Ajv2020 from "ajv/dist/2020";
+import { loadReviewedEvidenceMapCandidate } from "@/lib/preverif/reviewedEvidenceMapServerRegistry";
+import {
+  generateValidationRules,
+  getValidationFixture,
+  loadValidationFixtures,
+} from "../../fixtures/preverif/validationFixtureContract";
+
+const schema = JSON.parse(fs.readFileSync(
+  path.join(process.cwd(), "tests/fixtures/preverif/validation-fixture.schema.json"),
+  "utf8",
+));
+const fixtures = loadValidationFixtures();
+const maya = getValidationFixture("maya-forest-corridor-redd-belize-validation");
+const unseen = getValidationFixture("unseen-vm0007-v18-validation");
+
+describe("RC5 VM0007 validation fixtures", () => {
+  it("registers Maya with stable PDF identity and only ingestion metadata", () => {
+    expect(maya.pdf).toEqual(expect.objectContaining({
+      fileName: "12-maya-forest-corridor-redd-belize.pdf",
+      sha256: "407caaa782e9d9e07b250999539fc809c2c41888b0f20a628a9e49dbeb977a5b",
+    }));
+    const bytes = fs.readFileSync(path.join(process.cwd(), maya.pdf.sourcePath!));
+    expect(crypto.createHash("sha256").update(bytes).digest("hex")).toBe(maya.pdf.sha256);
+    expect(maya.methodology).toEqual({ id: "VM0007", version: "v1.8" });
+    expect(maya.project).toEqual(expect.objectContaining({ id: "5294", name: "Maya Forest Corridor REDD Project" }));
+    expect(maya).not.toHaveProperty("gold");
+    expect(maya).not.toHaveProperty("reviewedEvidence");
+  });
+
+  it("generates Maya's 58 rules through the VM0007 v1.8 methodology contract", async () => {
+    const generated = await generateValidationRules(maya);
+    expect(generated.source).toBe("rules.rich.json");
+    expect(generated.rules).toHaveLength(58);
+    expect(maya.generatedRuleCount).toBe(generated.rules.length);
+  });
+
+  it("keeps Maya validation identity out of Marcondes reviewed truth", () => {
+    expect(loadReviewedEvidenceMapCandidate({
+      sourcePdfSha256: maya.pdf.sha256,
+      sourceDocumentId: "maya-forest-corridor-redd-belize-extracted",
+    })).toBeNull();
+  });
+
+  it("keeps the unseen fixture empty and unable to carry reviewed artifacts", async () => {
+    expect(unseen.pdf).toEqual({ fileName: null, sourcePath: null, sha256: null });
+    expect(unseen.project).toEqual({});
+    expect(unseen).not.toHaveProperty("generatedRuleCount");
+    expect(unseen).not.toHaveProperty("expectedOutcomes");
+    expect(unseen).not.toHaveProperty("acceptedEvidence");
+    expect(unseen).not.toHaveProperty("reviewerHistory");
+    expect(loadReviewedEvidenceMapCandidate({ sourcePdfSha256: unseen.pdf.sha256 })).toBeNull();
+    const generated = await generateValidationRules(unseen);
+    expect(generated.rules).toHaveLength(58);
+  });
+
+  it("rejects reviewed fields and prevents validation fixture identifier collisions", () => {
+    const validate = new Ajv2020({ allErrors: true }).compile(schema);
+    for (const fixture of fixtures) expect(validate(fixture)).toBe(true);
+    expect(new Set(fixtures.map((fixture) => fixture.fixtureId)).size).toBe(fixtures.length);
+    expect(validate({ ...unseen, gold: {} })).toBe(false);
+    expect(validate({ ...unseen, reviewedEvidence: [] })).toBe(false);
+    expect(validate({ ...unseen, expectedOutcomes: {} })).toBe(false);
+  });
+
+  it("does not define expected rule rows in the validation fixture", () => {
+    expect(JSON.stringify(fixtures)).not.toContain("ruleReference");
+    expect(JSON.stringify(fixtures)).not.toContain("finalEvidenceState");
+    expect(JSON.stringify(fixtures)).not.toContain("goldCorrections");
+  });
+});


### PR DESCRIPTION
### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC4: done
  - RC5: active

Summary:
- Adds the RC5-1 Maya validation fixture contract and empty unseen VM0007 v1.8 fixture.
- Marks RC4 complete and activates RC5 in the roadmap SSOT and generated summary.
- No production code changed.

Validation:
- `git diff --check`
- `npm run roadmap:validate`
- `npm run roadmap:check`
- Push hook: `npm run lint` and `npm run typecheck`

Do not merge.