### PR TITLE
RC5-2 freeze Maya benchmark baseline

### DIFF
--- a/docs/roadmaps/interactive-evidence-review-mvp/rc/rc5/maya-rc5-2-freeze-record.md
+++ b/docs/roadmaps/interactive-evidence-review-mvp/rc/rc5/maya-rc5-2-freeze-record.md
@@ -1,0 +1,42 @@
+# Maya RC5-2 Benchmark Freeze Record
+
+- status: FROZEN
+- case: Maya Forest Corridor REDD
+- methodology: VM0007 v1.8
+- phase: RC5-2
+- purpose: machine-vs-human benchmark baseline
+
+## Frozen state
+
+Machine proposal:
+
+- SHA: `e996de2eef1fc80aefa94e723903049ae4451fb161baccf337750694a394479b`
+
+Reviewed truth:
+
+- 58 REVIEWED
+- 0 PROVISIONAL
+
+## Protected artifacts
+
+- machine proposal
+- reviewed truth
+- review packets
+- reviewer responses
+- provenance manifests
+- historical regression guards
+
+The final-six integration artifacts remain preserved as committed:
+
+- `docs/roadmaps/interactive-evidence-review-mvp/rc/rc5/rc5-2-maya-final-six-response-integration/integration-manifest.json`
+- `docs/roadmaps/interactive-evidence-review-mvp/rc/rc5/rc5-2-maya-final-six-response-integration/validated-reviewer-response.json`
+
+## Rules after freeze
+
+- reviewed truth must not be edited directly
+- machine proposal must remain unchanged
+- accuracy improvements must compare against this frozen benchmark
+- future corrections require a new versioned benchmark update
+- do not add Maya-specific production logic
+
+This is a benchmark freeze, not a product completion marker. RC5 remains open, and this record does not start RC5-3.


### PR DESCRIPTION
## What changed

Adds the formal Maya RC5-2 benchmark freeze record for VM0007 v1.8.

## Frozen baseline

- Machine proposal SHA: `e996de2eef1fc80aefa94e723903049ae4451fb161baccf337750694a394479b`
- Reviewed truth: 58 REVIEWED, 0 PROVISIONAL

## Scope

Documentation/integrity only. No machine proposal, reviewed truth, review packets, evidence objects, integration outputs, production logic, scoring, retrieval, UI, or report generation was changed. This is not an RC5 completion marker and does not start RC5-3.

## Validation

- `git diff --check`
- Push hook also ran the repository lint and typecheck successfully.