### PR TITLE
Marcondes: freeze VM0007 v1.8 Evidence Map v1.0-rc1

### DIFF
--- a/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/release-candidate-v1.0-rc1.json
+++ b/tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/release-candidate-v1.0-rc1.json
@@ -1,0 +1,22 @@
+{
+  "name": "Marcondes VM0007 v1.8 Evidence Map",
+  "version": "v1.0-rc1",
+  "status": "internal release candidate",
+  "sourceCommit": "9698d4f94ad8018ebc10a70b5571a486f0b10d57",
+  "reportReleaseState": "BLOCKED_PENDING_VERSION_RECONCILIATION",
+  "methodologyClassification": "DOCUMENT_INCONSISTENCY_OUTDATED_REFERENCE",
+  "reviewedRules": 58,
+  "acceptedEvidenceEntries": 97,
+  "counts": { "FOUND": 6, "UNCLEAR": 21, "MISSING": 9, "N/A": 22 },
+  "reviewerOutcomes": { "CONFORMS": 6, "ACTION_REQUIRED": 30, "NOT_APPLICABLE": 22, "NOT_ASSESSED": 0 },
+  "pinnedArtifacts": {
+    "gold.json": "ad9576b39f90c28f829b013121eaf177f841c98b2a9997391b85027b4fcee511",
+    "metadata.json": "e6db518b70297bb0647cb39ea837387b0193833a39fdc8270d8c186342101b83",
+    "release-status.json": "514af87d4096c684e0df118d30b6dd6f942af1434863eba14acf73ae0cfb1c19",
+    "REVIEW.md": "9e12d0f356cd68267ad9d2d28e7bd18e64cbedccdfad5df841763356476392c9",
+    "methodology-reconciliation.md": "c0a8e51c7dbd0ce72597193745670829e44edbbb29fe85c1e6b845c44b1059cd",
+    "machine-proposal.json": "068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6",
+    "raw-document-extraction.json": "7031b49bf70d541679788e65f74efef09921712a506a0ba4aa28d0b0bcd98747",
+    "raw-evidence-map.json": "bd71459647c878855a9ebfe1fe3d6af6e9ec5c8ba89464091bc06ee0dbfe649e"
+  }
+}

--- a/tests/lib/preverif/marcondesReleaseCandidateFreeze.test.ts
+++ b/tests/lib/preverif/marcondesReleaseCandidateFreeze.test.ts
@@ -1,0 +1,42 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const dir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
+const read = (name: string) => JSON.parse(fs.readFileSync(path.join(dir, name), "utf8")) as Record<string, any>;
+const sha256 = (name: string) => crypto.createHash("sha256").update(fs.readFileSync(path.join(dir, name))).digest("hex");
+
+describe("Marcondes v1.0-rc1 internal release candidate", () => {
+  const manifest = read("release-candidate-v1.0-rc1.json");
+
+  it("pins every release artifact to its recorded SHA-256", () => {
+    for (const [name, expected] of Object.entries(manifest.pinnedArtifacts)) expect(sha256(name)).toBe(expected);
+  });
+
+  it("records the audited source and exact reviewed totals", () => {
+    expect(manifest.sourceCommit).toBe("9698d4f94ad8018ebc10a70b5571a486f0b10d57");
+    expect(manifest.reviewedRules).toBe(58);
+    expect(manifest.acceptedEvidenceEntries).toBe(97);
+    expect(manifest.counts).toEqual({ FOUND: 6, UNCLEAR: 21, MISSING: 9, "N/A": 22 });
+    expect(manifest.reviewerOutcomes).toEqual({ CONFORMS: 6, ACTION_REQUIRED: 30, NOT_APPLICABLE: 22, NOT_ASSESSED: 0 });
+  });
+
+  it("remains blocked and cannot be treated as a final client release", () => {
+    expect(manifest.status).toBe("internal release candidate");
+    expect(manifest.version).toBe("v1.0-rc1");
+    expect(manifest.reportReleaseState).toBe("BLOCKED_PENDING_VERSION_RECONCILIATION");
+    expect(manifest.methodologyClassification).toBe("DOCUMENT_INCONSISTENCY_OUTDATED_REFERENCE");
+    expect(manifest.status).not.toMatch(/final|approved|validated|verified|certified/i);
+  });
+
+  it("keeps truth artifacts and the release blocker intact", () => {
+    const gold = read("gold.json");
+    const releaseStatus = read("release-status.json");
+    expect(gold.rows).toHaveLength(58);
+    expect(gold.rows.reduce((n: number, row: any) => n + row.acceptedEvidence.length, 0)).toBe(97);
+    expect(gold.counts).toEqual(manifest.counts);
+    expect(releaseStatus.reportReleaseState).toBe("BLOCKED_PENDING_VERSION_RECONCILIATION");
+    expect(releaseStatus.goldPromotionBlocked).toBe(true);
+    expect(releaseStatus.reportReleaseBlocker).toMatch(/page-61.*v1\.7.*Tables 30 and 31.*blocked/i);
+  });
+});


### PR DESCRIPTION
## Summary
- freeze the Marcondes VM0007 v1.8 Evidence Map as internal release candidate v1.0-rc1
- record the audited source commit, counts, reviewer outcomes, and SHA-256 pins
- add focused integrity and blocker-preservation coverage

## Release posture
This is not a final client release. The existing `BLOCKED_PENDING_VERSION_RECONCILIATION` state remains unchanged.

## Checks
- focused Marcondes reconciliation, methodology conflict, truth intake, and RC freeze Jest tests
- `git diff --check`
- pre-push lint and typecheck