### PR TITLE
Unify live and reproducible VM0007 proposal generation

### DIFF
--- a/scripts/preverif/generate-vm0007-machine-proposal.ts
+++ b/scripts/preverif/generate-vm0007-machine-proposal.ts
@@ -2,18 +2,16 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
-import { getStructuredQueryContext } from "../../src/lib/chat/quickCheckReviewQuestion";
 import { extractMethodologyMentions } from "../../src/lib/chat/quickCheckEvidence";
 import { resolveQuickCheckMethodology } from "../../src/lib/chat/quickCheckMethodology";
 import { resolveMethodologySignals } from "../../src/lib/chat/quickCheckMethodSignals";
 import { extractPdfPagesWithPdfParse } from "../../src/lib/chat/quickCheckPdfExtractor";
-import { auditEvidence } from "../../src/lib/preverif/evidenceAudit";
-import { buildVm0007EvidenceMapDraft } from "../../src/lib/preverif/vm0007EvidenceMapDraft";
-import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "../../src/lib/preverif/vm0007EvidenceContracts";
+import { formatQuickCheckPdfPages } from "../../src/lib/chat/quickCheckPdfPages";
+import { loadMethodRules } from "../../src/app/m/_lib/methodRules";
+import { buildVm0007MachineProposal } from "../../src/lib/preverif/vm0007MachineProposal";
 
 const root = process.cwd();
 const expectedPdfSha256 = "407caaa782e9d9e07b250999539fc809c2c41888b0f20a628a9e49dbeb977a5b";
