### PR TITLE
Add safe Evidence Map generation diagnostics

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -94,6 +94,7 @@ import {
 } from "@/lib/preverif/vm0007GapReportStore";
 import {
   classifyEvidenceMapGenerationError,
+  logEvidenceMapGenerationFailure,
   type EvidenceMapGenerationError,
 } from "@/lib/preverif/evidenceMapGenerationError";
 
@@ -1283,7 +1284,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         rules,
       });
       if (!savedAudit || !savedAudit.draftSaved || !savedAudit.auditId) {
-        setUploadVm0007GenerationError(savedAudit?.error ?? mapVm0007EvidenceMapGenerationError(savedAudit?.blockedBy ?? ["draft_persistence_failed"]));
+        const generationError = savedAudit?.error ?? mapVm0007EvidenceMapGenerationError(savedAudit?.blockedBy ?? ["draft_persistence_failed"]);
+        logEvidenceMapGenerationFailure(generationError, "quick-check-panel/upload-evidence-map");
+        setUploadVm0007GenerationError(generationError);
         return;
       }
       setUploadVm0007GapReportAuditId(savedAudit.auditId);
@@ -1534,10 +1537,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
             rules: auditRules,
           });
           vm0007GapReportAuditId = savedAudit?.draftSaved ? savedAudit.auditId ?? undefined : undefined;
