### PR TITLE
roadmap: activate RC5 unseen-PDD validation

### DIFF
--- a/docs/roadmaps/SUMMARY.md
+++ b/docs/roadmaps/SUMMARY.md
@@ -144,7 +144,7 @@ Details: `docs/roadmaps/interactive-evidence-review-mvp/PLAN.md`
 3) RC2 — Accuracy benchmark: Done
 4) RC3 — Generic accuracy improvements: Done
 5) RC4 — Guided reviewer interaction: Done
-6) RC5 — Unseen-PDD validation: Planned
+6) RC5 — Unseen-PDD validation: Active
 7) RC6 — Stellar MVP release: Planned
 
 ## project-verification

--- a/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
+++ b/docs/roadmaps/interactive-evidence-review-mvp/phase-status.json
@@ -1,7 +1,8 @@
 {
   "RC0": "done",
   "RC4": "done",
-  "currentPhase": "RC4",
+  "RC5": "active",
+  "currentPhase": "RC5",
   "name": "Interactive Evidence Review MVP",
   "phases": {
     "phase_0_roadmap_contract": {
@@ -26,7 +27,7 @@
     },
     "phase_5_unseen_pdd_validation": {
       "title": "Unseen-PDD validation",
-      "status": "planned"
+      "status": "active"
     },
     "phase_6_stellar_mvp_release": {
       "title": "Stellar MVP release",


### PR DESCRIPTION
### Roadmap-Update
- slug: interactive-evidence-review-mvp
- items:
  - RC4: done
  - RC5: active

This roadmap-only change marks RC4 complete and activates RC5 for unseen-PDD validation. No production code, tests, or fixtures changed.

Do not merge.