### PR TITLE
test: add RC5 retrospective mutation coverage

### DIFF
--- a/scripts/preverif/audit-rc5-maya-retrospective.ts
+++ b/scripts/preverif/audit-rc5-maya-retrospective.ts
@@ -116,8 +116,7 @@ export function validateAuditDecisionInvariants(
   const resolvedClientActionResult = (resolvedNotApplicable || resolvedConforms) && (decision.clientAction ?? "") !== "" ? "FAIL" : "PASS";
   if (resolvedClientActionResult === "FAIL") failures.push({ code: "RESOLVED_ROW_CLIENT_ACTION", stableRuleId: decision.stableRuleId });
   const staleAcceptanceClaim = /\b(?:should|ought to|needs? to)\b[^.\n]{0,80}\baccepted\b/i.test(decision.correctionReason ?? "")
-    || /\bshould have been accepted\b/i.test(decision.correctionReason ?? "")
-    || /\b(?:remains?|still)\b[^.\n]{0,80}\brejected span\b/i.test(decision.correctionReason ?? "");
+    || /\bshould have been accepted\b/i.test(decision.correctionReason ?? "");
   const correctionReasonResult = staleAcceptanceClaim
     && (decision.acceptedEvidence?.length ?? 0) > 0
     && (decision.rejectedEvidence?.length ?? 0) === 0 ? "FAIL" : "PASS";
@@ -245,7 +244,6 @@ function buildAudit() {
         correctionReasonResult: invariantResult.correctionReasonResult,
         resolvedJudgmentEvidenceResult: invariantResult.resolvedJudgmentEvidenceResult,
         semanticIntegrityResult: invariantResult.semanticIntegrityResult,
-        invariantFailures: invariantResult.failures,
         machineRowHashResult: machineRowHashResult ? "PASS" : "FAIL",
         schemaResult: schemaValid ? "PASS" : "FAIL",
       };

--- a/scripts/preverif/audit-rc5-maya-retrospective.ts
+++ b/scripts/preverif/audit-rc5-maya-retrospective.ts
@@ -43,6 +43,103 @@ const evidenceKey = (evidence: JsonRecord): string => JSON.stringify({
   documentSha256: evidence.documentSha256,
 });
 
+export type AuditInvariantFailureCode =
+  | "UNMATCHED_FROZEN_EVIDENCE"
+  | "DUPLICATE_EVIDENCE"
+  | "UNSUPPORTED_NOT_APPLICABLE"
+  | "RESOLVED_ROW_CLIENT_ACTION"
+  | "STALE_CORRECTION_REASON"
+  | "RESOLVED_JUDGMENT_WITHOUT_EVIDENCE";
+
+export type AuditInvariantFailure = {
+  code: AuditInvariantFailureCode;
+  stableRuleId: string;
+  field?: "acceptedEvidence" | "rejectedEvidence";
+  index?: number;
+  evidence?: JsonRecord;
+};
+
+export type AuditInvariantResult = {
+  provenanceResult: "PASS" | "FAIL";
+  unmatchedEvidence: JsonRecord[];
+  acceptedRejectedDuplicateEvidence: string[];
+  notApplicableEvidenceResult: "PASS" | "FAIL";
+  resolvedClientActionResult: "PASS" | "FAIL";
+  correctionReasonResult: "PASS" | "FAIL";
+  resolvedJudgmentEvidenceResult: "PASS" | "FAIL";
+  semanticIntegrityResult: "PASS" | "FAIL";
+  evidenceEntries: JsonRecord[];
+  ambiguousContextMatches: JsonRecord[];
+  failures: AuditInvariantFailure[];
+};
+
+export function validateAuditDecisionInvariants(
+  decision: JsonRecord,
+  contexts: JsonRecord[],
+): AuditInvariantResult {
+  const contextPool = new Map<string, JsonRecord[]>();
+  for (const context of contexts) {
+    const key = evidenceKey(evidenceFromContext(context));
+    contextPool.set(key, [...(contextPool.get(key) ?? []), context]);
+  }
+
+  const evidenceEntries: JsonRecord[] = [];
+  const unmatchedEvidence: JsonRecord[] = [];
+  const ambiguousContextMatches: JsonRecord[] = [];
+  const failures: AuditInvariantFailure[] = [];
+  for (const field of ["acceptedEvidence", "rejectedEvidence"] as const) {
+    for (const [index, evidence] of (decision[field] ?? []).entries()) {
+      const candidates = contextPool.get(evidenceKey(evidence)) ?? [];
+      const identicalFrozenContent = candidates.every((context) => evidenceKey(evidenceFromContext(context)) === evidenceKey(evidence));
+      evidenceEntries.push({ field, index, result: candidates.length > 0 ? "MATCH" : "UNMATCHED", candidateContextIds: candidates.map((context) => context.contextId) });
+      if (candidates.length === 0) {
+        unmatchedEvidence.push({ field, index, evidence });
+        failures.push({ code: "UNMATCHED_FROZEN_EVIDENCE", stableRuleId: decision.stableRuleId, field, index, evidence });
+      }
+      if (candidates.length > 1) {
+        ambiguousContextMatches.push({ field, index, candidateContextIds: candidates.map((context) => context.contextId), completeFrozenEvidenceIdentical: identicalFrozenContent, resolved: identicalFrozenContent ? "identical-content" : "UNRESOLVED" });
+      }
+    }
+  }
+
+  const acceptedKeys = new Set((decision.acceptedEvidence ?? []).map((evidence: JsonRecord) => evidenceKey(evidence)));
+  const rejectedKeys = new Set((decision.rejectedEvidence ?? []).map((evidence: JsonRecord) => evidenceKey(evidence)));
+  const acceptedRejectedDuplicateEvidence = [...acceptedKeys].filter((key) => rejectedKeys.has(key));
+  if (acceptedRejectedDuplicateEvidence.length > 0) {
+    failures.push({ code: "DUPLICATE_EVIDENCE", stableRuleId: decision.stableRuleId });
+  }
+
+  const notApplicableEvidenceResult = decision.finalApplicability === "NOT_APPLICABLE" && (decision.acceptedEvidence?.length ?? 0) === 0 ? "FAIL" : "PASS";
+  if (notApplicableEvidenceResult === "FAIL") failures.push({ code: "UNSUPPORTED_NOT_APPLICABLE", stableRuleId: decision.stableRuleId });
+  const resolvedNotApplicable = decision.finalApplicability === "NOT_APPLICABLE" && decision.reviewerOutcome === "NOT_APPLICABLE";
+  const resolvedConforms = decision.finalEvidenceState === "FOUND" && decision.reviewerOutcome === "CONFORMS";
+  const resolvedClientActionResult = (resolvedNotApplicable || resolvedConforms) && (decision.clientAction ?? "") !== "" ? "FAIL" : "PASS";
+  if (resolvedClientActionResult === "FAIL") failures.push({ code: "RESOLVED_ROW_CLIENT_ACTION", stableRuleId: decision.stableRuleId });
+  const staleAcceptanceClaim = /\b(?:should|ought to|needs? to)\b[^.\n]{0,80}\baccepted\b/i.test(decision.correctionReason ?? "")
+    || /\bshould have been accepted\b/i.test(decision.correctionReason ?? "")
+    || /\b(?:remains?|still)\b[^.\n]{0,80}\brejected span\b/i.test(decision.correctionReason ?? "");
+  const correctionReasonResult = staleAcceptanceClaim
+    && (decision.acceptedEvidence?.length ?? 0) > 0
+    && (decision.rejectedEvidence?.length ?? 0) === 0 ? "FAIL" : "PASS";
+  if (correctionReasonResult === "FAIL") failures.push({ code: "STALE_CORRECTION_REASON", stableRuleId: decision.stableRuleId });
+  const resolvedJudgmentEvidenceResult = ((decision.finalEvidenceState === "FOUND" || decision.reviewerOutcome === "CONFORMS" || resolvedNotApplicable)
+    && (decision.acceptedEvidence?.length ?? 0) === 0) ? "FAIL" : "PASS";
+  if (resolvedJudgmentEvidenceResult === "FAIL") failures.push({ code: "RESOLVED_JUDGMENT_WITHOUT_EVIDENCE", stableRuleId: decision.stableRuleId });
+  return {
+    provenanceResult: unmatchedEvidence.length === 0 ? "PASS" : "FAIL",
+    unmatchedEvidence,
+    acceptedRejectedDuplicateEvidence,
+    notApplicableEvidenceResult,
+    resolvedClientActionResult,
+    correctionReasonResult,
+    resolvedJudgmentEvidenceResult,
+    semanticIntegrityResult: acceptedRejectedDuplicateEvidence.length === 0 && notApplicableEvidenceResult === "PASS" && resolvedClientActionResult === "PASS" && correctionReasonResult === "PASS" && resolvedJudgmentEvidenceResult === "PASS" ? "PASS" : "FAIL",
+    evidenceEntries,
+    ambiguousContextMatches,
+    failures,
+  };
+}
+
 function machineRowHash(rule: JsonRecord): string | undefined {
   return rule.frozenMachineRowHash ?? rule.machineProposal?.rowSha256;
 }
@@ -132,40 +229,23 @@ function buildAudit() {
       }
       const machineRowHashResult = Boolean(rule && decision.machineRowSha256 === machineHash);
       batchHashResults.machineRows = batchHashResults.machineRows && machineRowHashResult;
-      const provenanceResult = unmatchedEvidence.length === 0 ? "PASS" : "FAIL";
-      const acceptedKeys = new Set((decision.acceptedEvidence ?? []).map((evidence: JsonRecord) => evidenceKey(evidence)));
-      const rejectedKeys = new Set((decision.rejectedEvidence ?? []).map((evidence: JsonRecord) => evidenceKey(evidence)));
-      const acceptedRejectedDuplicateEvidence = [...acceptedKeys].filter((key) => rejectedKeys.has(key));
-      const notApplicableEvidenceResult = decision.finalApplicability === "NOT_APPLICABLE" && (decision.acceptedEvidence?.length ?? 0) === 0 ? "FAIL" : "PASS";
-      const resolvedNotApplicable = decision.finalApplicability === "NOT_APPLICABLE" && decision.reviewerOutcome === "NOT_APPLICABLE";
-      const resolvedConforms = decision.finalEvidenceState === "FOUND" && decision.reviewerOutcome === "CONFORMS";
-      const resolvedClientActionResult = (resolvedNotApplicable || resolvedConforms) && (decision.clientAction ?? "") !== "" ? "FAIL" : "PASS";
-      const staleAcceptanceClaim = /\b(?:should|ought to|needs? to)\b[^.\n]{0,80}\baccepted\b/i.test(decision.correctionReason ?? "")
-        || /\bshould have been accepted\b/i.test(decision.correctionReason ?? "");
-      const correctionReasonResult = staleAcceptanceClaim
-        && (decision.acceptedEvidence?.length ?? 0) > 0
-        && (decision.rejectedEvidence?.length ?? 0) === 0 ? "FAIL" : "PASS";
-      const resolvedJudgmentEvidenceResult = ((decision.finalEvidenceState === "FOUND" || decision.reviewerOutcome === "CONFORMS" || resolvedNotApplicable)
-        && (decision.acceptedEvidence?.length ?? 0) === 0) ? "FAIL" : "PASS";
+      const invariantResult = validateAuditDecisionInvariants(decision, allContexts);
       const result = {
         batch: config.batch,
         stableRuleId: decision.stableRuleId,
         acceptedEvidenceCount: decision.acceptedEvidence?.length ?? 0,
         rejectedEvidenceCount: decision.rejectedEvidence?.length ?? 0,
-        provenanceResult,
+        provenanceResult: invariantResult.provenanceResult,
         evidenceEntries,
         unmatchedEvidence,
         ambiguousContextMatches,
-        acceptedRejectedDuplicateEvidence,
-        notApplicableEvidenceResult,
-        resolvedClientActionResult,
-        correctionReasonResult,
-        resolvedJudgmentEvidenceResult,
-        semanticIntegrityResult: acceptedRejectedDuplicateEvidence.length === 0
-          && notApplicableEvidenceResult === "PASS"
-          && resolvedClientActionResult === "PASS"
-          && correctionReasonResult === "PASS"
-          && resolvedJudgmentEvidenceResult === "PASS" ? "PASS" : "FAIL",
+        acceptedRejectedDuplicateEvidence: invariantResult.acceptedRejectedDuplicateEvidence,
+        notApplicableEvidenceResult: invariantResult.notApplicableEvidenceResult,
+        resolvedClientActionResult: invariantResult.resolvedClientActionResult,
+        correctionReasonResult: invariantResult.correctionReasonResult,
+        resolvedJudgmentEvidenceResult: invariantResult.resolvedJudgmentEvidenceResult,
+        semanticIntegrityResult: invariantResult.semanticIntegrityResult,
+        invariantFailures: invariantResult.failures,
         machineRowHashResult: machineRowHashResult ? "PASS" : "FAIL",
         schemaResult: schemaValid ? "PASS" : "FAIL",
       };
@@ -245,4 +325,4 @@ function buildAudit() {
   if (!report.mechanicalResult) process.exitCode = 1;
 }
 
-buildAudit();
+if (require.main === module) buildAudit();

--- a/tests/fixtures/preverif/rc5RetrospectiveMutation.test.ts
+++ b/tests/fixtures/preverif/rc5RetrospectiveMutation.test.ts
@@ -111,8 +111,10 @@ describe("RC5 retrospective audit mutation coverage", () => {
 
   it("rejects a stale correction reason after evidence is accepted", () => {
     const fixture = validFixture();
-    fixture.decision.correctionReason = "The evidence remains in a rejected span.";
+    fixture.decision.correctionReason = "This evidence should be accepted.";
 
+    expect(fixture.decision.acceptedEvidence).toHaveLength(1);
+    expect(fixture.decision.rejectedEvidence).toHaveLength(0);
     expect(failureCodes(fixture)).toEqual(["STALE_CORRECTION_REASON"]);
   });
 });

--- a/tests/fixtures/preverif/rc5RetrospectiveMutation.test.ts
+++ b/tests/fixtures/preverif/rc5RetrospectiveMutation.test.ts
@@ -1,0 +1,118 @@
+import {
+  validateAuditDecisionInvariants,
+  type AuditInvariantFailureCode,
+} from "../../../scripts/preverif/audit-rc5-maya-retrospective";
+
+type Fixture = {
+  decision: Record<string, any>;
+  contexts: Record<string, any>[];
+};
+
+const evidence = {
+  quote: "The project applies the methodology requirements.",
+  page: 84,
+  sectionHeading: "Methodology requirements",
+  spanId: "ctx-001",
+  documentId: "maya-pdd.pdf",
+  documentSha256: "document-sha256",
+};
+
+const context = {
+  contextId: "ctx-001",
+  exactQuote: evidence.quote,
+  pageNumber: evidence.page,
+  sectionHeading: evidence.sectionHeading,
+  sourceSpanId: evidence.spanId,
+  documentIdentity: {
+    documentId: evidence.documentId,
+    contentSha256: evidence.documentSha256,
+  },
+};
+
+function validFixture(): Fixture {
+  return {
+    decision: {
+      stableRuleId: "rule-001",
+      acceptedEvidence: [{ ...evidence }],
+      rejectedEvidence: [],
+      finalApplicability: "APPLICABLE",
+      finalEvidenceState: "FOUND",
+      reviewerOutcome: "CONFORMS",
+      clientAction: "",
+      correctionReason: "The accepted evidence supports the reviewed decision.",
+    },
+    contexts: [{ ...context, documentIdentity: { ...context.documentIdentity } }],
+  };
+}
+
+function failureCodes(fixture: Fixture): AuditInvariantFailureCode[] {
+  return validateAuditDecisionInvariants(fixture.decision, fixture.contexts).failures.map((failure) => failure.code);
+}
+
+describe("RC5 retrospective audit mutation coverage", () => {
+  it("passes a valid reviewed decision through all six invariant checks", () => {
+    const result = validateAuditDecisionInvariants(validFixture().decision, validFixture().contexts);
+
+    expect(result.provenanceResult).toBe("PASS");
+    expect(result.semanticIntegrityResult).toBe("PASS");
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("reports unmatched frozen evidence with the affected rule and evidence location", () => {
+    const fixture = validFixture();
+    fixture.decision.acceptedEvidence[0].page = 85;
+
+    const result = validateAuditDecisionInvariants(fixture.decision, fixture.contexts);
+
+    expect(result.failures).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: "UNMATCHED_FROZEN_EVIDENCE",
+        stableRuleId: "rule-001",
+        field: "acceptedEvidence",
+        index: 0,
+        evidence: expect.objectContaining({ page: 85 }),
+      }),
+    ]));
+    expect(result.provenanceResult).toBe("FAIL");
+  });
+
+  it("rejects accepted/rejected duplicate evidence", () => {
+    const fixture = validFixture();
+    fixture.decision.rejectedEvidence = [{ ...fixture.decision.acceptedEvidence[0] }];
+
+    expect(failureCodes(fixture)).toEqual(["DUPLICATE_EVIDENCE"]);
+  });
+
+  it("rejects unsupported NOT_APPLICABLE decisions", () => {
+    const fixture = validFixture();
+    fixture.decision.acceptedEvidence = [];
+    fixture.decision.finalApplicability = "NOT_APPLICABLE";
+    fixture.decision.finalEvidenceState = "MISSING";
+    fixture.decision.reviewerOutcome = "NEEDS_REVIEW";
+
+    expect(failureCodes(fixture)).toEqual(["UNSUPPORTED_NOT_APPLICABLE"]);
+  });
+
+  it("rejects a resolved N/A row with a client action", () => {
+    const fixture = validFixture();
+    fixture.decision.finalApplicability = "NOT_APPLICABLE";
+    fixture.decision.reviewerOutcome = "NOT_APPLICABLE";
+    fixture.decision.clientAction = "Explain the exclusion to the client.";
+
+    expect(failureCodes(fixture)).toEqual(["RESOLVED_ROW_CLIENT_ACTION"]);
+  });
+
+  it("rejects FOUND/CONFORMS with a client action", () => {
+    const fixture = validFixture();
+    fixture.decision.clientAction = "Request a follow-up explanation.";
+
+    expect(failureCodes(fixture)).toEqual(["RESOLVED_ROW_CLIENT_ACTION"]);
+  });
+
+  it("rejects a stale correction reason after evidence is accepted", () => {
+    const fixture = validFixture();
+    fixture.decision.correctionReason = "The evidence remains in a rejected span.";
+
+    expect(failureCodes(fixture)).toEqual(["STALE_CORRECTION_REASON"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract the RC5 retrospective per-decision invariant validation into reusable production logic.
- Add isolated in-memory mutation tests for all six protected data-integrity invariants plus a valid positive control.
- Keep the existing CLI behavior and repository truth/artifact boundaries unchanged.

## Mutation coverage

- unmatched frozen evidence, including rule and evidence location
- accepted/rejected duplicate evidence
- unsupported NOT_APPLICABLE
- resolved NOT_APPLICABLE with client action
- FOUND/CONFORMS with client action
- stale correction reason after acceptance

## Validation

- New mutation suite: 7 passed
- Existing focused RC5 suites: 9 suites, 47 passed
- npm run typecheck
- npm run lint
- git diff --check

No Batch 6 was created or modified.