### PR TITLE
Document regression-test strength invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,18 @@ This repository is app.article6.
 * Do not weaken tests to make a PR pass.
 * If the task is fixture-only, do not change production logic.
 
+### Regression-test strength invariant
+
+When updating tests after an authorized truth integration:
+
+* Historical artifact tests must remain pinned to their historical inputs.
+* Later-authorized row changes must be compared against the exact newer authorized truth.
+* Never replace full-row equality with status-only checks.
+* Never skip provenance, SHA, mutation, or deterministic-regeneration checks for changed rows.
+* Never compare a committed artifact to itself.
+* Any removed protection must be replaced by an equally strong or stronger assertion and documented in the PR.
+* Test-only changes that weaken coverage are blockers even when all CI checks pass.
+
 ## Quick Check PDF triage / Phase 7 fixture workflow
 
 For new Quick Check PDF triage or Phase 7 fixture tasks, first read and follow:


### PR DESCRIPTION
## Summary

Adds an explicit repository invariant preventing test-only fixes from weakening historical truth, provenance, SHA, mutation, or deterministic-regeneration protections.

## Scope

- `AGENTS.md` only
- no production code
- no truth, fixture, packet, response, manifest, generator, SHA, or audit artifact changes
- no effect on PR #1094

## Key rule

Later-authorized truth changes must be compared against the exact newer authorized truth. Historical tests must remain pinned to historical inputs. Full-row, provenance, SHA, mutation, and deterministic-regeneration protections cannot be replaced by weaker checks.

Draft PR; do not merge automatically.