### PR TITLE
Fix Evidence Map generation error diagnostics

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -92,6 +92,10 @@ import { buildMethodologyVersionLock } from "@/lib/preverif/evidenceAudit";
 import {
   buildAndSaveVm0007GapReportAudit,
 } from "@/lib/preverif/vm0007GapReportStore";
+import {
+  classifyEvidenceMapGenerationError,
+  type EvidenceMapGenerationError,
+} from "@/lib/preverif/evidenceMapGenerationError";
 
 type MethodInventoryRecord = {
   code: string;
@@ -664,26 +668,8 @@ function joinMethodologyLabels(values: string[]): string {
   return values.join(", ");
 }
 
-export function mapVm0007EvidenceMapGenerationError(blockedBy: readonly string[]): string {
-  if (blockedBy.some((reason) => reason === "methodology_id_mismatch" || reason === "rulebook_version_mismatch")) {
-    return "Evidence Map requires the VM0007 v1.8 methodology version.";
-  }
-  if (blockedBy.includes("pdd_declared_version_mismatch")) {
-    return "Evidence Map requires a PDD that declares VM0007 v1.8.";
-  }
-  if (blockedBy.includes("audit_not_successfully_audited")) {
-    return "The VM0007 evidence audit was not successfully completed.";
-  }
-  if (blockedBy.includes("canonical_rule_count_is_not_58")) {
-    return "Evidence Map requires all 58 canonical VM0007 requirements.";
-  }
-  if (blockedBy.some((reason) => ["missing_rule_ids", "duplicate_rule_ids", "unknown_rule_ids", "duplicate_canonical_rule_ids"].includes(reason))) {
-    return "Evidence Map could not match the complete set of 58 VM0007 requirements.";
-  }
-  if (blockedBy.some((reason) => reason.includes("persistence") || reason.includes("validation"))) {
-    return "Evidence Map draft could not be validated or saved. You can retry.";
-  }
-  return "Evidence Map could not be created. You can retry.";
+export function mapVm0007EvidenceMapGenerationError(blockedBy: readonly string[]): EvidenceMapGenerationError {
+  return classifyEvidenceMapGenerationError({ blockedBy });
 }
 
 export default function QuickCheckPanel({ initialMethod, initialVersion, onContinueToWorkspace, fixtureContract }: QuickCheckPanelProps) {
@@ -713,7 +699,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   const [evidenceCheckResults, setEvidenceCheckResults] = useState<StructuredEvidenceCheckResult[]>([]);
   const [runningEvidenceChecks, setRunningEvidenceChecks] = useState(false);
   const [uploadVm0007GapReportAuditId, setUploadVm0007GapReportAuditId] = useState<string | null>(null);
-  const [uploadVm0007GenerationError, setUploadVm0007GenerationError] = useState<string | null>(null);
+  const [uploadVm0007GenerationError, setUploadVm0007GenerationError] = useState<EvidenceMapGenerationError | null>(null);
   const [generatingUploadVm0007GapReport, setGeneratingUploadVm0007GapReport] = useState(false);
   const [selectedHeading, setSelectedHeading] = useState<DocumentHeading | null>(null);
   const [validatedResultKey, setValidatedResultKey] = useState<string | null>(null);
@@ -1297,12 +1283,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         rules,
       });
       if (!savedAudit || !savedAudit.draftSaved || !savedAudit.auditId) {
-        setUploadVm0007GenerationError(mapVm0007EvidenceMapGenerationError(savedAudit?.blockedBy ?? ["draft_persistence_failed"]));
+        setUploadVm0007GenerationError(savedAudit?.error ?? mapVm0007EvidenceMapGenerationError(savedAudit?.blockedBy ?? ["draft_persistence_failed"]));
         return;
       }
       setUploadVm0007GapReportAuditId(savedAudit.auditId);
-    } catch {
-      setUploadVm0007GenerationError("Evidence Map could not be created. You can retry.");
+    } catch (error) {
+      setUploadVm0007GenerationError(classifyEvidenceMapGenerationError({ error }));
     } finally {
       setGeneratingUploadVm0007GapReport(false);
     }

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -8,6 +8,7 @@ import {
   VM0007_EVIDENCE_MAP_DRAFT_EVENT,
 } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import type { Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import type { EvidenceMapGenerationError } from "@/lib/preverif/evidenceMapGenerationError";
 
 type Vm0007GapReportLaunchButtonProps = {
   isVm0007Result: boolean;
@@ -15,7 +16,7 @@ type Vm0007GapReportLaunchButtonProps = {
   projectId?: string | null;
   title?: string;
   onGenerate?: (() => void) | null;
-  generationError?: string | null;
+  generationError?: EvidenceMapGenerationError | null;
   generating?: boolean;
   generateDisabled?: boolean;
   testId?: string;
@@ -68,7 +69,12 @@ export default function Vm0007GapReportLaunchButton({
         </>
       ) : onGenerate ? (
         <>
-          {generationError ? <div className="mt-2 text-sm text-amber-800">{generationError}</div> : null}
+          {generationError ? (
+            <div className="mt-2 text-sm text-amber-800" role="alert" data-testid="evidence-map-generation-error">
+              <strong className="font-semibold">{generationError.category.replaceAll("_", " ")}</strong>
+              <span className="ml-2">{generationError.userMessage}</span>
+            </div>
+          ) : null}
           <div className="mt-2 text-sm text-slate-600">
             Create a machine-proposed Evidence Map from the VM0007 methodology requirements and the uploaded PDD.
           </div>

--- a/src/lib/preverif/evidenceMapGenerationError.ts
+++ b/src/lib/preverif/evidenceMapGenerationError.ts
@@ -55,10 +55,28 @@ export function classifyEvidenceMapGenerationError(input: {
   const reasons = input.blockedBy ?? [];
   const text = safeTechnicalMessage(input.error ?? reasons.join(", "));
   if (reasons.some((reason) => /methodology|version/i.test(reason))) {
-    return createEvidenceMapGenerationError("METHODOLOGY_ERROR", text);
+    const error = createEvidenceMapGenerationError("METHODOLOGY_ERROR", text);
+    return {
+      ...error,
+      userMessage: reasons.includes("methodology_id_mismatch") || reasons.includes("rulebook_version_mismatch")
+        ? "Evidence Map requires the VM0007 v1.8 methodology version."
+        : reasons.includes("pdd_declared_version_mismatch")
+          ? "Evidence Map requires a PDD that declares VM0007 v1.8."
+          : error.userMessage,
+    };
   }
   if (reasons.some((reason) => /malformed|missing_|duplicate_|unknown_|canonical_|audit_|rule_ids|rule_count|source_document/i.test(reason))) {
-    return createEvidenceMapGenerationError("VALIDATION_ERROR", text);
+    const error = createEvidenceMapGenerationError("VALIDATION_ERROR", text);
+    return {
+      ...error,
+      userMessage: reasons.includes("audit_not_successfully_audited")
+        ? "The VM0007 evidence audit was not successfully completed."
+        : reasons.includes("canonical_rule_count_is_not_58")
+          ? "Evidence Map requires all 58 canonical VM0007 requirements."
+          : reasons.some((reason) => ["missing_rule_ids", "duplicate_rule_ids", "unknown_rule_ids", "duplicate_canonical_rule_ids"].includes(reason))
+            ? "Evidence Map could not match the complete set of 58 VM0007 requirements."
+            : error.userMessage,
+    };
   }
   if (/timeout|timed out|abort/i.test(text)) {
     return createEvidenceMapGenerationError("GENERATION_ERROR", text);
@@ -67,7 +85,13 @@ export function classifyEvidenceMapGenerationError(input: {
     return createEvidenceMapGenerationError("PDF_PARSE_ERROR", text);
   }
   if (input.error || reasons.some((reason) => /persistence|generation/i.test(reason))) {
-    return createEvidenceMapGenerationError("GENERATION_ERROR", text);
+    const error = createEvidenceMapGenerationError("GENERATION_ERROR", text);
+    return {
+      ...error,
+      userMessage: reasons.some((reason) => /persistence|validation/i.test(reason))
+        ? "Evidence Map draft could not be validated or saved. You can retry."
+        : "Evidence Map could not be created. You can retry.",
+    };
   }
   return createEvidenceMapGenerationError("UNKNOWN_ERROR", text);
 }

--- a/src/lib/preverif/evidenceMapGenerationError.ts
+++ b/src/lib/preverif/evidenceMapGenerationError.ts
@@ -1,0 +1,73 @@
+export const EVIDENCE_MAP_ERROR_CATEGORIES = [
+  "PDF_PARSE_ERROR",
+  "METHODOLOGY_ERROR",
+  "GENERATION_ERROR",
+  "VALIDATION_ERROR",
+  "UNKNOWN_ERROR",
+] as const;
+
+export type EvidenceMapGenerationErrorCategory =
+  (typeof EVIDENCE_MAP_ERROR_CATEGORIES)[number];
+
+export type EvidenceMapGenerationError = {
+  category: EvidenceMapGenerationErrorCategory;
+  userMessage: string;
+  technicalMessage: string;
+};
+
+const USER_MESSAGES: Record<EvidenceMapGenerationErrorCategory, string> = {
+  PDF_PARSE_ERROR:
+    "The PDF could not be read. Upload a text-based PDF or retry the upload.",
+  METHODOLOGY_ERROR:
+    "The methodology or version could not be confirmed. Select VM0007 v1.8 and retry.",
+  GENERATION_ERROR:
+    "Evidence Map generation failed before it could be saved. Retry the generation.",
+  VALIDATION_ERROR:
+    "The generated Evidence Map did not pass validation. Retry with a VM0007 v1.8 PDD.",
+  UNKNOWN_ERROR:
+    "Evidence Map generation failed unexpectedly. Retry, and contact support if the problem continues.",
+};
+
+function safeTechnicalMessage(value: unknown): string {
+  const message = value instanceof Error ? value.message : String(value ?? "Unknown error");
+  // Keep diagnostics useful without returning stacks, local paths, or multiline data.
+  return message
+    .split("\n", 1)[0]
+    .replace(/(?:\/Users|\/home|[A-Z]:\\)[^ ]*/g, "[path]")
+    .slice(0, 500);
+}
+
+export function createEvidenceMapGenerationError(
+  category: EvidenceMapGenerationErrorCategory,
+  technicalMessage: unknown,
+): EvidenceMapGenerationError {
+  return {
+    category,
+    userMessage: USER_MESSAGES[category],
+    technicalMessage: safeTechnicalMessage(technicalMessage),
+  };
+}
+
+export function classifyEvidenceMapGenerationError(input: {
+  blockedBy?: readonly string[];
+  error?: unknown;
+} = {}): EvidenceMapGenerationError {
+  const reasons = input.blockedBy ?? [];
+  const text = safeTechnicalMessage(input.error ?? reasons.join(", "));
+  if (reasons.some((reason) => /methodology|version/i.test(reason))) {
+    return createEvidenceMapGenerationError("METHODOLOGY_ERROR", text);
+  }
+  if (reasons.some((reason) => /malformed|missing_|duplicate_|unknown_|canonical_|audit_|rule_ids|rule_count|source_document/i.test(reason))) {
+    return createEvidenceMapGenerationError("VALIDATION_ERROR", text);
+  }
+  if (/timeout|timed out|abort/i.test(text)) {
+    return createEvidenceMapGenerationError("GENERATION_ERROR", text);
+  }
+  if (/pdf|parse|extract|selectable text|scanned/i.test(text)) {
+    return createEvidenceMapGenerationError("PDF_PARSE_ERROR", text);
+  }
+  if (input.error || reasons.some((reason) => /persistence|generation/i.test(reason))) {
+    return createEvidenceMapGenerationError("GENERATION_ERROR", text);
+  }
+  return createEvidenceMapGenerationError("UNKNOWN_ERROR", text);
+}

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -7,6 +7,10 @@ import type { EvidenceMapSourceDocumentIdentity } from "@/lib/evidence/evidenceM
 import { type DraftBuildResult, type Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
 import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import { buildVm0007MachineProposal } from "@/lib/preverif/vm0007MachineProposal";
+import {
+  classifyEvidenceMapGenerationError,
+  type EvidenceMapGenerationError,
+} from "@/lib/preverif/evidenceMapGenerationError";
 
 const VM0007_GAP_REPORT_AUDIT_PREFIX = "a6:vm0007-gap-report-audit:v1:";
 
@@ -31,15 +35,17 @@ export type Vm0007EvidenceMapGenerationResult = {
   blockedBy: string[];
   auditId: string | null;
   audit: Vm0007GapReportAuditRecord | null;
+  error?: EvidenceMapGenerationError;
 };
 
-const failedGeneration = (blockedBy: string[] = []): Vm0007EvidenceMapGenerationResult => ({
+const failedGeneration = (blockedBy: string[] = [], error?: EvidenceMapGenerationError): Vm0007EvidenceMapGenerationResult => ({
   auditSaved: false,
   draftBuilt: false,
   draftSaved: false,
   blockedBy,
   auditId: null,
   audit: null,
+  ...(error ? { error } : { error: classifyEvidenceMapGenerationError({ blockedBy }) }),
 });
 
 export function completeVm0007EvidenceMapGeneration(input: {
@@ -50,11 +56,11 @@ export function completeVm0007EvidenceMapGeneration(input: {
   loadDraft?: (auditId: string) => Vm0007EvidenceMapDraftPackage | null;
 }): Vm0007EvidenceMapGenerationResult {
   if (!input.auditSaved) return { ...failedGeneration(["audit_persistence_failed"]), auditId: input.audit.auditId, audit: input.audit };
-  if (!input.draft.ok) return { auditSaved: true, draftBuilt: false, draftSaved: false, blockedBy: input.draft.blockedBy, auditId: input.audit.auditId, audit: input.audit };
+  if (!input.draft.ok) return { auditSaved: true, draftBuilt: false, draftSaved: false, blockedBy: input.draft.blockedBy, auditId: input.audit.auditId, audit: input.audit, error: classifyEvidenceMapGenerationError({ blockedBy: input.draft.blockedBy }) };
   const saveDraft = input.saveDraft ?? saveVm0007EvidenceMapDraft;
   const loadDraft = input.loadDraft ?? loadVm0007EvidenceMapDraft;
-  if (!saveDraft(input.draft.package)) return { auditSaved: true, draftBuilt: true, draftSaved: false, blockedBy: ["draft_persistence_failed"], auditId: input.audit.auditId, audit: input.audit };
-  if (!loadDraft(input.audit.auditId)) return { auditSaved: true, draftBuilt: true, draftSaved: false, blockedBy: ["draft_persistence_failed"], auditId: input.audit.auditId, audit: input.audit };
+  if (!saveDraft(input.draft.package)) return { ...failedGeneration(["draft_persistence_failed"]), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
+  if (!loadDraft(input.audit.auditId)) return { ...failedGeneration(["draft_persistence_failed"]), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
   return { auditSaved: true, draftBuilt: true, draftSaved: true, blockedBy: [], auditId: input.audit.auditId, audit: input.audit };
 }
 
@@ -135,7 +141,8 @@ export function buildAndSaveVm0007GapReportAudit(input: {
   userAcceptedVersionWarning?: boolean;
 }): Vm0007EvidenceMapGenerationResult {
   if (input.methodology.methodologyId.trim().toUpperCase() !== "VM0007") return failedGeneration(["methodology_id_mismatch"]);
-  if (!input.rawPddText.trim() || input.rules.length === 0) return failedGeneration(["malformed_audit_output"]);
+  if (!input.rawPddText.trim()) return failedGeneration(["pdf_parse_failed"], classifyEvidenceMapGenerationError({ error: "PDF extraction returned no text" }));
+  if (input.rules.length === 0) return failedGeneration(["malformed_audit_output"]);
 
   const auditId = createVm0007GapReportAuditId();
   let built: ReturnType<typeof buildVm0007MachineProposal>;
@@ -152,8 +159,8 @@ export function buildAndSaveVm0007GapReportAudit(input: {
       rules: input.rules,
       userAcceptedVersionWarning: input.userAcceptedVersionWarning,
     });
-  } catch {
-    return failedGeneration(["malformed_audit_output"]);
+  } catch (error) {
+    return failedGeneration(["generation_failed"], classifyEvidenceMapGenerationError({ error }));
   }
 
   const record: Vm0007GapReportAuditRecord = {

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import Vm0007GapReportLaunchButton from "@/components/preverif/Vm0007GapReportLaunchButton";
 import { saveVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import type { Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
+import { createEvidenceMapGenerationError } from "@/lib/preverif/evidenceMapGenerationError";
 
 describe("Vm0007GapReportLaunchButton", () => {
   let container: HTMLDivElement;
@@ -77,12 +78,13 @@ describe("Vm0007GapReportLaunchButton", () => {
           isVm0007Result
           auditId="stale-audit"
           onGenerate={onGenerate}
-          generationError="Evidence Map requires a PDD that declares VM0007 v1.8."
+          generationError={createEvidenceMapGenerationError("METHODOLOGY_ERROR", "pdd_declared_version_mismatch")}
         />,
       );
     });
     expect(container.querySelector("a")).toBeNull();
-    expect(container.textContent).toContain("Evidence Map requires a PDD that declares VM0007 v1.8.");
+    expect(container.textContent).toContain("METHODOLOGY ERROR");
+    expect(container.textContent).toContain("methodology or version could not be confirmed");
     expect(container.textContent).toContain("Retry Evidence Map");
     container.querySelector("button")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onGenerate).toHaveBeenCalledTimes(1);

--- a/tests/lib/preverif/vm0007GapReportStore.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.test.ts
@@ -20,6 +20,31 @@ const rawPddText = readQuickCheckFixtureText(
 afterEach(() => window.localStorage.clear());
 
 describe("VM0007 uploaded PDF source identity propagation", () => {
+  test("returns a structured validation error when draft generation is blocked", () => {
+    const audit = {
+      auditId: "audit-failure",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1.8",
+      loadedRulebookId: "VM0007",
+      loadedRulebookVersion: "v1.8",
+      methodology: null,
+      generatedAt: "2026-07-01T00:00:00Z",
+      audit: {} as never,
+    };
+    const result = completeVm0007EvidenceMapGeneration({
+      audit,
+      auditSaved: true,
+      draft: { ok: false, blockedBy: ["canonical_rule_count_is_not_58"] },
+    });
+
+    expect(result.error).toEqual({
+      category: "VALIDATION_ERROR",
+      userMessage: expect.stringContaining("did not pass validation"),
+      technicalMessage: "canonical_rule_count_is_not_58",
+    });
+    expect(result.error?.technicalMessage).not.toContain("Error:");
+  });
+
   test("persists the SHA-256 of uploaded bytes through audit and Evidence Map package", async () => {
     const uploadedPdfBytes = new TextEncoder().encode(
       "original uploaded PDF bytes",

--- a/tests/lib/preverif/vm0007GapReportStore.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.test.ts
@@ -39,7 +39,7 @@ describe("VM0007 uploaded PDF source identity propagation", () => {
 
     expect(result.error).toEqual({
       category: "VALIDATION_ERROR",
-      userMessage: expect.stringContaining("did not pass validation"),
+      userMessage: "Evidence Map requires all 58 canonical VM0007 requirements.",
       technicalMessage: "canonical_rule_count_is_not_58",
     });
     expect(result.error?.technicalMessage).not.toContain("Error:");


### PR DESCRIPTION
## Summary

- Added structured Evidence Map error categories: PDF parse, methodology, generation, validation, and unknown errors.
- Added parser, methodology, validation, generation, and timeout failure handling.
- Updated the UI to show safe, actionable user-facing errors without sensitive stack traces.
- Preserved successful Evidence Map generation behavior.

## Tests run

- Focused Jest tests
- `npm run typecheck`
- Targeted ESLint
- `git diff --check`