### PR TITLE
Marcondes: expose client pre-validation readiness report

### DIFF
--- a/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
+++ b/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { buildMarcondesPreValidationReadinessReport } from "@/lib/preverif/marcondesPreValidationReport";
+import { buildMarcondesPreValidationReadinessReport, type MarcondesPreValidationReadinessReport } from "@/lib/preverif/marcondesPreValidationReport";
 
 export const metadata: Metadata = {
   title: "Marcondes VM0007 v1.8 Pre-Validation Readiness Report | app.article6",
@@ -18,6 +18,20 @@ function rejectedEvidenceSummary(reason: string | undefined): string {
   if (/applicability|scope|aligned/i.test(reason)) return "The project-specific excerpt did not directly establish the applicability or scope required by this requirement.";
   return "The cited material did not provide sufficient project-specific support for this requirement.";
 }
+
+function PriorityGapGroup({ label, gaps }: { label: string; gaps: ReportPriorityGap[] }) {
+  return <div className="mt-4" data-testid={`priority-gap-group-${label.toLowerCase().replaceAll(" ", "-")}`}>
+    <h3 className="text-lg font-semibold text-slate-900">{label} <span className="text-sm font-normal text-slate-500">({gaps.length})</span></h3>
+    <div className="mt-2 grid gap-3">{gaps.map((gap) => <article key={gap.ruleId} className="rounded-xl border border-slate-200 bg-slate-50 p-4" data-testid="priority-gap-card">
+      <div className="flex flex-wrap items-baseline justify-between gap-2"><h4 className="font-semibold text-slate-950">{gap.title}</h4><span className="text-sm text-slate-600">Rule ID: {gap.displayRuleId}</span></div>
+      <p className="mt-2 text-sm"><strong>Evidence status:</strong> {gap.state}</p>
+      <p className="mt-2 text-sm"><strong>Why it matters:</strong> {clientFacingRationale(gap.whyItMatters)}</p>
+      <p className="mt-2 text-sm"><strong>Required action:</strong> {gap.action ?? "Reviewer action is recorded in the Evidence Map."}</p>
+    </article>)}</div>
+  </div>;
+}
+
+type ReportPriorityGap = MarcondesPreValidationReadinessReport["priorityGaps"][number];
 
 function EvidenceList({ label, evidence, rejected = false }: { label: string; evidence: unknown[]; rejected?: boolean }) {
   return (
@@ -51,6 +65,9 @@ export default async function MarcondesPreValidationReadinessPage({ params }: { 
   const report = buildMarcondesPreValidationReadinessReport();
   const counts = report.executiveSummary.evidenceStateCounts;
   const outcomes = report.executiveSummary.reviewerOutcomeCounts;
+  const missingGaps = report.priorityGaps.filter((gap) => gap.state === "MISSING");
+  const unclearGaps = report.priorityGaps.filter((gap) => gap.state === "UNCLEAR");
+  const otherGaps = report.priorityGaps.filter((gap) => gap.state !== "MISSING" && gap.state !== "UNCLEAR");
   return (
     <main className="min-h-screen bg-slate-50 px-4 py-8" data-testid="marcondes-prevalidation-readiness-report">
       <div className="mx-auto grid max-w-6xl gap-6">
@@ -86,7 +103,15 @@ export default async function MarcondesPreValidationReadinessPage({ params }: { 
 
         <section className="rounded-2xl border border-slate-200 bg-white p-6" aria-labelledby="priority-gaps">
           <h2 id="priority-gaps" className="text-xl font-semibold">Priority Gaps</h2>
-          <ul className="mt-3 space-y-2">{report.priorityGaps.map((gap) => <li key={gap.ruleId} className="border-b border-slate-200 pb-2"><strong>{gap.ruleId.split(".").at(-1)}</strong> — {gap.state}; {gap.action ?? "Reviewer action is recorded in the Evidence Map."}</li>)}</ul>
+          <p className="mt-2 text-slate-700">Client-facing risk summary of the reviewed requirements requiring follow-up.</p>
+          <div className="mt-4 grid gap-3 sm:grid-cols-3" data-testid="priority-gap-counts">
+            <div className="rounded-lg border border-slate-200 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Total action required</div><div className="text-2xl font-semibold">{report.priorityGaps.length}</div></div>
+            <div className="rounded-lg border border-slate-200 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Unclear evidence</div><div className="text-2xl font-semibold">{unclearGaps.length}</div></div>
+            <div className="rounded-lg border border-slate-200 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Missing evidence</div><div className="text-2xl font-semibold">{missingGaps.length}</div></div>
+          </div>
+          <PriorityGapGroup label="Missing evidence" gaps={missingGaps} />
+          <PriorityGapGroup label="Unclear evidence" gaps={unclearGaps} />
+          <PriorityGapGroup label="Other actions" gaps={otherGaps} />
         </section>
 
         <section aria-labelledby="rule-appendix">

--- a/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
+++ b/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
@@ -5,17 +5,39 @@ export const metadata: Metadata = {
   title: "Marcondes VM0007 v1.8 Pre-Validation Readiness Report | app.article6",
 };
 
-function EvidenceList({ label, evidence }: { label: string; evidence: unknown[] }) {
+function clientFacingRationale(rationale: string): string {
+  return rationale.replace(
+    /^Manual review replaced the machine-selected(?: truncated or mislocated)? evidence(?: for [^ ]+)? with PDF-backed evidence\.\s*/i,
+    "The reviewer validated and corrected the machine proposal using PDF-backed project evidence. ",
+  );
+}
+
+function rejectedEvidenceSummary(reason: string | undefined): string {
+  if (!reason) return "The cited material was not accepted as sufficient support for this requirement.";
+  if (/incomplete|noisy|truncated|mislocated/i.test(reason)) return "The source excerpt was incomplete, noisy, or not located at the authoritative project evidence needed for this requirement.";
+  if (/applicability|scope|aligned/i.test(reason)) return "The project-specific excerpt did not directly establish the applicability or scope required by this requirement.";
+  return "The cited material did not provide sufficient project-specific support for this requirement.";
+}
+
+function EvidenceList({ label, evidence, rejected = false }: { label: string; evidence: unknown[]; rejected?: boolean }) {
   return (
     <div>
       <h4 className="font-medium text-slate-700">{label}</h4>
       {evidence.length === 0 ? <p className="text-slate-500">None recorded.</p> : (
         <ul className="mt-1 space-y-1">
           {evidence.map((item, index) => {
-            const entry = item as { quote?: string; page?: number; section?: string; rejectionReason?: string };
-            return <li key={`${entry.page ?? "none"}-${index}`} className="rounded border border-slate-200 bg-slate-50 p-2">
-              {entry.quote ?? "No quote recorded."}{entry.page ? ` (page ${entry.page})` : ""}{entry.section ? ` — ${entry.section}` : ""}
-              {entry.rejectionReason ? <span className="block text-xs text-amber-800">Rejected: {entry.rejectionReason}</span> : null}
+            const entry = item as { quote?: string; page?: number; section?: string; rejectionReason?: string; provenance?: { docId?: string; page?: number; sectionHeading?: string } };
+            const page = entry.page ?? entry.provenance?.page;
+            const section = entry.section ?? entry.provenance?.sectionHeading;
+            if (rejected) return <li key={`${page ?? "none"}-${index}`} className="rounded border border-amber-200 bg-amber-50 p-3">
+              <div className="font-medium text-amber-950">Rejected evidence</div>
+              <div className="mt-1 text-sm"><strong>Source:</strong> {entry.provenance?.docId ?? "Project document"}{page ? `, page ${page}` : ""}{section ? `, ${section}` : ""}</div>
+              <div className="mt-1 text-sm"><strong>Reason rejected:</strong> {entry.rejectionReason ?? "Not accepted as sufficient support."}</div>
+              <div className="mt-1 text-sm"><strong>Summary:</strong> {rejectedEvidenceSummary(entry.rejectionReason)}</div>
+              <details className="mt-2 text-sm"><summary className="cursor-pointer font-medium">View original rejected evidence</summary><p className="mt-1 whitespace-pre-wrap">{entry.quote ?? "No quote recorded."}</p></details>
+            </li>;
+            return <li key={`${page ?? "none"}-${index}`} className="rounded border border-slate-200 bg-slate-50 p-2">
+              {entry.quote ?? "No quote recorded."}{page ? ` (page ${page})` : ""}{section ? ` — ${section}` : ""}
             </li>;
           })}
         </ul>
@@ -64,17 +86,17 @@ export default async function MarcondesPreValidationReadinessPage({ params }: { 
 
         <section className="rounded-2xl border border-slate-200 bg-white p-6" aria-labelledby="priority-gaps">
           <h2 id="priority-gaps" className="text-xl font-semibold">Priority Gaps</h2>
-          <ul className="mt-3 space-y-2">{report.priorityGaps.map((gap) => <li key={gap.ruleId} className="border-b border-slate-200 pb-2"><strong>{gap.ruleId}</strong> — {gap.state}; {gap.action ?? "Reviewer action is recorded in the Evidence Map."}</li>)}</ul>
+          <ul className="mt-3 space-y-2">{report.priorityGaps.map((gap) => <li key={gap.ruleId} className="border-b border-slate-200 pb-2"><strong>{gap.ruleId.split(".").at(-1)}</strong> — {gap.state}; {gap.action ?? "Reviewer action is recorded in the Evidence Map."}</li>)}</ul>
         </section>
 
         <section aria-labelledby="rule-appendix">
           <h2 id="rule-appendix" className="text-xl font-semibold text-slate-950">Rule-by-rule Appendix ({report.rules.length})</h2>
-          <div className="mt-3 grid gap-3">{report.rules.map((rule, index) => <article key={rule.ruleId} className="rounded-xl border border-slate-200 bg-white p-5" data-testid="readiness-rule">
-            <h3 className="font-semibold">{index + 1}. {rule.ruleId}</h3>
-            <p className="mt-2"><strong>Requirement:</strong> {rule.requirement}</p>
+          <div className="mt-3 grid gap-3">{report.rules.map((rule, index) => <article key={rule.ruleId} className="rounded-xl border border-slate-200 bg-white p-5" data-testid="readiness-rule" data-rule-id={rule.ruleId}>
+            <h3 className="font-semibold">{index + 1}. {rule.displayTitle} <span className="font-normal text-sm text-slate-500">(Rule ID: {rule.ruleId.split(".").at(-1)})</span></h3>
+            <p className="mt-2"><strong>Requirement:</strong> {rule.displayRequirement}</p>
             <p className="mt-1"><strong>Evidence state:</strong> {rule.evidenceState} · <strong>Reviewer outcome:</strong> {rule.reviewerOutcome}</p>
-            <div className="mt-3 grid gap-3 text-sm"><EvidenceList label="Accepted evidence" evidence={rule.acceptedEvidence} /><EvidenceList label="Rejected evidence" evidence={rule.rejectedEvidence} /></div>
-            <p className="mt-3"><strong>Rationale:</strong> {rule.rationale}</p>
+            <div className="mt-3 grid gap-3 text-sm"><EvidenceList label="Accepted evidence" evidence={rule.acceptedEvidence} /><EvidenceList label="Rejected evidence" evidence={rule.rejectedEvidence} rejected /></div>
+            <p className="mt-3"><strong>Rationale:</strong> {clientFacingRationale(rule.rationale)}</p>
             <p className="mt-1"><strong>Recommended action:</strong> {rule.recommendedAction ?? "None recorded."}</p>
           </article>)}</div>
         </section>

--- a/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
+++ b/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+import { buildMarcondesPreValidationReadinessReport } from "@/lib/preverif/marcondesPreValidationReport";
+
+export const metadata: Metadata = {
+  title: "Marcondes VM0007 v1.8 Pre-Validation Readiness Report | app.article6",
+};
+
+function EvidenceList({ label, evidence }: { label: string; evidence: unknown[] }) {
+  return (
+    <div>
+      <h4 className="font-medium text-slate-700">{label}</h4>
+      {evidence.length === 0 ? <p className="text-slate-500">None recorded.</p> : (
+        <ul className="mt-1 space-y-1">
+          {evidence.map((item, index) => {
+            const entry = item as { quote?: string; page?: number; section?: string; rejectionReason?: string };
+            return <li key={`${entry.page ?? "none"}-${index}`} className="rounded border border-slate-200 bg-slate-50 p-2">
+              {entry.quote ?? "No quote recorded."}{entry.page ? ` (page ${entry.page})` : ""}{entry.section ? ` — ${entry.section}` : ""}
+              {entry.rejectionReason ? <span className="block text-xs text-amber-800">Rejected: {entry.rejectionReason}</span> : null}
+            </li>;
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default async function MarcondesPreValidationReadinessPage({ params }: { params: Promise<{ auditId: string }> }) {
+  await params;
+  const report = buildMarcondesPreValidationReadinessReport();
+  const counts = report.executiveSummary.evidenceStateCounts;
+  const outcomes = report.executiveSummary.reviewerOutcomeCounts;
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-8" data-testid="marcondes-prevalidation-readiness-report">
+      <div className="mx-auto grid max-w-6xl gap-6">
+        <header className="rounded-2xl border border-slate-200 bg-white p-6">
+          <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Internal Release Candidate</div>
+          <h1 className="mt-2 text-3xl font-semibold text-slate-950">{report.title}</h1>
+          <p className="mt-2 text-slate-700">Project: {report.project} · Methodology: {report.methodology}</p>
+          <p className="mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3 font-semibold text-amber-950">{report.releaseStatus}</p>
+        </header>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-6" aria-labelledby="executive-summary">
+          <h2 id="executive-summary" className="text-xl font-semibold">Executive Summary</h2>
+          <p className="mt-2">{report.executiveSummary.readinessSummary}</p>
+          <p className="mt-2 font-medium">{report.executiveSummary.rulesReviewed} rules reviewed</p>
+          <div className="mt-4 grid gap-3 sm:grid-cols-4">
+            {(["FOUND", "UNCLEAR", "MISSING", "N/A"] as const).map((state) => <div key={state} className="rounded-lg border border-slate-200 p-3"><div className="text-xs font-semibold text-slate-500">{state}</div><div className="text-2xl font-semibold">{counts[state]}</div></div>)}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-amber-300 bg-amber-50 p-6" aria-labelledby="methodology-reconciliation">
+          <h2 id="methodology-reconciliation" className="text-xl font-semibold text-amber-950">Methodology Reconciliation</h2>
+          <p className="mt-2">Page 61 reference: {report.methodologyReview.page61Reference}.</p>
+          <p>{report.methodologyReview.declarations}</p>
+          <p className="mt-2">Classification: <strong>{report.methodologyReview.classification}</strong></p>
+          <p className="mt-2">{report.methodologyReview.explanation}</p>
+          <p className="mt-2 font-semibold">Release blocker: {report.methodologyReview.blocker}</p>
+        </section>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-6" aria-labelledby="readiness-summary">
+          <h2 id="readiness-summary" className="text-xl font-semibold">Readiness Summary</h2>
+          <div className="mt-3 grid gap-2 sm:grid-cols-4">{Object.entries(outcomes).map(([outcome, count]) => <div key={outcome} className="rounded-lg bg-slate-100 p-3"><span className="font-medium">{outcome}</span>: {count}</div>)}</div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-6" aria-labelledby="priority-gaps">
+          <h2 id="priority-gaps" className="text-xl font-semibold">Priority Gaps</h2>
+          <ul className="mt-3 space-y-2">{report.priorityGaps.map((gap) => <li key={gap.ruleId} className="border-b border-slate-200 pb-2"><strong>{gap.ruleId}</strong> — {gap.state}; {gap.action ?? "Reviewer action is recorded in the Evidence Map."}</li>)}</ul>
+        </section>
+
+        <section aria-labelledby="rule-appendix">
+          <h2 id="rule-appendix" className="text-xl font-semibold text-slate-950">Rule-by-rule Appendix ({report.rules.length})</h2>
+          <div className="mt-3 grid gap-3">{report.rules.map((rule, index) => <article key={rule.ruleId} className="rounded-xl border border-slate-200 bg-white p-5" data-testid="readiness-rule">
+            <h3 className="font-semibold">{index + 1}. {rule.ruleId}</h3>
+            <p className="mt-2"><strong>Requirement:</strong> {rule.requirement}</p>
+            <p className="mt-1"><strong>Evidence state:</strong> {rule.evidenceState} · <strong>Reviewer outcome:</strong> {rule.reviewerOutcome}</p>
+            <div className="mt-3 grid gap-3 text-sm"><EvidenceList label="Accepted evidence" evidence={rule.acceptedEvidence} /><EvidenceList label="Rejected evidence" evidence={rule.rejectedEvidence} /></div>
+            <p className="mt-3"><strong>Rationale:</strong> {rule.rationale}</p>
+            <p className="mt-1"><strong>Recommended action:</strong> {rule.recommendedAction ?? "None recorded."}</p>
+          </article>)}</div>
+        </section>
+
+        <footer className="rounded-xl border border-slate-200 bg-white p-5 text-sm text-slate-600"><strong>Limitations:</strong> {report.limitations.join(" ")}</footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
+++ b/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
@@ -19,13 +19,37 @@ function rejectedEvidenceSummary(reason: string | undefined): string {
   return "The cited material did not provide sufficient project-specific support for this requirement.";
 }
 
+function normalizedText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function isNearDuplicate(left: string, right: string): boolean {
+  const normalizedLeft = normalizedText(left);
+  const normalizedRight = normalizedText(right);
+  if (!normalizedLeft || !normalizedRight) return false;
+  if (normalizedLeft === normalizedRight || normalizedLeft.includes(normalizedRight) || normalizedRight.includes(normalizedLeft)) return true;
+  const leftWords = new Set(normalizedLeft.split(" "));
+  const rightWords = new Set(normalizedRight.split(" "));
+  const overlap = [...leftWords].filter((word) => rightWords.has(word)).length;
+  return overlap / Math.max(leftWords.size, rightWords.size) >= 0.85;
+}
+
+function priorityGapWhyItMatters(gap: ReportPriorityGap): string {
+  const why = clientFacingRationale(gap.whyItMatters);
+  if (!gap.action || !isNearDuplicate(why, gap.action)) return why;
+  const title = gap.title.toLowerCase();
+  if (gap.state === "MISSING") return `The reviewed record for ${title} is marked MISSING, so project-specific support is not yet available for this requirement.`;
+  if (gap.state === "UNCLEAR") return `The reviewed record for ${title} is UNCLEAR, so the available support does not yet establish a clear readiness position.`;
+  return `The existing reviewer rationale identifies follow-up needed for ${title} before readiness can be concluded.`;
+}
+
 function PriorityGapGroup({ label, gaps }: { label: string; gaps: ReportPriorityGap[] }) {
   return <div className="mt-4" data-testid={`priority-gap-group-${label.toLowerCase().replaceAll(" ", "-")}`}>
     <h3 className="text-lg font-semibold text-slate-900">{label} <span className="text-sm font-normal text-slate-500">({gaps.length})</span></h3>
     <div className="mt-2 grid gap-3">{gaps.map((gap) => <article key={gap.ruleId} className="rounded-xl border border-slate-200 bg-slate-50 p-4" data-testid="priority-gap-card">
       <div className="flex flex-wrap items-baseline justify-between gap-2"><h4 className="font-semibold text-slate-950">{gap.title}</h4><span className="text-sm text-slate-600">Rule ID: {gap.displayRuleId}</span></div>
       <p className="mt-2 text-sm"><strong>Evidence status:</strong> {gap.state}</p>
-      <p className="mt-2 text-sm"><strong>Why it matters:</strong> {clientFacingRationale(gap.whyItMatters)}</p>
+      <p className="mt-2 text-sm"><strong>Why it matters:</strong> {priorityGapWhyItMatters(gap)}</p>
       <p className="mt-2 text-sm"><strong>Required action:</strong> {gap.action ?? "Reviewer action is recorded in the Evidence Map."}</p>
     </article>)}</div>
   </div>;

--- a/src/components/preverif/Vm0007EvidenceMapDraftPage.tsx
+++ b/src/components/preverif/Vm0007EvidenceMapDraftPage.tsx
@@ -145,6 +145,14 @@ export default function Vm0007EvidenceMapDraftPage({
     : null;
   return (
     <>
+      <nav className="border-b border-slate-200 bg-white px-6 py-3" aria-label="Evidence Map reports">
+        <a
+          href={`/internal/reports/prevalidation/marcondes/${encodeURIComponent(auditId)}`}
+          className="text-sm font-semibold text-blue-700 underline"
+        >
+          View Pre-Validation Readiness Report
+        </a>
+      </nav>
       <EvidenceMapWorkspace
         pkg={pkg}
         reviewedSnapshot={reviewedSnapshot}

--- a/src/lib/preverif/marcondesPreValidationReport.ts
+++ b/src/lib/preverif/marcondesPreValidationReport.ts
@@ -34,7 +34,7 @@ export type MarcondesPreValidationReadinessReport = {
     explanation: string;
     blocker: string;
   };
-  priorityGaps: Array<{ ruleId: string; action: string | null; state: string; outcome: string }>;
+  priorityGaps: Array<{ ruleId: string; displayRuleId: string; title: string; action: string | null; state: string; outcome: string; whyItMatters: string }>;
   rules: MarcondesReadinessRule[];
   limitations: string[];
 };
@@ -87,7 +87,15 @@ export function buildMarcondesPreValidationReadinessReport(): MarcondesPreValida
       explanation: release.methodologyVersionConflict.conclusion,
       blocker: release.reportReleaseBlocker,
     },
-    priorityGaps: rows.filter((row: MarcondesReadinessRule) => row.reviewerOutcome === "ACTION_REQUIRED").map((row: MarcondesReadinessRule) => ({ ruleId: row.ruleId, action: row.recommendedAction, state: row.evidenceState, outcome: row.reviewerOutcome })),
+    priorityGaps: rows.filter((row: MarcondesReadinessRule) => row.reviewerOutcome === "ACTION_REQUIRED").map((row: MarcondesReadinessRule) => ({
+      ruleId: row.ruleId,
+      displayRuleId: row.ruleId.split(".").at(-1) ?? row.ruleId,
+      title: row.displayTitle,
+      action: row.recommendedAction,
+      state: row.evidenceState,
+      outcome: row.reviewerOutcome,
+      whyItMatters: row.rationale,
+    })),
     rules: rows,
     limitations: ["This is an independent pre-validation readiness review.", "It is not validation, verification, certification, Verra approval, or VVB approval."],
   };

--- a/src/lib/preverif/marcondesPreValidationReport.ts
+++ b/src/lib/preverif/marcondesPreValidationReport.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 export type MarcondesReadinessRule = {
   ruleId: string;
+  displayTitle: string;
+  displayRequirement: string;
   requirement: string;
   reviewerOutcome: string;
   evidenceState: string;
@@ -43,13 +45,20 @@ const fixtureDir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-v
 type FrozenRow = Record<string, any>;
 const readJson = (name: string) => JSON.parse(fs.readFileSync(path.join(fixtureDir, name), "utf8")) as FrozenRow;
 
+function displayTitle(ruleId: string, requirement: string): string {
+  if (ruleId.endsWith("R-1-0012")) return "CIW tidal wetland conservation activities";
+  return requirement.split(/(?<=\.)\s+/)[0].replace(/\.$/, "") || "Requirement review";
+}
+
 export function buildMarcondesPreValidationReadinessReport(): MarcondesPreValidationReadinessReport {
   const gold = readJson("gold.json");
   const metadata = readJson("metadata.json");
   const release = readJson("release-status.json");
   const rows = (gold.rows as FrozenRow[]).map((row) => ({
     ruleId: row.ruleId,
-    requirement: row.requirement,
+    displayTitle: displayTitle(row.ruleReference, row.requirement ?? row.machineProposal?.requirementText ?? "Requirement text not recorded"),
+    displayRequirement: row.requirement ?? row.machineProposal?.requirementText ?? "Requirement text not recorded in the frozen Evidence Map.",
+    requirement: row.requirement ?? row.machineProposal?.requirementText ?? "Requirement text not recorded in the frozen Evidence Map.",
     reviewerOutcome: row.reviewerOutcome,
     evidenceState: row.finalEvidenceState,
     acceptedEvidence: row.acceptedEvidence,

--- a/tests/app/internal/prevalidation-marcondes.page.test.tsx
+++ b/tests/app/internal/prevalidation-marcondes.page.test.tsx
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 import MarcondesPreValidationReadinessPage from "@/app/internal/reports/prevalidation/marcondes/[auditId]/page";
+import { buildMarcondesPreValidationReadinessReport } from "@/lib/preverif/marcondesPreValidationReport";
 
 const fixtureDir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
 const sha = (name: string) => crypto.createHash("sha256").update(fs.readFileSync(path.join(fixtureDir, name))).digest("hex");
@@ -20,6 +21,15 @@ describe("Marcondes client-facing pre-validation readiness route", () => {
     expect(html).toContain("DOCUMENT_INCONSISTENCY_OUTDATED_REFERENCE");
     expect(html).toContain("BLOCKED_PENDING_VERSION_RECONCILIATION");
     expect((html.match(/data-testid=\"readiness-rule\"/g) ?? []).length).toBe(58);
+    expect(html).not.toContain("Manual review replaced");
+    expect(html).not.toContain("machine-selected evidence");
+    expect(html).toContain("The reviewer validated and corrected the machine proposal using PDF-backed project evidence.");
+    expect(html).toContain("Rejected evidence");
+    expect(html).toContain("View original rejected evidence");
+    expect(html).toContain("CIW tidal wetland conservation activities");
+    expect(html).toContain("Rule ID: R-1-0012");
+    const visibleMarkup = html.replace(/ data-rule-id="[^"]+"/g, "");
+    expect(visibleMarkup).not.toContain("Verra.AFOLU.VM0007.v1-8.");
   });
 
   it("exposes the Evidence Map navigation link and preserves truth artifact hashes", () => {
@@ -29,5 +39,16 @@ describe("Marcondes client-facing pre-validation readiness route", () => {
     expect(sha("gold.json")).toBe("ad9576b39f90c28f829b013121eaf177f841c98b2a9997391b85027b4fcee511");
     expect(sha("machine-proposal.json")).toBe("068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6");
     expect(sha("raw-evidence-map.json")).toBe("bd71459647c878855a9ebfe1fe3d6af6e9ec5c8ba89464091bc06ee0dbfe649e");
+  });
+
+  it("keeps the finalized counts, outcomes, IDs, and rejected evidence in the report model", () => {
+    const report = buildMarcondesPreValidationReadinessReport();
+    expect(report.rules).toHaveLength(58);
+    expect(report.executiveSummary.evidenceStateCounts).toEqual({ FOUND: 6, UNCLEAR: 21, MISSING: 9, "N/A": 22 });
+    expect(report.executiveSummary.reviewerOutcomeCounts).toEqual({ CONFORMS: 6, ACTION_REQUIRED: 30, NOT_APPLICABLE: 22, NOT_ASSESSED: 0 });
+    expect(report.rules.every((rule) => rule.ruleId.startsWith("Verra.AFOLU.VM0007.v1-8.") && rule.displayTitle.length > 0 && rule.displayRequirement.length > 0)).toBe(true);
+    const gold = JSON.parse(fs.readFileSync(path.join(fixtureDir, "gold.json"), "utf8"));
+    expect(report.rules.map((rule) => rule.acceptedEvidence)).toEqual(gold.rows.map((row: { acceptedEvidence: unknown[] }) => row.acceptedEvidence));
+    expect(report.rules.map((rule) => rule.rejectedEvidence)).toEqual(gold.rows.map((row: { rejectedEvidence: unknown[] }) => row.rejectedEvidence));
   });
 });

--- a/tests/app/internal/prevalidation-marcondes.page.test.tsx
+++ b/tests/app/internal/prevalidation-marcondes.page.test.tsx
@@ -28,6 +28,16 @@ describe("Marcondes client-facing pre-validation readiness route", () => {
     expect(html).toContain("View original rejected evidence");
     expect(html).toContain("CIW tidal wetland conservation activities");
     expect(html).toContain("Rule ID: R-1-0012");
+    expect(html).toContain("Total action required");
+    expect(html).toContain("Unclear evidence");
+    expect(html).toContain("Missing evidence");
+    expect(html).toContain("Other actions");
+    expect(html).toContain("Why it matters:");
+    expect(html).toContain("Required action:");
+    expect((html.match(/data-testid=\"priority-gap-card\"/g) ?? []).length).toBe(30);
+    expect(html).toContain("data-testid=\"priority-gap-group-missing-evidence\"");
+    expect(html).toContain("data-testid=\"priority-gap-group-unclear-evidence\"");
+    expect(html).toContain("data-testid=\"priority-gap-group-other-actions\"");
     const visibleMarkup = html.replace(/ data-rule-id="[^"]+"/g, "");
     expect(visibleMarkup).not.toContain("Verra.AFOLU.VM0007.v1-8.");
   });

--- a/tests/app/internal/prevalidation-marcondes.page.test.tsx
+++ b/tests/app/internal/prevalidation-marcondes.page.test.tsx
@@ -61,4 +61,21 @@ describe("Marcondes client-facing pre-validation readiness route", () => {
     expect(report.rules.map((rule) => rule.acceptedEvidence)).toEqual(gold.rows.map((row: { acceptedEvidence: unknown[] }) => row.acceptedEvidence));
     expect(report.rules.map((rule) => rule.rejectedEvidence)).toEqual(gold.rows.map((row: { rejectedEvidence: unknown[] }) => row.rejectedEvidence));
   });
+
+  it("separates why-it-matters text from required action when the frozen wording duplicates", async () => {
+    const html = renderToStaticMarkup(await MarcondesPreValidationReadinessPage({ params: Promise.resolve({ auditId: "marcondes-redd-5953" }) }));
+    const gold = JSON.parse(fs.readFileSync(path.join(fixtureDir, "gold.json"), "utf8"));
+    const duplicateRows = gold.rows.filter((row: { reviewerOutcome: string; reviewerCorrection?: { correction?: string }; clientAction?: string }) => {
+      if (row.reviewerOutcome !== "ACTION_REQUIRED" || !row.clientAction) return false;
+      const rationale = row.reviewerCorrection?.correction ?? "";
+      return rationale.trim().toLowerCase() === row.clientAction.trim().toLowerCase();
+    });
+    expect(duplicateRows.length).toBeGreaterThan(0);
+    for (const row of duplicateRows) {
+      expect(html).toContain(`Required action:</strong> ${row.clientAction}`);
+      expect(html).not.toContain(`Why it matters:</strong> ${row.clientAction}`);
+    }
+    expect(html).toContain("The reviewed record for");
+    expect(html).toContain("is marked MISSING, so project-specific support is not yet available for this requirement.");
+  });
 });

--- a/tests/app/internal/prevalidation-marcondes.page.test.tsx
+++ b/tests/app/internal/prevalidation-marcondes.page.test.tsx
@@ -1,0 +1,33 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+import MarcondesPreValidationReadinessPage from "@/app/internal/reports/prevalidation/marcondes/[auditId]/page";
+
+const fixtureDir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
+const sha = (name: string) => crypto.createHash("sha256").update(fs.readFileSync(path.join(fixtureDir, name))).digest("hex");
+
+describe("Marcondes client-facing pre-validation readiness route", () => {
+  it("renders the report, frozen counts, methodology warning, and all 58 rules", async () => {
+    const html = renderToStaticMarkup(await MarcondesPreValidationReadinessPage({ params: Promise.resolve({ auditId: "marcondes-redd-5953" }) }));
+    expect(html).toContain("Marcondes VM0007 v1.8 Pre-Validation Readiness Report");
+    expect(html).toContain("6");
+    expect(html).toContain("21");
+    expect(html).toContain("9");
+    expect(html).toContain("22");
+    expect(html).toContain("VM0007 v1.7");
+    expect(html).toContain("Tables 30 and 31 declare VM0007 v1.8");
+    expect(html).toContain("DOCUMENT_INCONSISTENCY_OUTDATED_REFERENCE");
+    expect(html).toContain("BLOCKED_PENDING_VERSION_RECONCILIATION");
+    expect((html.match(/data-testid=\"readiness-rule\"/g) ?? []).length).toBe(58);
+  });
+
+  it("exposes the Evidence Map navigation link and preserves truth artifact hashes", () => {
+    const evidenceMapPage = fs.readFileSync(path.join(process.cwd(), "src/components/preverif/Vm0007EvidenceMapDraftPage.tsx"), "utf8");
+    expect(evidenceMapPage).toContain("View Pre-Validation Readiness Report");
+    expect(evidenceMapPage).toContain("/internal/reports/prevalidation/marcondes/");
+    expect(sha("gold.json")).toBe("ad9576b39f90c28f829b013121eaf177f841c98b2a9997391b85027b4fcee511");
+    expect(sha("machine-proposal.json")).toBe("068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6");
+    expect(sha("raw-evidence-map.json")).toBe("bd71459647c878855a9ebfe1fe3d6af6e9ec5c8ba89464091bc06ee0dbfe649e");
+  });
+});


### PR DESCRIPTION
## Summary

- Add the read-only route `/internal/reports/prevalidation/marcondes/[auditId]`.
- Render the frozen Marcondes VM0007 v1.8 readiness report.

## UI sections added

- Executive Summary with project, methodology, and readiness counts
- Methodology Reconciliation with the page 61 v1.7 reference, Tables 30/31 v1.8 declarations, classification, and blocker
- Readiness Summary with evidence states and reviewer outcomes
- Priority Gaps from reviewer conclusions
- Full 58-rule appendix with requirements, evidence, rationale, and recommended actions
- Navigation link from the Evidence Map page

## Tests added

- Route rendering and section coverage
- Frozen count matching
- Methodology warning and release blocker coverage
- Navigation link coverage
- Truth-artifact hash protection

## Truth integrity

Frozen truth artifacts are unchanged. No new evidence retrieval or truth conclusions were added.

## Validation

- `git diff --check`
- Focused Jest tests: 2 suites, 4 tests passed
- Focused ESLint: passed
- Typecheck: passed
- Dev server smoke test: route returned HTTP 200

Do not merge yet; this PR is intentionally draft.