-        } catch (error) {
-          if (process.env.NODE_ENV !== "production") {
-            console.error("Failed to save VM0007 gap report audit output.", error);
+          if (savedAudit && (!savedAudit.draftSaved || !savedAudit.auditId)) {
+            logEvidenceMapGenerationFailure(savedAudit.error ?? mapVm0007EvidenceMapGenerationError(savedAudit.blockedBy), "quick-check-panel/quick-check-completion");
           }
+        } catch (error) {
+          logEvidenceMapGenerationFailure(classifyEvidenceMapGenerationError({ error }), "quick-check-panel/quick-check-completion");
         }
       }
       const nextResult = buildQuickCheckResult({
@@ -2931,6 +2935,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               title="Internal VM0007 report"
               onGenerate={handleGenerateUploadVm0007GapReport}
               generationError={uploadVm0007GenerationError}
+              failureSource="quick-check-panel/upload-evidence-map"
               generating={generatingUploadVm0007GapReport}
               generateDisabled={!canGenerateUploadVm0007Report}
               testId="vm0007-upload-report-section"

--- a/src/components/preverif/Vm0007GapReportLaunchButton.tsx
+++ b/src/components/preverif/Vm0007GapReportLaunchButton.tsx
@@ -19,6 +19,7 @@ type Vm0007GapReportLaunchButtonProps = {
   generationError?: EvidenceMapGenerationError | null;
   generating?: boolean;
   generateDisabled?: boolean;
+  failureSource?: string;
   testId?: string;
 };
 
@@ -30,6 +31,7 @@ export default function Vm0007GapReportLaunchButton({
   generationError = null,
   generating = false,
   generateDisabled = false,
+  failureSource,
   testId = "vm0007-internal-report-section",
 }: Vm0007GapReportLaunchButtonProps) {
   const [draftPackage, setDraftPackage] = useState<Vm0007EvidenceMapDraftPackage | null>(null);
@@ -73,6 +75,12 @@ export default function Vm0007GapReportLaunchButton({
             <div className="mt-2 text-sm text-amber-800" role="alert" data-testid="evidence-map-generation-error">
               <strong className="font-semibold">{generationError.category.replaceAll("_", " ")}</strong>
               <span className="ml-2">{generationError.userMessage}</span>
+              {process.env.NODE_ENV !== "production" ? (
+                <div className="mt-2 border-t border-amber-200 pt-2 text-xs text-amber-900" data-testid="evidence-map-generation-diagnostics">
+                  <div><span className="font-semibold">Technical:</span> {generationError.technicalMessage}</div>
+                  {failureSource ? <div><span className="font-semibold">Source:</span> {failureSource}</div> : null}
+                </div>
+              ) : null}
             </div>
           ) : null}
           <div className="mt-2 text-sm text-slate-600">

--- a/src/lib/preverif/evidenceMapGenerationError.ts
+++ b/src/lib/preverif/evidenceMapGenerationError.ts
@@ -15,6 +15,27 @@ export type EvidenceMapGenerationError = {
   technicalMessage: string;
 };
 
+export type EvidenceMapGenerationFailureLog = EvidenceMapGenerationError & {
+  timestamp: string;
+  source: string;
+};
+
+/** Log only the structured, sanitized failure details. Never pass document data here. */
+export function logEvidenceMapGenerationFailure(
+  error: EvidenceMapGenerationError,
+  source: string,
+  timestamp = new Date().toISOString(),
+): void {
+  const entry: EvidenceMapGenerationFailureLog = {
+    category: error.category,
+    userMessage: error.userMessage,
+    technicalMessage: error.technicalMessage,
+    timestamp,
+    source,
+  };
+  console.error(entry);
+}
+
 const USER_MESSAGES: Record<EvidenceMapGenerationErrorCategory, string> = {
   PDF_PARSE_ERROR:
     "The PDF could not be read. Upload a text-based PDF or retry the upload.",

--- a/tests/components/vm0007GapReportLaunchButton.test.tsx
+++ b/tests/components/vm0007GapReportLaunchButton.test.tsx
@@ -11,6 +11,7 @@ import { createEvidenceMapGenerationError } from "@/lib/preverif/evidenceMapGene
 describe("Vm0007GapReportLaunchButton", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
     container = document.createElement("div");
@@ -25,6 +26,7 @@ describe("Vm0007GapReportLaunchButton", () => {
     });
     container.remove();
     window.localStorage.clear();
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
   function makeDraft(auditId: string): Vm0007EvidenceMapDraftPackage {
@@ -88,6 +90,46 @@ describe("Vm0007GapReportLaunchButton", () => {
     expect(container.textContent).toContain("Retry Evidence Map");
     container.querySelector("button")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows technical diagnostics and source outside production", async () => {
+    process.env.NODE_ENV = "development";
+    await act(async () => {
+      root.render(
+        <Vm0007GapReportLaunchButton
+          isVm0007Result
+          auditId="stale-audit"
+          onGenerate={jest.fn()}
+          failureSource="quick-check-panel/upload-evidence-map"
+          generationError={createEvidenceMapGenerationError("GENERATION_ERROR", "draft persistence failed: duplicate audit id")}
+        />,
+      );
+    });
+
+    expect(container.querySelector('[data-testid="evidence-map-generation-diagnostics"]')?.textContent).toContain(
+      "Technical: draft persistence failed: duplicate audit id",
+    );
+    expect(container.textContent).toContain("Source: quick-check-panel/upload-evidence-map");
+  });
+
+  test("hides technical diagnostics in production", async () => {
+    process.env.NODE_ENV = "production";
+    await act(async () => {
+      root.render(
+        <Vm0007GapReportLaunchButton
+          isVm0007Result
+          auditId="stale-audit"
+          onGenerate={jest.fn()}
+          failureSource="quick-check-panel/upload-evidence-map"
+          generationError={createEvidenceMapGenerationError("GENERATION_ERROR", "draft persistence failed: duplicate audit id")}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("GENERATION ERROR");
+    expect(container.textContent).toContain("Evidence Map generation failed before it could be saved");
+    expect(container.querySelector('[data-testid="evidence-map-generation-diagnostics"]')).toBeNull();
+    expect(container.textContent).not.toContain("duplicate audit id");
   });
 
   test("shows a disabled helper state when VM0007 result has no audit id yet", async () => {

--- a/tests/lib/preverif/evidenceMapGenerationError.test.ts
+++ b/tests/lib/preverif/evidenceMapGenerationError.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  createEvidenceMapGenerationError,
+  logEvidenceMapGenerationFailure,
+} from "@/lib/preverif/evidenceMapGenerationError";
+
+describe("Evidence Map generation diagnostics", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test("logs structured failure details without changing the error", () => {
+    const error = createEvidenceMapGenerationError("GENERATION_ERROR", "draft persistence failed: duplicate audit id");
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+    logEvidenceMapGenerationFailure(error, "quick-check-panel/upload-evidence-map", "2026-07-21T00:00:00.000Z");
+
+    expect(error).toEqual({
+      category: "GENERATION_ERROR",
+      userMessage: "Evidence Map generation failed before it could be saved. Retry the generation.",
+      technicalMessage: "draft persistence failed: duplicate audit id",
+    });
+    expect(consoleError).toHaveBeenCalledWith({
+      ...error,
+      timestamp: "2026-07-21T00:00:00.000Z",
+      source: "quick-check-panel/upload-evidence-map",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- show technical Evidence Map generation diagnostics only in non-production environments
- log structured generation failures with category, safe messages, timestamp, and source
- preserve the existing user-facing error contract and add regression coverage

## Safety review

- Technical diagnostics are gated by `NODE_ENV !== "production"`.
- The changed UI does not feed technical errors into report or PDF rendering.
- No PDD, client-document, evidence text, or truth artifact is added to the diagnostic log payload.
- Error categories and the existing `{ category, userMessage, technicalMessage }` contract remain unchanged.
- The diff is limited to the generation UI/logging path and focused tests.

## Validation

- Focused Jest: 4 suites, 15 tests passed
- `npm run typecheck`
- Targeted ESLint and pre-push lint/typecheck
- `git diff --check`
- Dev server startup verified

`npm run pr:gate` and full suites were not run, per request.