### PR TITLE
Marcondes: add methodology reconciliation and report support

### DIFF
--- a/src/components/preverif/Vm0007GapReportView.tsx
+++ b/src/components/preverif/Vm0007GapReportView.tsx
@@ -147,6 +147,20 @@ export default function Vm0007GapReportView({ report }: Vm0007GapReportViewProps
         )}
       </div>
 
+      {report.methodologyReconciliation ? sectionCard(
+        <div data-testid="methodology-reconciliation">
+          <h2 className="text-lg font-semibold text-slate-950">Methodology Review / Version Reconciliation</h2>
+          <div className="mt-3 grid gap-3 text-sm text-slate-700">
+            <div><span className="font-semibold text-slate-900">Finding:</span> {report.methodologyReconciliation.finding}</div>
+            <div><span className="font-semibold text-slate-900">Classification:</span> {report.methodologyReconciliation.classification}</div>
+            <div><span className="font-semibold text-slate-900">Assessment:</span> {report.methodologyReconciliation.assessment}</div>
+            <div><span className="font-semibold text-slate-900">Impact on review:</span> {report.methodologyReconciliation.impactOnReview}</div>
+            <div><span className="font-semibold text-slate-900">Release status:</span> {report.methodologyReconciliation.releaseStatus}</div>
+            <div><span className="font-semibold text-slate-900">Limitation:</span> {report.methodologyReconciliation.limitation}</div>
+          </div>
+        </div>,
+      ) : null}
+
       <div className="grid gap-4 lg:grid-cols-2">
         {sectionCard(
           <>

--- a/src/lib/preverif/vm0007GapReport.ts
+++ b/src/lib/preverif/vm0007GapReport.ts
@@ -42,6 +42,15 @@ export type Vm0007GapReportFinding = {
   confidence: MethodologyEvidenceAuditResult["confidence"];
 };
 
+export type Vm0007MethodologyReconciliation = {
+  finding: string;
+  classification: "DOCUMENT_INCONSISTENCY_OUTDATED_REFERENCE";
+  assessment: string;
+  impactOnReview: string;
+  releaseStatus: "BLOCKED_PENDING_VERSION_RECONCILIATION";
+  limitation: string;
+};
+
 export type Vm0007GapReport = {
   reportId: string;
   generatedAt: string;
@@ -70,6 +79,7 @@ export type Vm0007GapReport = {
     summary: string;
     notes: string[];
   };
+  methodologyReconciliation: Vm0007MethodologyReconciliation | null;
   keySupportedFindings: Vm0007GapReportFinding[];
   notApplicableRules: Vm0007GapReportFinding[];
   mainEvidenceGaps: Vm0007GapReportFinding[];
@@ -158,6 +168,18 @@ function buildVersionWarning(input: Vm0007GapReportInput): string | null {
   const methodologyId = input.audit.methodologyId?.trim() || input.methodology.code;
 
   return `Methodology version mismatch: PDD declares ${methodologyId} ${declaredVersion}, but loaded rulebook is ${methodologyId} ${loadedVersion}. Evidence judgment may be wrong.`;
+}
+
+function buildMethodologyReconciliation(input: Vm0007GapReportInput): Vm0007MethodologyReconciliation | null {
+  if (input.audit.versionMatch !== false) return null;
+  return {
+    finding: "The Marcondes PDD contains a methodology version inconsistency: page 61 references VM0007 v1.7, while Tables 30 and 31 formally declare VM0007 v1.8.",
+    classification: "DOCUMENT_INCONSISTENCY_OUTDATED_REFERENCE",
+    assessment: "The evidence indicates an outdated document reference. The available evidence does not indicate confirmed application of two different methodology versions. The Evidence Map review was performed against VM0007 v1.8.",
+    impactOnReview: "The Evidence Map findings remain based on VM0007 v1.8. The methodology inconsistency remains a release blocker pending authorized validation/confirmation of the document inconsistency.",
+    releaseStatus: "BLOCKED_PENDING_VERSION_RECONCILIATION",
+    limitation: "This is an independent pre-validation readiness review. It does not constitute validation, verification, approval, certification, or confirmation by Verra or a VVB.",
+  };
 }
 
 function toFinding(result: MethodologyEvidenceAuditResult): Vm0007GapReportFinding {
@@ -274,6 +296,7 @@ export function buildVm0007GapReport(input: Vm0007GapReportInput): Vm0007GapRepo
         "Weak and missing rules keep follow-up guidance from the audit output without changing the underlying audit logic.",
       ],
     },
+    methodologyReconciliation: buildMethodologyReconciliation(input),
     keySupportedFindings,
     notApplicableRules,
     mainEvidenceGaps,

--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/methodology-reconciliation.md
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/methodology-reconciliation.md
@@ -1,0 +1,47 @@
+# Methodology Version Reconciliation Note
+
+## Finding
+
+The Marcondes PDD contains a methodology version inconsistency.
+
+Identified references:
+
+- Page 61 contains wording referencing VM0007 v1.7.
+- Tables 30 and 31 contain formal declarations referencing VM0007 v1.8.
+
+## Classification
+
+DOCUMENT_INCONSISTENCY_OUTDATED_REFERENCE
+
+## Assessment
+
+The evidence indicates an outdated document reference. The available evidence does not indicate confirmed application of two different methodology versions. The Evidence Map review was performed against VM0007 v1.8.
+
+## Evidence Preservation
+
+The review preserves:
+
+- exact page 61 v1.7 wording
+- exact Tables 30 and 31 v1.8 declarations
+- affected reviewed rows
+- reviewer reconciliation rationale
+
+No methodology version was silently normalized.
+
+## Release Impact
+
+The Evidence Map findings remain based on VM0007 v1.8.
+
+The methodology inconsistency remains a release blocker pending authorized validation/confirmation of the document inconsistency.
+
+## Limitation
+
+This is an independent pre-validation readiness review.
+
+It does not constitute:
+
+- validation
+- verification
+- approval
+- certification
+- confirmation by Verra or a VVB

--- a/tests/lib/preverif/marcondesFinalReconciliation.test.ts
+++ b/tests/lib/preverif/marcondesFinalReconciliation.test.ts
@@ -37,6 +37,16 @@ describe("Marcondes finalized Evidence Map reconciliation", () => {
     expect(crypto.createHash("sha256").update(fs.readFileSync(path.join(dir, "raw-evidence-map.json"))).digest("hex")).toBe("bd71459647c878855a9ebfe1fe3d6af6e9ec5c8ba89464091bc06ee0dbfe649e");
   });
 
+  it("preserves the methodology reconciliation artifact and release blocker", () => {
+    const note = fs.readFileSync(path.join(dir, "methodology-reconciliation.md"), "utf8");
+    expect(note).toContain("# Methodology Version Reconciliation Note");
+    for (const section of ["Finding", "Classification", "Assessment", "Evidence Preservation", "Release Impact", "Limitation"]) {
+      expect(note).toContain(`## ${section}`);
+    }
+    expect(note).toContain("DOCUMENT_INCONSISTENCY_OUTDATED_REFERENCE");
+    expect(read("release-status.json").reportReleaseState).toBe("BLOCKED_PENDING_VERSION_RECONCILIATION");
+  });
+
   it("retains exact quote, page, section, span, and provenance for accepted and rejected evidence", () => {
     const gold = read("gold.json");
     const extraction = read("raw-document-extraction.json");


### PR DESCRIPTION
## Purpose

Add permanent documentation and report support for the Marcondes VM0007 v1.8 methodology reconciliation issue.

## Changes

- Added methodology reconciliation artifact
- Added report methodology review section
- Preserved release blocker state
- Added focused validation coverage

## Protected

- gold truth unchanged
- machine proposal unchanged
- raw extraction unchanged
- raw evidence map unchanged

## Validation

- Marcondes reconciliation tests passed
- VM0007 report tests passed
- pr:check:local passed

## Release status

Still blocked pending authorized validation/confirmation of the document inconsistency.