-const rulesPath = path.join(root, "public/methodologies/Verra/AFOLU/VM0007/v1-8/rules.rich.json");
 const manifestPath = path.join(root, "public/manifest/index.json");
 
 function arg(name: string): string {
@@ -45,7 +43,7 @@ async function main(): Promise<void> {
   const extraction = await extractPdfPagesWithPdfParse({ bytes: pdfBytes.buffer.slice(pdfBytes.byteOffset, pdfBytes.byteOffset + pdfBytes.byteLength) });
 if (!extraction.text.trim() || extraction.pages.length === 0) throw new Error("PDF extraction produced no page text");
 
-const rawText = extraction.text.trim();
+const rawText = formatQuickCheckPdfPages(extraction.pages).trim();
 const mentions = extractMethodologyMentions(rawText);
 const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Array<Record<string, unknown>>;
 const methods = Array.from(new Map(
@@ -59,54 +57,24 @@ if (!methodologySignals.exactlyOne || methodologySignals.detectedMethods[0]?.met
   throw new Error(`Methodology detection did not resolve VM0007: ${JSON.stringify({ methodologyResolution, methodologySignals })}`);
 }
 
-const context = getStructuredQueryContext(rawText);
-const rules = JSON.parse(fs.readFileSync(rulesPath, "utf8")) as Array<Record<string, unknown>>;
-if (rules.length !== 58) throw new Error(`VM0007 v1.8 rulebook contains ${rules.length} rules, expected 58`);
 const declaredMethodologyVersion = rawText.match(/\bVM0007\b[\s\S]{0,160}?\b(?:version\s*)?1[.-]8\b/i)?.[0]?.replace(/\s+/g, " ").trim();
 if (!declaredMethodologyVersion) throw new Error("Could not extract a VM0007 v1.8 declaration from the PDF");
-const audit = auditEvidence({
-  rules: rules.map((rule) => ({
-    id: String(rule.id), title: String(rule.title ?? ""), summary: String(rule.summary ?? ""),
-    logic: String(rule.logic ?? ""), text: String(rule.text ?? ""), type: String(rule.type ?? ""),
-  })),
-  evidenceDocument: context.evidenceDocument,
-  getContract: getVm0007EvidenceContract,
-  normalizeRuleId: normalizeVm0007RuleId,
-  sections: context.documentStructure.sections,
-  rawText,
-  diagnosticTrace: true,
-  versionContext: { methodologyId: "VM0007", rulebookVersion: "v1.8", pddDeclaredMethodologyVersion: declaredMethodologyVersion },
-});
-if (audit.auditStatus !== "AUDITED" || !audit.versionMatch || audit.pddDeclaredMethodologyVersion !== "v1.8") {
-  throw new Error(`VM0007 v1.8 version lock failed: ${JSON.stringify({ auditStatus: audit.auditStatus, versionMatch: audit.versionMatch, declared: audit.pddDeclaredMethodologyVersion, reason: audit.versionMismatchReason })}`);
-}
-if (audit.results.length !== 58) throw new Error(`Audit generated ${audit.results.length} rules, expected 58`);
-
-const documentId = "maya-forest-corridor-redd-belize-extracted";
-const sourceDocument = { documentId, documentName: path.basename(pdfPath), contentSha256: sourcePdfSha256 };
-const draft = buildVm0007EvidenceMapDraft({
+const rulesResult = await loadMethodRules("VM0007", "v1-8");
+if (rulesResult.rules.length !== 58) throw new Error(`VM0007 v1.8 rulebook contains ${rulesResult.rules.length} rules, expected 58`);
+const built = buildVm0007MachineProposal({
   auditId: "maya-forest-corridor-redd-belize-vm0007-v18-machine-proposal",
   generatedAt,
-  rules: rules.map((rule) => ({
-    id: String(rule.id), title: String(rule.title ?? ""), summary: String(rule.summary ?? ""),
-    logic: String(rule.logic ?? ""), text: String(rule.text ?? ""), type: String(rule.type ?? ""),
-    snippet: String(rule.text ?? rule.logic ?? rule.title ?? ""), tags: [],
-  })),
-  audit,
-  sourceDocument,
+  methodologyId: "VM0007",
+  methodologyVersion: "v1-8",
+  evidenceFileName: path.basename(pdfPath),
+  sourcePdfSha256,
+  rawPddText: rawText,
+  rules: rulesResult.rules,
 });
+const draft = built.draft;
 if (!draft.ok) throw new Error(`Machine proposal generation blocked: ${draft.blockedBy.join(", ")}`);
 if (draft.package.rows.length !== 58 || draft.package.proposalState !== "MACHINE_PROPOSED") throw new Error("Generated proposal failed canonical shape checks");
 
-const outcomeCounts = { CONFORMS: 0, ACTION_REQUIRED: 0, NOT_APPLICABLE: 0, NOT_ASSESSED: 0 };
-for (const row of draft.package.rows) {
-  const outcome = row.proposedApplicability === "NOT_APPLICABLE"
-    ? "NOT_APPLICABLE"
-    : row.proposedEvidenceStatus === "FOUND" ? "CONFORMS"
-      : row.proposedEvidenceStatus === "UNCLEAR" || row.proposedEvidenceStatus === "MISSING" ? "ACTION_REQUIRED"
-        : "NOT_ASSESSED";
-  outcomeCounts[outcome] += 1;
-}
 const evidenceStateCounts = { FOUND: 0, UNCLEAR: 0, MISSING: 0 };
 const applicabilityCounts = { APPLICABLE: 0, NOT_APPLICABLE: 0, UNKNOWN: 0 };
 let acceptedEvidenceItems = 0;
@@ -122,7 +90,7 @@ for (const row of draft.package.rows) {
 }
 
 writeJson(path.join(outputDir, "raw-document-extraction.json"), {
-  sourceDocument: { ...sourceDocument, sourcePdfSha256 },
+  sourceDocument: { ...built.sourceDocument, sourcePdfSha256 },
   extraction: { engine: extraction.engine, metadata: extraction.metadata, pageCount: extraction.pages.length },
   text: rawText,
   pages: extraction.pages,
@@ -135,11 +103,10 @@ const baselinePath = path.join(root, "docs/roadmaps/interactive-evidence-review-
 const proposalPath = path.join(outputDir, "machine-proposal.json");
 const evidenceCounts = Object.entries(evidenceStateCounts).map(([key, value]) => `${key} ${value}`).join(", ");
 const applicability = Object.entries(applicabilityCounts).map(([key, value]) => `${key} ${value}`).join(", ");
-const outcomes = Object.entries(outcomeCounts).map(([key, value]) => `${key} ${value}`).join(", ");
-const baseline = `# Maya machine proposal baseline\n\n- PDF identity: Maya Forest Corridor REDD Belize (${path.basename(pdfPath)})\n- SHA: ${sourcePdfSha256}\n- RC5-1 fixture identity match: yes (${sourcePdfSha256})\n- Methodology: VM0007\n- Version: v1.8\n- Generation command: npx tsx scripts/preverif/generate-vm0007-machine-proposal.ts --pdf "${pdfPath}" --output "${outputDir}" --generated-at "${generatedAt}"\n- Generation timestamp: ${generatedAt}\n- Number of rules: ${draft.package.rows.length}\n- Evidence-state counts: ${evidenceCounts}\n- Applicability counts: ${applicability}\n- Reviewer-outcome proposal counts: ${outcomes}\n- Accepted evidence items: ${acceptedEvidenceItems}\n- Rejected evidence items: ${rejectedEvidenceItems}\n- Rules with incomplete provenance: ${incompleteProvenanceRules}\n- Reviewed truth exists: no\n- Manual corrections made: no\n- Generation blockers or warnings: none\n- Canonical artifact: [${relative(proposalPath)}](../../../../${relative(proposalPath)})\n`;
+const baseline = `# Maya machine proposal baseline\n\n- PDF identity: Maya Forest Corridor REDD Belize (${path.basename(pdfPath)})\n- SHA: ${sourcePdfSha256}\n- RC5-1 fixture identity match: yes (${sourcePdfSha256})\n- Methodology: VM0007\n- Version: v1.8\n- Generation command: npx tsx scripts/preverif/generate-vm0007-machine-proposal.ts --pdf "${pdfPath}" --output "${outputDir}" --generated-at "${generatedAt}"\n- Generation timestamp: ${generatedAt}\n- Number of rules: ${draft.package.rows.length}\n- Evidence-state counts: ${evidenceCounts}\n- Applicability counts: ${applicability}\n- Accepted evidence items: ${acceptedEvidenceItems}\n- Rejected evidence items: ${rejectedEvidenceItems}\n- Rules with incomplete provenance: ${incompleteProvenanceRules}\n- Reviewed truth exists: no\n- Manual corrections made: no\n- Generation blockers or warnings: none\n- Canonical artifact: [${relative(proposalPath)}](../../../../${relative(proposalPath)})\n`;
 fs.mkdirSync(path.dirname(baselinePath), { recursive: true });
 fs.writeFileSync(baselinePath, baseline, "utf8");
-  console.log(JSON.stringify({ proposalPath: relative(proposalPath), baselinePath: relative(baselinePath), pdfSha256: sourcePdfSha256, methodology: "VM0007", version: "v1.8", rules: 58, evidenceStateCounts, applicabilityCounts, outcomeCounts, acceptedEvidenceItems, rejectedEvidenceItems, incompleteProvenanceRules, generatedAt }, null, 2));
+  console.log(JSON.stringify({ proposalPath: relative(proposalPath), baselinePath: relative(baselinePath), pdfSha256: sourcePdfSha256, methodology: "VM0007", version: "v1.8", rules: 58, evidenceStateCounts, applicabilityCounts, acceptedEvidenceItems, rejectedEvidenceItems, incompleteProvenanceRules, generatedAt }, null, 2));
 }
 
 main().catch((error: unknown) => {

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -145,6 +145,7 @@ export function buildAndSaveVm0007GapReportAudit(input: {
       generatedAt: nowIso(),
       methodologyId: input.loadedRulebookId,
       methodologyVersion: input.loadedRulebookVersion,
+      methodology: input.methodology,
       evidenceFileName: input.evidenceFileName,
       sourcePdfSha256: input.sourcePdfSha256,
       rawPddText: input.rawPddText,

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -1,24 +1,12 @@
 import type { RuleSummary } from "@/app/m/_lib/methodRules";
-import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
-import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
-import { parseExtractedText } from "@/lib/quickCheckV2/evidence";
-import { validateAnswerResults } from "@/lib/quickCheckV2/status";
 import {
-  buildQuickCheckMethodologyIdentity,
   type QuickCheckMethodologyIdentity,
 } from "@/lib/quickCheckV2/methodologyIdentity";
-import {
-  auditEvidence,
-  type MethodologyEvidenceAuditRule,
-  type MethodologyEvidenceAuditSummary,
-} from "@/lib/preverif/evidenceAudit";
-import {
-  getVm0007EvidenceContract,
-  normalizeVm0007RuleId,
-} from "@/lib/preverif/vm0007EvidenceContracts";
+import type { MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
 import type { EvidenceMapSourceDocumentIdentity } from "@/lib/evidence/evidenceMapDependencyContract";
-import { buildVm0007EvidenceMapDraft, type DraftBuildResult, type Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import { type DraftBuildResult, type Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
 import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
+import { buildVm0007MachineProposal } from "@/lib/preverif/vm0007MachineProposal";
 
 const VM0007_GAP_REPORT_AUDIT_PREFIX = "a6:vm0007-gap-report-audit:v1:";
 
@@ -81,17 +69,6 @@ function storageKey(auditId: string): string {
 
 function nowIso(): string {
   return new Date().toISOString();
-}
-
-function mapRule(rule: RuleSummary): MethodologyEvidenceAuditRule {
-  return {
-    id: rule.id,
-    title: rule.title,
-    summary: rule.summary ?? rule.snippet,
-    type: rule.type,
-    logic: rule.logic,
-    text: rule.text,
-  };
 }
 
 export function createVm0007GapReportAuditId(): string {
@@ -160,53 +137,39 @@ export function buildAndSaveVm0007GapReportAudit(input: {
   if (input.methodology.methodologyId.trim().toUpperCase() !== "VM0007") return failedGeneration(["methodology_id_mismatch"]);
   if (!input.rawPddText.trim() || input.rules.length === 0) return failedGeneration(["malformed_audit_output"]);
 
-  const context = getStructuredQueryContext(input.rawPddText);
-  const parsedDocument = parseExtractedText(
-    input.rawPddText,
-    context.evidenceDocument.docId,
-    context.parsedDocument.adapterId ?? "quick-check-panel",
-  );
-  const methodologyResult = validateAnswerResults(
-    extractAnswersForAllChecks(parsedDocument),
-  ).find((result) => result.checkName === "methodology");
-  const methodology = methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null) ?? input.methodology;
-  const audit = auditEvidence({
-    rules: input.rules.map(mapRule),
-    evidenceDocument: context.evidenceDocument,
-    getContract: getVm0007EvidenceContract,
-    normalizeRuleId: normalizeVm0007RuleId,
-    sections: context.documentStructure.sections,
-    rawText: input.rawPddText,
-    versionContext: {
+  const auditId = createVm0007GapReportAuditId();
+  let built: ReturnType<typeof buildVm0007MachineProposal>;
+  try {
+    built = buildVm0007MachineProposal({
+      auditId,
+      generatedAt: nowIso(),
       methodologyId: input.loadedRulebookId,
-      rulebookVersion: input.loadedRulebookVersion,
-      pddDeclaredMethodologyVersion: methodology.pddDeclaredMethodologyVersion ?? "",
-    },
-    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
-  });
+      methodologyVersion: input.loadedRulebookVersion,
+      evidenceFileName: input.evidenceFileName,
+      sourcePdfSha256: input.sourcePdfSha256,
+      rawPddText: input.rawPddText,
+      rules: input.rules,
+      userAcceptedVersionWarning: input.userAcceptedVersionWarning,
+    });
+  } catch {
+    return failedGeneration(["malformed_audit_output"]);
+  }
 
   const record: Vm0007GapReportAuditRecord = {
-    auditId: createVm0007GapReportAuditId(),
+    auditId,
     methodologyId: input.loadedRulebookId.trim(),
     methodologyVersion: input.loadedRulebookVersion.trim(),
     loadedRulebookId: input.loadedRulebookId.trim(),
     loadedRulebookVersion: input.loadedRulebookVersion.trim(),
-    methodology,
-    generatedAt: nowIso(),
+    methodology: built.methodology ?? input.methodology,
+    generatedAt: built.draft.ok ? built.draft.package.generatedAt : nowIso(),
     evidenceFileName: input.evidenceFileName?.trim() || undefined,
     userAcceptedVersionWarning: input.userAcceptedVersionWarning,
-    audit,
-    sourceDocument: { documentId: context.evidenceDocument.docId, documentName: input.evidenceFileName?.trim() || null, contentSha256: input.sourcePdfSha256?.trim() || null },
+    audit: built.audit,
+    sourceDocument: built.sourceDocument,
   };
   saveVm0007GapReportAudit(record);
   const auditSaved = loadVm0007GapReportAudit(record.auditId) !== null;
   if (!auditSaved) return { ...failedGeneration(["audit_persistence_failed"]), auditId: record.auditId, audit: record };
-  const draft = buildVm0007EvidenceMapDraft({
-    auditId: record.auditId,
-    generatedAt: record.generatedAt,
-    rules: input.rules,
-    audit,
-    sourceDocument: record.sourceDocument,
-  });
-  return completeVm0007EvidenceMapGeneration({ audit: record, auditSaved: true, draft });
+  return completeVm0007EvidenceMapGeneration({ audit: record, auditSaved: true, draft: built.draft });
 }

--- a/src/lib/preverif/vm0007MachineProposal.ts
+++ b/src/lib/preverif/vm0007MachineProposal.ts
@@ -1,0 +1,55 @@
+import type { RuleSummary } from "@/app/m/_lib/methodRules";
+import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
+import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
+import { parseExtractedText } from "@/lib/quickCheckV2/evidence";
+import { validateAnswerResults } from "@/lib/quickCheckV2/status";
+import { buildQuickCheckMethodologyIdentity, type QuickCheckMethodologyIdentity } from "@/lib/quickCheckV2/methodologyIdentity";
+import { auditEvidence, type MethodologyEvidenceAuditRule, type MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
+import { getVm0007EvidenceContract, normalizeVm0007RuleId } from "@/lib/preverif/vm0007EvidenceContracts";
+import { buildVm0007EvidenceMapDraft, type DraftBuildResult } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import type { EvidenceMapSourceDocumentIdentity } from "@/lib/evidence/evidenceMapDependencyContract";
+
+export type Vm0007MachineProposalBuild = {
+  methodology: QuickCheckMethodologyIdentity | null;
+  audit: MethodologyEvidenceAuditSummary;
+  sourceDocument: EvidenceMapSourceDocumentIdentity;
+  draft: DraftBuildResult;
+};
+
+function mapRule(rule: RuleSummary): MethodologyEvidenceAuditRule {
+  return { id: rule.id, title: rule.title, summary: rule.summary ?? rule.snippet, type: rule.type, logic: rule.logic, text: rule.text };
+}
+
+/** Canonical pure VM0007 proposal builder shared by Quick Check and reproducible generation. */
+export function buildVm0007MachineProposal(input: {
+  auditId: string;
+  generatedAt: string;
+  methodologyId: string;
+  methodologyVersion: string;
+  evidenceFileName?: string;
+  sourcePdfSha256?: string | null;
+  rawPddText: string;
+  rules: readonly RuleSummary[];
+  userAcceptedVersionWarning?: boolean;
+}): Vm0007MachineProposalBuild {
+  if (input.methodologyId.trim().toUpperCase() !== "VM0007") throw new Error("methodology_id_mismatch");
+  if (!input.rawPddText.trim() || input.rules.length === 0) throw new Error("malformed_audit_output");
+
+  const context = getStructuredQueryContext(input.rawPddText);
+  const parsedDocument = parseExtractedText(input.rawPddText, context.evidenceDocument.docId, context.parsedDocument.adapterId ?? "quick-check-panel");
+  const methodologyResult = validateAnswerResults(extractAnswersForAllChecks(parsedDocument)).find((result) => result.checkName === "methodology");
+  const methodology = methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null);
+  const audit = auditEvidence({
+    rules: input.rules.map(mapRule), evidenceDocument: context.evidenceDocument, getContract: getVm0007EvidenceContract,
+    normalizeRuleId: normalizeVm0007RuleId, sections: context.documentStructure.sections, rawText: input.rawPddText,
+    versionContext: { methodologyId: input.methodologyId, rulebookVersion: input.methodologyVersion, pddDeclaredMethodologyVersion: methodology?.pddDeclaredMethodologyVersion ?? "" },
+    userAcceptedVersionWarning: input.userAcceptedVersionWarning,
+  });
+  const sourceDocument: EvidenceMapSourceDocumentIdentity = {
+    documentId: context.evidenceDocument.docId,
+    documentName: input.evidenceFileName?.trim() || null,
+    contentSha256: input.sourcePdfSha256?.trim() || null,
+  };
+  const draft = buildVm0007EvidenceMapDraft({ auditId: input.auditId, generatedAt: input.generatedAt, rules: input.rules, audit, sourceDocument });
+  return { methodology, audit, sourceDocument, draft };
+}

--- a/src/lib/preverif/vm0007MachineProposal.ts
+++ b/src/lib/preverif/vm0007MachineProposal.ts
@@ -26,6 +26,7 @@ export function buildVm0007MachineProposal(input: {
   generatedAt: string;
   methodologyId: string;
   methodologyVersion: string;
+  methodology?: QuickCheckMethodologyIdentity | null;
   evidenceFileName?: string;
   sourcePdfSha256?: string | null;
   rawPddText: string;
@@ -38,7 +39,7 @@ export function buildVm0007MachineProposal(input: {
   const context = getStructuredQueryContext(input.rawPddText);
   const parsedDocument = parseExtractedText(input.rawPddText, context.evidenceDocument.docId, context.parsedDocument.adapterId ?? "quick-check-panel");
   const methodologyResult = validateAnswerResults(extractAnswersForAllChecks(parsedDocument)).find((result) => result.checkName === "methodology");
-  const methodology = methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null);
+  const methodology = methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null) ?? input.methodology ?? null;
   const audit = auditEvidence({
     rules: input.rules.map(mapRule), evidenceDocument: context.evidenceDocument, getContract: getVm0007EvidenceContract,
     normalizeRuleId: normalizeVm0007RuleId, sections: context.documentStructure.sections, rawText: input.rawPddText,

--- a/tests/lib/preverif/vm0007MachineProposalParity.test.ts
+++ b/tests/lib/preverif/vm0007MachineProposalParity.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "@jest/globals";
+import { loadMethodRules } from "@/app/m/_lib/methodRules";
+import { buildVm0007MachineProposal } from "@/lib/preverif/vm0007MachineProposal";
+
+describe("VM0007 machine proposal generation parity", () => {
+  it("is deterministic for the same PDF SHA, app version, and generation config", async () => {
+    const appVersion = (JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8")) as { version: string }).version;
+    const rawPddText = [
+      "Maya Forest Corridor REDD Belize",
+      "Methodology: VM0007 v1.8",
+      "Project description and baseline evidence.",
+      "Section 1 Project Description",
+      "The project area is forest land and the project activity is REDD.",
+    ].join("\n");
+    const rulesResult = await loadMethodRules("VM0007", "v1-8");
+    const config = {
+      appVersion,
+      auditId: "parity-fixed-audit",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      evidenceFileName: "maya-forest-corridor-redd-belize.pdf",
+      sourcePdfSha256: "407caaa782e9d9e07b250999539fc809c2c41888b0f20a628a9e49dbeb977a5b",
+      rawPddText,
+      rules: rulesResult.rules,
+    } as const;
+
+    const first = buildVm0007MachineProposal(config);
+    const second = buildVm0007MachineProposal(config);
+
+    expect(first.draft.ok).toBe(true);
+    expect(second.draft.ok).toBe(true);
+    if (!first.draft.ok || !second.draft.ok) return;
+    expect(first.draft.package.rows).toHaveLength(58);
+    expect(second.draft.package.rows).toHaveLength(58);
+    expect(first.draft.package).toEqual(second.draft.package);
+    expect(first.sourceDocument).toEqual(second.sourceDocument);
+    expect(first.audit).toEqual(second.audit);
+  });
+});

--- a/tests/lib/preverif/vm0007MachineProposalParity.test.ts
+++ b/tests/lib/preverif/vm0007MachineProposalParity.test.ts
@@ -39,4 +39,63 @@ describe("VM0007 machine proposal generation parity", () => {
     expect(first.sourceDocument).toEqual(second.sourceDocument);
     expect(first.audit).toEqual(second.audit);
   });
+
+  it("keeps machine evidence and applicability separate from reviewer outcomes", async () => {
+    const rawPddText = "Project description without an independently detected methodology.";
+    const rulesResult = await loadMethodRules("VM0007", "v1-8");
+    const built = buildVm0007MachineProposal({
+      auditId: "truth-boundary-audit",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      methodology: {
+        methodologyId: "VM0007",
+        methodologyName: "VM0007",
+        methodologyAlias: null,
+        pddDeclaredMethodologyVersion: "v1.8",
+        versionStatus: "DECLARED",
+        evidencePage: 1,
+        evidenceSection: "Caller resolution",
+        evidenceQuote: "Caller-resolved VM0007 v1.8",
+      },
+      rawPddText,
+      rules: rulesResult.rules,
+    });
+
+    expect(built.methodology?.methodologyId).toBe("VM0007");
+    expect(built.draft.ok).toBe(true);
+    if (!built.draft.ok) return;
+    expect(built.draft.package.rows).toHaveLength(58);
+    expect(built.draft.package).not.toHaveProperty("outcomeCounts");
+    expect(built.draft.package.rows.every((row) => !Object.prototype.hasOwnProperty.call(row, "reviewerOutcome"))).toBe(true);
+    expect(built.draft.package.rows.every((row) => ["FOUND", "UNCLEAR", "MISSING"].includes(row.proposedEvidenceStatus))).toBe(true);
+    expect(built.draft.package.rows.every((row) => ["APPLICABLE", "NOT_APPLICABLE", "UNKNOWN"].includes(row.proposedApplicability))).toBe(true);
+  });
+
+  it("preserves the Maya canonical evidence-state counts", () => {
+    const rawPddText = fs.readFileSync(
+      path.join(process.cwd(), "tests/fixtures/quick-check/v2/maya-forest-corridor-redd-belize/extracted.txt"),
+      "utf8",
+    );
+    return loadMethodRules("VM0007", "v1-8").then((rulesResult) => {
+      const built = buildVm0007MachineProposal({
+        auditId: "maya-counts-audit",
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        methodologyId: "VM0007",
+        methodologyVersion: "v1-8",
+        rawPddText,
+        rules: rulesResult.rules,
+      });
+      expect(built.draft.ok).toBe(true);
+      if (!built.draft.ok) return;
+      const counts = built.draft.package.rows.reduce<Record<string, number>>((result, row) => {
+        result[row.proposedEvidenceStatus] = (result[row.proposedEvidenceStatus] ?? 0) + 1;
+        return result;
+      }, { FOUND: 0, UNCLEAR: 0, MISSING: 0 });
+      expect(built.draft.package.rows).toHaveLength(58);
+      expect(counts).toEqual({ FOUND: 0, UNCLEAR: 44, MISSING: 14 });
+      expect(built.draft.package).not.toHaveProperty("outcomeCounts");
+      expect(built.draft.package.rows.every((row) => !Object.prototype.hasOwnProperty.call(row, "reviewerOutcome"))).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary\n\nUnify the reproducible VM0007 machine-proposal script with the canonical Quick Check production builder.\n\nThe first divergence was direct baseline rule loading/mapping from  versus production  normalization. The shared path now also preserves the caller-resolved methodology fallback.\n\n## Truth-model invariants\n\n- Machine evidence states remain separate from reviewer truth.\n- No  or inferred  are added to unreviewed machine proposals.\n- FOUND, UNCLEAR, and MISSING are preserved as machine evidence states only.\n\n## Evidence\n\nMaya SHA  produces 58 rows:\n\n- FOUND: 0\n- UNCLEAR: 44\n- MISSING: 14\n\nPR #1071 remains open and unchanged. This PR must not be merged automatically.\n\n## Validation on final rebased head\n\n- \n- \n- \n- 
> app.article6@0.1.0 lint
> node --require ./scripts/node-version-shim.js ./node_modules/next/dist/bin/next lint --max-warnings=0

✔ No ESLint warnings or errors\n- 
> app.article6@0.1.0 typecheck
> tsc --noEmit\n- 
> app.article6@0.1.0 prebuild
> npm run fetch:methodologies-pack && npm run generate:manifest && npm run derive:all && npm run assert:derived && npm run check:golden


> app.article6@0.1.0 fetch:methodologies-pack
> bash scripts/fetch-methodologies-pack.sh

[pack] using existing pinned methodologies in public/methodologies (87eef90379f06df40a917894a159d10a5d4c2703)

> app.article6@0.1.0 generate:manifest
> node scripts/generate-manifest-from-pack.mjs

Generated manifest: 225 entries from 16 methodologies
Providers: GoldStandard, UNFCCC, Verra

> app.article6@0.1.0 derive:all
> npm run build:derived && npm run manifest:derived && npm run verify:derived


> app.article6@0.1.0 build:derived
> node scripts/build-derived-artifacts.mjs


> app.article6@0.1.0 manifest:derived
> node scripts/build-derived-manifest.mjs


> app.article6@0.1.0 verify:derived
> node scripts/verify-derived-artifacts.mjs


> app.article6@0.1.0 assert:derived
> node scripts/assert-derived-present.mjs

✅ Derived manifest present in public/**/derived/manifest.json

> app.article6@0.1.0 check:golden
> bash scripts/check-golden-rich.sh

✅ Golden rich present: public/methodologies/UNFCCC/Forestry/AR-AM0014/v03-0/rules.rich.json

> app.article6@0.1.0 build
> next build

   ▲ Next.js 15.4.10
   - Environments: .env.local

   Creating an optimized production build ...
 ✓ Compiled successfully in 28.0s
   Linting and checking validity of types ...
   Collecting page data ...
[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}
   Generating static pages (0/27) ...
   Generating static pages (6/27) 
   Generating static pages (13/27) 
   Generating static pages (20/27) 
[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}
 ✓ Generating static pages (27/27)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                             Size  First Load JS
┌ ○ /                                                47.3 kB         423 kB
├ ○ /_not-found                                        994 B         101 kB
├ ƒ /api/chat                                          209 B         100 kB
├ ƒ /api/exports/audit-pack                            209 B         100 kB
├ ƒ /api/exports/client-readiness-report               209 B         100 kB
├ ƒ /api/exports/internal/envira-vm0007-report         209 B         100 kB
├ ƒ /api/exports/vvb-workpaper                         209 B         100 kB
├ ƒ /api/health                                        209 B         100 kB
├ ƒ /api/manifest                                      209 B         100 kB
├ ƒ /api/manifest/health                               209 B         100 kB
├ ƒ /api/manifest/rule/[sha]                           209 B         100 kB
├ ƒ /api/methods/[code]/v/[ver]/rich                   209 B         100 kB
├ ƒ /api/methods/[code]/v/[ver]/rules                  209 B         100 kB
├ ƒ /api/methods/[code]/v/[ver]/sections               209 B         100 kB
├ ƒ /api/methods/[code]/v/[ver]/trace                  209 B         100 kB
├ ƒ /api/methods/inventory                             209 B         100 kB
├ ƒ /api/projects/[id]/export-pdf                      209 B         100 kB
├ ƒ /api/projects/[id]/export-premium                  209 B         100 kB
├ ƒ /api/projects/extract-evidence                     209 B         100 kB
├ ƒ /api/projects/manual-review/extract-findings       209 B         100 kB
├ ƒ /api/projects/method-rules                         209 B         100 kB
├ ƒ /api/projects/methods                              209 B         100 kB
├ ƒ /api/projects/reconcile-evidence                   209 B         100 kB
├ ƒ /api/projects/record-decision                      209 B         100 kB
├ ƒ /api/query                                         209 B         100 kB
├ ƒ /api/quick-check/llm-extract                       209 B         100 kB
├ ƒ /api/quick-check/pdf-extract                       209 B         100 kB
├ ƒ /api/quick-check/presigned-upload                  209 B         100 kB
├ ƒ /api/quick-check/semantic-evidence                 209 B         100 kB
├ ƒ /api/quick-check/upload                            209 B         100 kB
├ ƒ /api/stac/search                                   209 B         100 kB
├ ○ /audit                                           5.11 kB         105 kB
├ ○ /dashboard                                       3.76 kB         104 kB
├ ○ /internal/reports/envira-vm0007                    209 B         100 kB
├ ƒ /internal/reports/pre-validation-readiness       2.14 kB         108 kB
├ ƒ /internal/reports/vm0007-evidence-map/[auditId]  17.2 kB         144 kB
├ ƒ /internal/reports/vm0007-gap/[auditId]           8.52 kB         208 kB
├ ○ /m                                               2.75 kB         408 kB
├ ƒ /m/[code]                                        2.75 kB         408 kB
├ ƒ /m/[code]/v/[ver]                                2.75 kB         408 kB
├ ƒ /m/[code]/v/[ver]/evidence                         651 B         406 kB
├ ○ /manifest                                        3.24 kB         106 kB
├ ƒ /pdf/[id]                                          209 B         100 kB
├ ○ /projects                                        1.61 kB         247 kB
├ ƒ /projects/[id]                                   16.3 kB         262 kB
├ ƒ /projects/[id]/pre-validation-readiness          2.49 kB         108 kB
├ ○ /projects/new                                    2.62 kB         245 kB
└ ƒ /quick-check/pre-validation-readiness            2.67 kB         108 kB
+ First Load JS shared by all                        99.8 kB
  ├ chunks/4bd1b696-602635ee57868870.js              54.1 kB
  ├ chunks/5964-3827e5675982a839.js                  43.6 kB
  └ other shared chunks (total)                      2.03 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand\n- 
> app.article6@0.1.0 pr:check:local
> npm run guard:methodology-boundary && npm run lint && npm run typecheck && npm run check:docs-layout && npm run roadmap:validate-evidence && npm run preverif:guard:truth-review && git diff --check


> app.article6@0.1.0 guard:methodology-boundary
> node scripts/guard-methodology-boundary.mjs

[methodology-boundary] ok base=origin/main branch=agent/fix-maya-generation-parity changed=4

> app.article6@0.1.0 lint
> node --require ./scripts/node-version-shim.js ./node_modules/next/dist/bin/next lint --max-warnings=0

✔ No ESLint warnings or errors

> app.article6@0.1.0 typecheck
> tsc --noEmit


> app.article6@0.1.0 check:docs-layout
> node scripts/check-docs-layout.mjs

docs layout OK

> app.article6@0.1.0 roadmap:validate-evidence
> node scripts/roadmap/validate-pr-evidence.mjs

[roadmap] pr evidence OK

> app.article6@0.1.0 preverif:guard:truth-review
> node scripts/preverif/check-truth-review-guard.mjs

[preverif-truth-guard] ok base=origin/main changed=4 (no truth-review validation required)\n\nAll passed. 
> app.article6@0.1.0 pr:gate
> node scripts/pr-gate.mjs


=== build ===
$ npm run build

> app.article6@0.1.0 prebuild
> npm run fetch:methodologies-pack && npm run generate:manifest && npm run derive:all && npm run assert:derived && npm run check:golden


> app.article6@0.1.0 fetch:methodologies-pack
> bash scripts/fetch-methodologies-pack.sh

[pack] using existing pinned methodologies in public/methodologies (87eef90379f06df40a917894a159d10a5d4c2703)

> app.article6@0.1.0 generate:manifest
> node scripts/generate-manifest-from-pack.mjs

Generated manifest: 225 entries from 16 methodologies
Providers: GoldStandard, UNFCCC, Verra

> app.article6@0.1.0 derive:all
> npm run build:derived && npm run manifest:derived && npm run verify:derived


> app.article6@0.1.0 build:derived
> node scripts/build-derived-artifacts.mjs


> app.article6@0.1.0 manifest:derived
> node scripts/build-derived-manifest.mjs


> app.article6@0.1.0 verify:derived
> node scripts/verify-derived-artifacts.mjs


> app.article6@0.1.0 assert:derived
> node scripts/assert-derived-present.mjs

✅ Derived manifest present in public/**/derived/manifest.json

> app.article6@0.1.0 check:golden
> bash scripts/check-golden-rich.sh

✅ Golden rich present: public/methodologies/UNFCCC/Forestry/AR-AM0014/v03-0/rules.rich.json

> app.article6@0.1.0 build
> next build

   ▲ Next.js 15.4.10
   - Environments: .env.local

   Creating an optimized production build ...
 ✓ Compiled successfully in 26.0s
   Linting and checking validity of types ...
   Collecting page data ...
[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}
   Generating static pages (0/27) ...
   Generating static pages (6/27) 
   Generating static pages (13/27) 
   Generating static pages (20/27) 
[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}
 ✓ Generating static pages (27/27)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                             Size  First Load JS
┌ ○ /                                                47.3 kB         423 kB
├ ○ /_not-found                                        994 B         101 kB
├ ƒ /api/chat                                          209 B         100 kB
├ ƒ /api/exports/audit-pack                            209 B         100 kB
├ ƒ /api/exports/client-readiness-report               209 B         100 kB
├ ƒ /api/exports/internal/envira-vm0007-report         209 B         100 kB
├ ƒ /api/exports/vvb-workpaper                         209 B         100 kB
├ ƒ /api/health                                        209 B         100 kB
├ ƒ /api/manifest                                      209 B         100 kB
├ ƒ /api/manifest/health                               209 B         100 kB
├ ƒ /api/manifest/rule/[sha]                           209 B         100 kB
├ ƒ /api/methods/[code]/v/[ver]/rich                   209 B         100 kB
├ ƒ /api/methods/[code]/v/[ver]/rules                  209 B         100 kB
├ ƒ /api/methods/[code]/v/[ver]/sections               209 B         100 kB
├ ƒ /api/methods/[code]/v/[ver]/trace                  209 B         100 kB
├ ƒ /api/methods/inventory                             209 B         100 kB
├ ƒ /api/projects/[id]/export-pdf                      209 B         100 kB
├ ƒ /api/projects/[id]/export-premium                  209 B         100 kB
├ ƒ /api/projects/extract-evidence                     209 B         100 kB
├ ƒ /api/projects/manual-review/extract-findings       209 B         100 kB
├ ƒ /api/projects/method-rules                         209 B         100 kB
├ ƒ /api/projects/methods                              209 B         100 kB
├ ƒ /api/projects/reconcile-evidence                   209 B         100 kB
├ ƒ /api/projects/record-decision                      209 B         100 kB
├ ƒ /api/query                                         209 B         100 kB
├ ƒ /api/quick-check/llm-extract                       209 B         100 kB
├ ƒ /api/quick-check/pdf-extract                       209 B         100 kB
├ ƒ /api/quick-check/presigned-upload                  209 B         100 kB
├ ƒ /api/quick-check/semantic-evidence                 209 B         100 kB
├ ƒ /api/quick-check/upload                            209 B         100 kB
├ ƒ /api/stac/search                                   209 B         100 kB
├ ○ /audit                                           5.11 kB         105 kB
├ ○ /dashboard                                       3.76 kB         104 kB
├ ○ /internal/reports/envira-vm0007                    209 B         100 kB
├ ƒ /internal/reports/pre-validation-readiness       2.14 kB         108 kB
├ ƒ /internal/reports/vm0007-evidence-map/[auditId]  17.2 kB         144 kB
├ ƒ /internal/reports/vm0007-gap/[auditId]           8.52 kB         208 kB
├ ○ /m                                               2.75 kB         408 kB
├ ƒ /m/[code]                                        2.75 kB         408 kB
├ ƒ /m/[code]/v/[ver]                                2.75 kB         408 kB
├ ƒ /m/[code]/v/[ver]/evidence                         651 B         406 kB
├ ○ /manifest                                        3.24 kB         106 kB
├ ƒ /pdf/[id]                                          209 B         100 kB
├ ○ /projects                                        1.61 kB         247 kB
├ ƒ /projects/[id]                                   16.3 kB         262 kB
├ ƒ /projects/[id]/pre-validation-readiness          2.49 kB         108 kB
├ ○ /projects/new                                    2.62 kB         245 kB
└ ƒ /quick-check/pre-validation-readiness            2.67 kB         108 kB
+ First Load JS shared by all                        99.8 kB
  ├ chunks/4bd1b696-602635ee57868870.js              54.1 kB
  ├ chunks/5964-3827e5675982a839.js                  43.6 kB
  └ other shared chunks (total)                      2.03 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand


=== test ===
$ npm run test

> app.article6@0.1.0 test
> jest --passWithNoTests


=== lint ===
$ npm run lint

> app.article6@0.1.0 lint
> node --require ./scripts/node-version-shim.js ./node_modules/next/dist/bin/next lint --max-warnings=0

✔ No ESLint warnings or errors

=== quickcheck:eval:corpus -- --strict ===
$ npm run quickcheck:eval:corpus -- --strict

> app.article6@0.1.0 quickcheck:eval:corpus
> npx tsx scripts/run-quickcheck-eval-corpus.ts --strict

Quick Check Eval Corpus: phase6-foundation
Fixtures: 14

Metrics
- Fact extraction accuracy: 100.0% (154/154)
- Provenance correctness: 100.0% (112/112)
- Section retrieval precision: 100.0% (25/25)
- Section retrieval recall: 100.0% (25/25)
- Unsupported rejection rate: 100.0% (14/14)
- No-evidence false negative rate: 0.0% (0/26)
- Hallucinated answer rate: 0.0% (0/59)
- First-pass success rate: 100.0% (14/14)
- Visible answer gold match: 100.0% (112/112)
- Visible answer / Technical agreement: 100.0% (112/112)
- Regression count: 0

Fixtures
- real-cdm-nepal: PASS
- real-envira-amazonia: PASS
- real-pd-redd-v130: PASS
- real-pd-redd-v130-full: PASS
- real-gs-luf: PASS
- real-plum-pdd: PASS
- real-plum-weak-ocr: PASS
- real-blue-nile-redd: PASS
- regression-toc-only-pdd: PASS
- regression-boilerplate-metadata: PASS
- regression-methodology-preamble: PASS
- regression-baseline-calculation: PASS
- regression-generic-leakage: PASS
- regression-strong-real-evidence: PASS

All strict eval corpus thresholds passed.

=== quickcheck:guard:no-fixture-hardcoding ===
$ npm run quickcheck:guard:no-fixture-hardcoding

> app.article6@0.1.0 quickcheck:guard:no-fixture-hardcoding
> node scripts/quickcheck/check-no-fixture-hardcoding.mjs

[no-fixture-hardcoding] ok base=origin/main changed=0

=== preverif:guard:truth-review ===
$ npm run preverif:guard:truth-review

> app.article6@0.1.0 preverif:guard:truth-review
> node scripts/preverif/check-truth-review-guard.mjs

[preverif-truth-guard] ok base=origin/main changed=4 (no truth-review validation required)

=== start server ===
$ npm run start -- -p 3000

=== health check ===
$ GET http://localhost:3000/api/health

> app.article6@0.1.0 start
> next start -p 3000

   ▲ Next.js 15.4.10
   - Local:        http://localhost:3000
   - Network:      http://192.168.1.2:3000

 ✓ Starting...
 ✓ Ready in 1663ms
[metrics] route=api/health:GET count=1 p95=3.58ms latest=3.58ms status=200

=== test:audit-pack:smoke ===
$ BASE_URL=http://localhost:3000 npm run test:audit-pack:smoke

> app.article6@0.1.0 test:audit-pack:smoke
> node scripts/test-audit-pack-smoke.mjs

Starting server on http://localhost:3011 ...

> app.article6@0.1.0 start
> next start -p 3011

[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}
   ▲ Next.js 15.4.10
   - Local:        http://localhost:3011
   - Network:      http://192.168.1.2:3011

 ✓ Starting...
[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}
 ✓ Ready in 3s
[metrics] route=api/health:GET count=1 p95=31.83ms latest=31.83ms status=200
Fetching audit-pack from http://localhost:3011/api/exports/audit-pack?method=AR-ACM0003&version=v02-0
[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}
[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}
✅ Downloaded audit-pack sha256=05ed603dd1dea256eb946b97a56480b2a1a5390724705e52d2f688d77783af31
Verifying zip...

> app.article6@0.1.0 verify:audit-pack
> node scripts/verify-audit-pack.mjs /tmp/audit-pack-smoke/run1.zip

✅ PASS ok=12 fail=0 (strict inventory + sha256)
Tampering with a JSON file...
tampered: /tmp/audit-pack-smoke/tamper/data/method/AR-ACM0003/v02-0/META.json
Verifying tampered zip (should fail)...

> app.article6@0.1.0 verify:audit-pack
> node scripts/verify-audit-pack.mjs /tmp/audit-pack-smoke/tampered.zip

✅ PASS: verification + tamper fail

=== test:audit-pack:trail-smoke ===
$ BASE_URL=http://localhost:3000 npm run test:audit-pack:trail-smoke

> app.article6@0.1.0 test:audit-pack:trail-smoke
> node scripts/test-audit-pack-trail-smoke.mjs

Starting server on http://localhost:3012 ...

> app.article6@0.1.0 start
> next start -p 3012

   ▲ Next.js 15.4.10
   - Local:        http://localhost:3012
   - Network:      http://192.168.1.2:3012

 ✓ Starting...
 ✓ Ready in 2.2s
[metrics] route=api/health:GET count=1 p95=4.8ms latest=4.8ms status=200
Fetching audit-pack from http://localhost:3012/api/exports/audit-pack?method=AR-ACM0003&version=v02-0
✅ Downloaded audit-pack sha256=05ed603dd1dea256eb946b97a56480b2a1a5390724705e52d2f688d77783af31
Verifying zip...

> app.article6@0.1.0 verify:audit-pack
> node scripts/verify-audit-pack.mjs /tmp/audit-pack-trail-smoke/run1.zip

✅ PASS ok=12 fail=0 (strict inventory + sha256)
Tampering with trail.jsonl...
Verifying tampered zip (should fail)...
[pymupdf:vercel] PyMuPDF parser adapter is ready. {
  pythonPath: '/Users/stphen/app.article6/.venv/bin/python3',
  pymupdfVersion: "('1.27.2.3', '1.27.2', None)",
  pythonPackagesPath: undefined
}

> app.article6@0.1.0 verify:audit-pack
> node scripts/verify-audit-pack.mjs /tmp/audit-pack-trail-smoke/tampered.zip

Removing trail.jsonl...
Verifying missing-trail zip (should fail)...

> app.article6@0.1.0 verify:audit-pack
> node scripts/verify-audit-pack.mjs /tmp/audit-pack-trail-smoke/missing-trail.zip

✅ PASS: trail verification + tamper fail was not run locally.