### PR TITLE
Fix remaining Evidence Map generation error path

### DIFF
--- a/src/lib/preverif/evidenceMapGenerationError.ts
+++ b/src/lib/preverif/evidenceMapGenerationError.ts
@@ -3,6 +3,7 @@ export const EVIDENCE_MAP_ERROR_CATEGORIES = [
   "METHODOLOGY_ERROR",
   "GENERATION_ERROR",
   "VALIDATION_ERROR",
+  "TIMEOUT_ERROR",
   "UNKNOWN_ERROR",
 ] as const;
 
@@ -21,11 +22,13 @@ const USER_MESSAGES: Record<EvidenceMapGenerationErrorCategory, string> = {
   METHODOLOGY_ERROR:
     "The methodology or version could not be confirmed. Select VM0007 v1.8 and retry.",
   GENERATION_ERROR:
-    "Evidence Map generation failed before it could be saved. Retry the generation.",
+    "Evidence Map generation could not be completed. Retry generation, and confirm the uploaded PDD is available.",
   VALIDATION_ERROR:
     "The generated Evidence Map did not pass validation. Retry with a VM0007 v1.8 PDD.",
+  TIMEOUT_ERROR:
+    "Evidence Map generation timed out. Retry with a smaller text-based PDD.",
   UNKNOWN_ERROR:
-    "Evidence Map generation failed unexpectedly. Retry, and contact support if the problem continues.",
+    "Evidence Map could not be created because of an unexpected problem. Retry, and contact support if it continues.",
 };
 
 function safeTechnicalMessage(value: unknown): string {
@@ -79,7 +82,7 @@ export function classifyEvidenceMapGenerationError(input: {
     };
   }
   if (/timeout|timed out|abort/i.test(text)) {
-    return createEvidenceMapGenerationError("GENERATION_ERROR", text);
+    return createEvidenceMapGenerationError("TIMEOUT_ERROR", text);
   }
   if (/pdf|parse|extract|selectable text|scanned/i.test(text)) {
     return createEvidenceMapGenerationError("PDF_PARSE_ERROR", text);
@@ -89,8 +92,8 @@ export function classifyEvidenceMapGenerationError(input: {
     return {
       ...error,
       userMessage: reasons.some((reason) => /persistence|validation/i.test(reason))
-        ? "Evidence Map draft could not be validated or saved. You can retry."
-        : "Evidence Map could not be created. You can retry.",
+        ? "Evidence Map draft could not be saved. Retry generation, and check that browser storage is available."
+        : error.userMessage,
     };
   }
   return createEvidenceMapGenerationError("UNKNOWN_ERROR", text);

--- a/src/lib/preverif/evidenceMapGenerationError.ts
+++ b/src/lib/preverif/evidenceMapGenerationError.ts
@@ -3,7 +3,6 @@ export const EVIDENCE_MAP_ERROR_CATEGORIES = [
   "METHODOLOGY_ERROR",
   "GENERATION_ERROR",
   "VALIDATION_ERROR",
-  "TIMEOUT_ERROR",
   "UNKNOWN_ERROR",
 ] as const;
 
@@ -25,8 +24,6 @@ const USER_MESSAGES: Record<EvidenceMapGenerationErrorCategory, string> = {
     "Evidence Map generation could not be completed. Retry generation, and confirm the uploaded PDD is available.",
   VALIDATION_ERROR:
     "The generated Evidence Map did not pass validation. Retry with a VM0007 v1.8 PDD.",
-  TIMEOUT_ERROR:
-    "Evidence Map generation timed out. Retry with a smaller text-based PDD.",
   UNKNOWN_ERROR:
     "Evidence Map could not be created because of an unexpected problem. Retry, and contact support if it continues.",
 };
@@ -82,7 +79,7 @@ export function classifyEvidenceMapGenerationError(input: {
     };
   }
   if (/timeout|timed out|abort/i.test(text)) {
-    return createEvidenceMapGenerationError("TIMEOUT_ERROR", text);
+    return createEvidenceMapGenerationError("GENERATION_ERROR", text);
   }
   if (/pdf|parse|extract|selectable text|scanned/i.test(text)) {
     return createEvidenceMapGenerationError("PDF_PARSE_ERROR", text);

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -59,8 +59,19 @@ export function completeVm0007EvidenceMapGeneration(input: {
   if (!input.draft.ok) return { auditSaved: true, draftBuilt: false, draftSaved: false, blockedBy: input.draft.blockedBy, auditId: input.audit.auditId, audit: input.audit, error: classifyEvidenceMapGenerationError({ blockedBy: input.draft.blockedBy }) };
   const saveDraft = input.saveDraft ?? saveVm0007EvidenceMapDraft;
   const loadDraft = input.loadDraft ?? loadVm0007EvidenceMapDraft;
-  if (!saveDraft(input.draft.package)) return { ...failedGeneration(["draft_persistence_failed"]), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
-  if (!loadDraft(input.audit.auditId)) return { ...failedGeneration(["draft_persistence_failed"]), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
+  try {
+    if (!saveDraft(input.draft.package)) return { ...failedGeneration(["draft_persistence_failed"]), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
+    if (!loadDraft(input.audit.auditId)) return { ...failedGeneration(["draft_persistence_failed"]), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
+  } catch (error) {
+    return {
+      ...failedGeneration(["draft_persistence_failed"], classifyEvidenceMapGenerationError({ error })),
+      auditSaved: true,
+      draftBuilt: true,
+      draftSaved: false,
+      auditId: input.audit.auditId,
+      audit: input.audit,
+    };
+  }
   return { auditSaved: true, draftBuilt: true, draftSaved: true, blockedBy: [], auditId: input.audit.auditId, audit: input.audit };
 }
 
@@ -176,8 +187,13 @@ export function buildAndSaveVm0007GapReportAudit(input: {
     audit: built.audit,
     sourceDocument: built.sourceDocument,
   };
-  saveVm0007GapReportAudit(record);
-  const auditSaved = loadVm0007GapReportAudit(record.auditId) !== null;
+  let auditSaved = false;
+  try {
+    saveVm0007GapReportAudit(record);
+    auditSaved = loadVm0007GapReportAudit(record.auditId) !== null;
+  } catch (error) {
+    return failedGeneration(["audit_persistence_failed"], classifyEvidenceMapGenerationError({ error }));
+  }
   if (!auditSaved) return { ...failedGeneration(["audit_persistence_failed"]), auditId: record.auditId, audit: record };
   return completeVm0007EvidenceMapGeneration({ audit: record, auditSaved: true, draft: built.draft });
 }

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -90,6 +90,25 @@ describe("Vm0007GapReportLaunchButton", () => {
     expect(onGenerate).toHaveBeenCalledTimes(1);
   });
 
+  test("renders an actionable structured generation error without the legacy fallback", async () => {
+    await act(async () => {
+      root.render(
+        <Vm0007GapReportLaunchButton
+          isVm0007Result
+          auditId="failed-audit"
+          onGenerate={jest.fn()}
+          generationError={createEvidenceMapGenerationError("GENERATION_ERROR", "localStorage quota exceeded")}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("GENERATION ERROR");
+    expect(container.textContent).toContain("Retry generation");
+    expect(container.textContent).toContain("confirm the uploaded PDD is available");
+    expect(container.textContent).not.toContain("Evidence Map could not be created. You can retry.");
+    expect(container.textContent).not.toContain("localStorage quota exceeded");
+  });
+
   test("shows a disabled helper state when VM0007 result has no audit id yet", async () => {
     await act(async () => {
       root.render(<Vm0007GapReportLaunchButton isVm0007Result auditId={null} />);

--- a/tests/lib/preverif/vm0007GapReportStore.orchestration.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.orchestration.test.ts
@@ -26,6 +26,30 @@ describe("VM0007 Evidence Map generation orchestration", () => {
     expect(completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => true, loadDraft: () => null })).toMatchObject({ draftBuilt: true, draftSaved: false, blockedBy: ["draft_persistence_failed"] });
   });
 
+  test("converts a thrown draft persistence error into the structured generation contract", () => {
+    const result = completeVm0007EvidenceMapGeneration({
+      audit,
+      auditSaved: true,
+      draft: builtDraft,
+      saveDraft: () => {
+        throw new Error("Quota exceeded while writing localStorage");
+      },
+      loadDraft: () => draftPackage,
+    });
+
+    expect(result).toMatchObject({
+      draftBuilt: true,
+      draftSaved: false,
+      blockedBy: ["draft_persistence_failed"],
+      error: {
+        category: "GENERATION_ERROR",
+        userMessage: expect.stringContaining("Retry generation"),
+        technicalMessage: "Quota exceeded while writing localStorage",
+      },
+    });
+    expect(result.error?.userMessage).not.toContain("Evidence Map could not be created. You can retry.");
+  });
+
   test("preserves internal blocker reasons while failing an unsaved audit", () => {
     const result = completeVm0007EvidenceMapGeneration({ audit, auditSaved: false, draft: builtDraft });
     expect(result).toMatchObject({ auditSaved: false, draftSaved: false, blockedBy: ["audit_persistence_failed"] });

--- a/tests/lib/preverif/vm0007GapReportStore.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.test.ts
@@ -3,11 +3,11 @@
 import { afterEach, describe, expect, test } from "@jest/globals";
 import { sha256ArrayBuffer } from "@/lib/proof/hash";
 import {
-  EVIDENCE_MAP_ERROR_CATEGORIES,
   buildAndSaveVm0007GapReportAudit,
   completeVm0007EvidenceMapGeneration,
   loadVm0007GapReportAudit,
 } from "@/lib/preverif/vm0007GapReportStore";
+import { EVIDENCE_MAP_ERROR_CATEGORIES } from "@/lib/preverif/evidenceMapGenerationError";
 import { buildVm0007EvidenceMapDraft } from "@/lib/preverif/vm0007EvidenceMapDraft";
 import {
   readQuickCheckFixtureText,

--- a/tests/lib/preverif/vm0007GapReportStore.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.test.ts
@@ -20,6 +20,23 @@ const rawPddText = readQuickCheckFixtureText(
 afterEach(() => window.localStorage.clear());
 
 describe("VM0007 uploaded PDF source identity propagation", () => {
+  test("classifies timeout failures as structured timeout errors", () => {
+    const result = completeVm0007EvidenceMapGeneration({
+      audit: { auditId: "audit-timeout" } as never,
+      auditSaved: true,
+      draft: { ok: true, package: {} as never },
+      saveDraft: () => {
+        throw new Error("Evidence Map generation timed out");
+      },
+      loadDraft: () => null,
+    });
+
+    expect(result.error).toMatchObject({
+      category: "TIMEOUT_ERROR",
+      userMessage: expect.stringContaining("timed out"),
+    });
+  });
+
   test("returns a structured validation error when draft generation is blocked", () => {
     const audit = {
       auditId: "audit-failure",

--- a/tests/lib/preverif/vm0007GapReportStore.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, test } from "@jest/globals";
 import { sha256ArrayBuffer } from "@/lib/proof/hash";
 import {
+  EVIDENCE_MAP_ERROR_CATEGORIES,
   buildAndSaveVm0007GapReportAudit,
   completeVm0007EvidenceMapGeneration,
   loadVm0007GapReportAudit,
@@ -20,7 +21,7 @@ const rawPddText = readQuickCheckFixtureText(
 afterEach(() => window.localStorage.clear());
 
 describe("VM0007 uploaded PDF source identity propagation", () => {
-  test("classifies timeout failures as structured timeout errors", () => {
+  test("classifies timeout failures as generation errors without adding a public category", () => {
     const result = completeVm0007EvidenceMapGeneration({
       audit: { auditId: "audit-timeout" } as never,
       auditSaved: true,
@@ -32,9 +33,12 @@ describe("VM0007 uploaded PDF source identity propagation", () => {
     });
 
     expect(result.error).toMatchObject({
-      category: "TIMEOUT_ERROR",
-      userMessage: expect.stringContaining("timed out"),
+      category: "GENERATION_ERROR",
+      userMessage: expect.stringContaining("Retry generation"),
+      technicalMessage: "Evidence Map generation timed out",
     });
+    expect(result.error?.category).not.toBe("TIMEOUT_ERROR");
+    expect(EVIDENCE_MAP_ERROR_CATEGORIES).not.toContain("TIMEOUT_ERROR");
   });
 
   test("returns a structured validation error when draft generation is blocked", () => {


### PR DESCRIPTION
## Summary

- Convert thrown audit/draft persistence failures into the structured Evidence Map generation error contract.
- Keep timeout failures under the existing `GENERATION_ERROR` category with timeout detail retained only in safe technical diagnostics.
- Preserve successful generation and existing methodology/validation behavior.

## Root cause

The generation orchestration assumed storage save/reload callbacks returned normally. A thrown persistence exception escaped the structured result path and reached the panel catch, where it became the legacy generic message. Audit persistence had the same uncaught boundary.

## Fix

Both persistence boundaries now return structured errors with safe technical diagnostics. Timeout failures classify as `GENERATION_ERROR`; the UI continues to render only the category and safe actionable user message in production, with technical diagnostics remaining development-only.

## Validation

- Focused Jest
- `npm run typecheck`
- Targeted ESLint on changed source/tests
- `git diff --check`
- Pre-push lint and typecheck passed

Truth artifacts, report model, PDF renderer, Evidence Map logic, and extraction pipeline were not changed. `npm run pr:gate` and full expensive suites were not run.