### PR TITLE
Fix Marcondes priority gap presentation parity

### DIFF
--- a/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
+++ b/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
@@ -1,21 +1,60 @@
 import type { Metadata } from "next";
 import { buildMarcondesPreValidationReadinessReport } from "@/lib/preverif/marcondesPreValidationReport";
-import { buildMarcondesClientReportPresentation, clientRuleFields, type ClientPriorityGapPresentation } from "@/lib/preverif/marcondesClientReportPresentation";
+import { buildMarcondesClientReportPresentation, clientRuleFields } from "@/lib/preverif/marcondesClientReportPresentation";
+import { buildMarcondesPriorityGapPresentation, marcondesPriorityGapFields } from "@/lib/preverif/marcondesPriorityGapPresentation";
 
 export const metadata: Metadata = {
   title: "Marcondes VM0007 v1.8 Pre-Validation Readiness Report | app.article6",
 };
 
-function PriorityGapGroup({ label, gaps }: { label: string; gaps: ClientPriorityGapPresentation[] }) {
+function clientFacingRationale(rationale: string): string {
+  return rationale.replace(
+    /^Manual review replaced the machine-selected(?: truncated or mislocated)? evidence(?: for [^ ]+)? with PDF-backed evidence\.\s*/i,
+    "The reviewer validated and corrected the machine proposal using PDF-backed project evidence. ",
+  );
+}
+
+function rejectedEvidenceSummary(reason: string | undefined): string {
+  if (!reason) return "The cited material was not accepted as sufficient support for this requirement.";
+  if (/incomplete|noisy|truncated|mislocated/i.test(reason)) return "The source excerpt was incomplete, noisy, or not located at the authoritative project evidence needed for this requirement.";
+  if (/applicability|scope|aligned/i.test(reason)) return "The project-specific excerpt did not directly establish the applicability or scope required by this requirement.";
+  return "The cited material did not provide sufficient project-specific support for this requirement.";
+}
+
+function PriorityGapGroup({ label, gaps }: { label: string; gaps: ReturnType<typeof buildMarcondesPriorityGapPresentation> }) {
   return <div className="mt-4" data-testid={`priority-gap-group-${label.toLowerCase().replaceAll(" ", "-")}`}>
     <h3 className="text-lg font-semibold text-slate-900">{label} <span className="text-sm font-normal text-slate-500">({gaps.length})</span></h3>
     <div className="mt-2 grid gap-3">{gaps.map((gap) => <article key={gap.ruleId} className="rounded-xl border border-slate-200 bg-slate-50 p-4" data-testid="priority-gap-card">
-      <div className="flex flex-wrap items-baseline justify-between gap-2"><h4 className="font-semibold text-slate-950">{gap.title}</h4><span className="text-sm text-slate-600">Rule ID: {gap.ruleId}</span></div>
-      <p className="mt-2 text-sm"><strong>Evidence status:</strong> {gap.evidenceStatus}</p>
-      <p className="mt-2 text-sm"><strong>Why it matters:</strong> {gap.whyItMatters}</p>
-      <p className="mt-2 text-sm"><strong>Required action:</strong> {gap.requiredAction}</p>
+      {marcondesPriorityGapFields(gap).map(({ label, value }) => <p className="mt-2 text-sm" key={label}><strong>{label}:</strong> {value}</p>)}
     </article>)}</div>
   </div>;
+}
+
+function EvidenceList({ label, evidence, rejected = false }: { label: string; evidence: unknown[]; rejected?: boolean }) {
+  return (
+    <div>
+      <h4 className="font-medium text-slate-700">{label}</h4>
+      {evidence.length === 0 ? <p className="text-slate-500">None recorded.</p> : (
+        <ul className="mt-1 space-y-1">
+          {evidence.map((item, index) => {
+            const entry = item as { quote?: string; page?: number; section?: string; rejectionReason?: string; provenance?: { docId?: string; page?: number; sectionHeading?: string } };
+            const page = entry.page ?? entry.provenance?.page;
+            const section = entry.section ?? entry.provenance?.sectionHeading;
+            if (rejected) return <li key={`${page ?? "none"}-${index}`} className="rounded border border-amber-200 bg-amber-50 p-3">
+              <div className="font-medium text-amber-950">Rejected evidence</div>
+              <div className="mt-1 text-sm"><strong>Source:</strong> {entry.provenance?.docId ?? "Project document"}{page ? `, page ${page}` : ""}{section ? `, ${section}` : ""}</div>
+              <div className="mt-1 text-sm"><strong>Reason rejected:</strong> {entry.rejectionReason ?? "Not accepted as sufficient support."}</div>
+              <div className="mt-1 text-sm"><strong>Summary:</strong> {rejectedEvidenceSummary(entry.rejectionReason)}</div>
+              <details className="mt-2 text-sm"><summary className="cursor-pointer font-medium">View original rejected evidence</summary><p className="mt-1 whitespace-pre-wrap">{entry.quote ?? "No quote recorded."}</p></details>
+            </li>;
+            return <li key={`${page ?? "none"}-${index}`} className="rounded border border-slate-200 bg-slate-50 p-2">
+              {entry.quote ?? "No quote recorded."}{page ? ` (page ${page})` : ""}{section ? ` — ${section}` : ""}
+            </li>;
+          })}
+        </ul>
+      )}
+    </div>
+  );
 }
 
 export default async function MarcondesPreValidationReadinessPage({ params }: { params: Promise<{ auditId: string }> }) {
@@ -24,9 +63,10 @@ export default async function MarcondesPreValidationReadinessPage({ params }: { 
   const counts = report.executiveSummary.evidenceStateCounts;
   const outcomes = report.executiveSummary.reviewerOutcomeCounts;
   const presentation = buildMarcondesClientReportPresentation(report);
-  const missingGaps = presentation.priorityGaps.filter((gap) => gap.evidenceStatus === "MISSING");
-  const unclearGaps = presentation.priorityGaps.filter((gap) => gap.evidenceStatus === "UNCLEAR");
-  const otherGaps = presentation.priorityGaps.filter((gap) => gap.evidenceStatus !== "MISSING" && gap.evidenceStatus !== "UNCLEAR");
+  const priorityGaps = buildMarcondesPriorityGapPresentation(report);
+  const missingGaps = priorityGaps.filter((gap) => gap.evidenceStatus === "MISSING");
+  const unclearGaps = priorityGaps.filter((gap) => gap.evidenceStatus === "UNCLEAR");
+  const otherGaps = priorityGaps.filter((gap) => gap.evidenceStatus !== "MISSING" && gap.evidenceStatus !== "UNCLEAR");
   return (
     <main className="min-h-screen bg-slate-50 px-4 py-8" data-testid="marcondes-prevalidation-readiness-report">
       <div className="mx-auto grid max-w-6xl gap-6">
@@ -67,7 +107,7 @@ export default async function MarcondesPreValidationReadinessPage({ params }: { 
           <h2 id="priority-gaps" className="text-xl font-semibold">Priority Gaps</h2>
           <p className="mt-2 text-slate-700">Client-facing risk summary of the reviewed requirements requiring follow-up.</p>
           <div className="mt-4 grid gap-3 sm:grid-cols-3" data-testid="priority-gap-counts">
-            <div className="rounded-lg border border-slate-200 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Total action required</div><div className="text-2xl font-semibold">{presentation.priorityGaps.length}</div></div>
+            <div className="rounded-lg border border-slate-200 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Total action required</div><div className="text-2xl font-semibold">{priorityGaps.length}</div></div>
             <div className="rounded-lg border border-slate-200 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Unclear evidence</div><div className="text-2xl font-semibold">{unclearGaps.length}</div></div>
             <div className="rounded-lg border border-slate-200 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Missing evidence</div><div className="text-2xl font-semibold">{missingGaps.length}</div></div>
           </div>

--- a/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
+++ b/src/app/internal/reports/prevalidation/marcondes/[auditId]/page.tsx
@@ -7,20 +7,6 @@ export const metadata: Metadata = {
   title: "Marcondes VM0007 v1.8 Pre-Validation Readiness Report | app.article6",
 };
 
-function clientFacingRationale(rationale: string): string {
-  return rationale.replace(
-    /^Manual review replaced the machine-selected(?: truncated or mislocated)? evidence(?: for [^ ]+)? with PDF-backed evidence\.\s*/i,
-    "The reviewer validated and corrected the machine proposal using PDF-backed project evidence. ",
-  );
-}
-
-function rejectedEvidenceSummary(reason: string | undefined): string {
-  if (!reason) return "The cited material was not accepted as sufficient support for this requirement.";
-  if (/incomplete|noisy|truncated|mislocated/i.test(reason)) return "The source excerpt was incomplete, noisy, or not located at the authoritative project evidence needed for this requirement.";
-  if (/applicability|scope|aligned/i.test(reason)) return "The project-specific excerpt did not directly establish the applicability or scope required by this requirement.";
-  return "The cited material did not provide sufficient project-specific support for this requirement.";
-}
-
 function PriorityGapGroup({ label, gaps }: { label: string; gaps: ReturnType<typeof buildMarcondesPriorityGapPresentation> }) {
   return <div className="mt-4" data-testid={`priority-gap-group-${label.toLowerCase().replaceAll(" ", "-")}`}>
     <h3 className="text-lg font-semibold text-slate-900">{label} <span className="text-sm font-normal text-slate-500">({gaps.length})</span></h3>
@@ -28,33 +14,6 @@ function PriorityGapGroup({ label, gaps }: { label: string; gaps: ReturnType<typ
       {marcondesPriorityGapFields(gap).map(({ label, value }) => <p className="mt-2 text-sm" key={label}><strong>{label}:</strong> {value}</p>)}
     </article>)}</div>
   </div>;
-}
-
-function EvidenceList({ label, evidence, rejected = false }: { label: string; evidence: unknown[]; rejected?: boolean }) {
-  return (
-    <div>
-      <h4 className="font-medium text-slate-700">{label}</h4>
-      {evidence.length === 0 ? <p className="text-slate-500">None recorded.</p> : (
-        <ul className="mt-1 space-y-1">
-          {evidence.map((item, index) => {
-            const entry = item as { quote?: string; page?: number; section?: string; rejectionReason?: string; provenance?: { docId?: string; page?: number; sectionHeading?: string } };
-            const page = entry.page ?? entry.provenance?.page;
-            const section = entry.section ?? entry.provenance?.sectionHeading;
-            if (rejected) return <li key={`${page ?? "none"}-${index}`} className="rounded border border-amber-200 bg-amber-50 p-3">
-              <div className="font-medium text-amber-950">Rejected evidence</div>
-              <div className="mt-1 text-sm"><strong>Source:</strong> {entry.provenance?.docId ?? "Project document"}{page ? `, page ${page}` : ""}{section ? `, ${section}` : ""}</div>
-              <div className="mt-1 text-sm"><strong>Reason rejected:</strong> {entry.rejectionReason ?? "Not accepted as sufficient support."}</div>
-              <div className="mt-1 text-sm"><strong>Summary:</strong> {rejectedEvidenceSummary(entry.rejectionReason)}</div>
-              <details className="mt-2 text-sm"><summary className="cursor-pointer font-medium">View original rejected evidence</summary><p className="mt-1 whitespace-pre-wrap">{entry.quote ?? "No quote recorded."}</p></details>
-            </li>;
-            return <li key={`${page ?? "none"}-${index}`} className="rounded border border-slate-200 bg-slate-50 p-2">
-              {entry.quote ?? "No quote recorded."}{page ? ` (page ${page})` : ""}{section ? ` — ${section}` : ""}
-            </li>;
-          })}
-        </ul>
-      )}
-    </div>
-  );
 }
 
 export default async function MarcondesPreValidationReadinessPage({ params }: { params: Promise<{ auditId: string }> }) {

--- a/src/lib/preverif/marcondesPreValidationPdf.ts
+++ b/src/lib/preverif/marcondesPreValidationPdf.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { MarcondesPreValidationReadinessReport } from "./marcondesPreValidationReport";
 import { buildMarcondesClientReportPresentation, clientRuleFields } from "./marcondesClientReportPresentation";
+import { buildMarcondesPriorityGapPresentation, marcondesPriorityGapFields } from "./marcondesPriorityGapPresentation";
 
 type FontDefinition = {
   file: Buffer;
@@ -207,14 +208,14 @@ function assemble(streams: string[], codePoints: readonly number[]): Buffer {
 export function buildMarcondesPreValidationPdf(report: MarcondesPreValidationReadinessReport): Buffer {
   const counts = report.executiveSummary.evidenceStateCounts;
   const presentation = buildMarcondesPreValidationPdfPresentation(report);
-  const priorityGaps = ["MISSING", "UNCLEAR", "OTHER"].flatMap((state) => presentation.priorityGaps.filter((gap) => state === "OTHER" ? gap.evidenceStatus !== "MISSING" && gap.evidenceStatus !== "UNCLEAR" : gap.evidenceStatus === state));
+  const priorityGaps = buildMarcondesPriorityGapPresentation(report);
   const sections: Array<{ title: string; lines: PdfLine[] }> = [
     { title: report.title, lines: [textLine("Internal Release Candidate"), textLine(`${report.project} | ${report.methodology}`), textLine(report.releaseStatus)] },
     { title: "Executive Summary", lines: [textLine(report.executiveSummary.readinessSummary), field("Rules reviewed", String(report.executiveSummary.rulesReviewed)), textLine(`FOUND: ${counts.FOUND} | UNCLEAR: ${counts.UNCLEAR} | MISSING: ${counts.MISSING} | N/A: ${counts["N/A"]}`), ...report.executiveSummary.keyLimitations.map(textLine)] },
     { title: "Project Overview", lines: [field("Project", report.project), field("Methodology", report.methodology), textLine("Scope: independent pre-validation readiness review based on the finalized Evidence Map report model.")] },
     { title: "Methodology Reconciliation", lines: [field("Page 61 reference", report.methodologyReview.page61Reference), textLine(report.methodologyReview.declarations), field("Classification", report.methodologyReview.classification), textLine(report.methodologyReview.explanation), field("Release blocker", report.methodologyReview.blocker)] },
     { title: "Readiness Summary", lines: [textLine(`Reviewer outcomes: ${Object.entries(report.executiveSummary.reviewerOutcomeCounts).map(([key, value]) => `${key}: ${value}`).join(" | ")}`), textLine(report.executiveSummary.readinessSummary)] },
-    { title: "Priority Gaps", lines: priorityGaps.flatMap((gap) => [field("Rule ID", gap.ruleId), field("Title", gap.title), field("Evidence status", gap.evidenceStatus), field("Why it matters", gap.whyItMatters), field("Required action", gap.requiredAction), textLine("")]) },
+    { title: "Priority Gaps", lines: priorityGaps.flatMap((gap) => marcondesPriorityGapFields(gap).map(({ label, value }) => field(label, value)).concat(textLine(""))) },
     ...presentation.rules.map((rule, index) => ({ title: `Rule Appendix ${index + 1} of ${presentation.rules.length}`, lines: clientRuleFields(rule).map(({ label, value }) => field(label, value)) })),
     { title: "Disclaimer", lines: [textLine("This document is an independent pre-validation readiness review and internal release candidate."), textLine("It does not provide a final assurance conclusion or positive release determination."), field("Release state", report.releaseStatus)] },
   ];

--- a/src/lib/preverif/marcondesPriorityGapPresentation.ts
+++ b/src/lib/preverif/marcondesPriorityGapPresentation.ts
@@ -1,0 +1,86 @@
+import type { MarcondesPreValidationReadinessReport } from "./marcondesPreValidationReport";
+
+export const PRIORITY_GAP_HEADINGS = ["Rule ID", "Title", "Evidence status", "Why it matters", "Required action"] as const;
+
+export type MarcondesPriorityGapField = {
+  label: (typeof PRIORITY_GAP_HEADINGS)[number];
+  value: string;
+};
+
+export type MarcondesPriorityGapPresentation = {
+  ruleId: string;
+  title: string;
+  evidenceStatus: string;
+  whyItMatters: string;
+  requiredAction: string;
+  fields: MarcondesPriorityGapField[];
+};
+
+type ReportPriorityGap = MarcondesPreValidationReadinessReport["priorityGaps"][number];
+
+function clientFacingRationale(rationale: string): string {
+  return rationale.replace(
+    /^Manual review replaced the machine-selected(?: truncated or mislocated)? evidence(?: for [^ ]+)? with PDF-backed evidence\.\s*/i,
+    "The reviewer validated and corrected the machine proposal using PDF-backed project evidence. ",
+  );
+}
+
+function normalizedText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function isNearDuplicate(left: string, right: string): boolean {
+  const normalizedLeft = normalizedText(left);
+  const normalizedRight = normalizedText(right);
+  if (!normalizedLeft || !normalizedRight) return false;
+  if (normalizedLeft === normalizedRight || normalizedLeft.includes(normalizedRight) || normalizedRight.includes(normalizedLeft)) return true;
+  const leftWords = new Set(normalizedLeft.split(" "));
+  const rightWords = new Set(normalizedRight.split(" "));
+  const overlap = [...leftWords].filter((word) => rightWords.has(word)).length;
+  return overlap / Math.max(leftWords.size, rightWords.size) >= 0.85;
+}
+
+function priorityGapWhyItMatters(gap: ReportPriorityGap): string {
+  const why = clientFacingRationale(gap.whyItMatters);
+  if (!gap.action || !isNearDuplicate(why, gap.action)) return why;
+  const title = gap.title.toLowerCase();
+  if (gap.state === "MISSING") return `The reviewed record for ${title} is marked MISSING, so project-specific support is not yet available for this requirement.`;
+  if (gap.state === "UNCLEAR") return `The reviewed record for ${title} is UNCLEAR, so the available support does not yet establish a clear readiness position.`;
+  return `The existing reviewer rationale identifies follow-up needed for ${title} before readiness can be concluded.`;
+}
+
+type MarcondesPriorityGapValues = Omit<MarcondesPriorityGapPresentation, "fields">;
+
+function priorityGapFields(gap: MarcondesPriorityGapValues): MarcondesPriorityGapField[] {
+  return [
+    { label: "Rule ID", value: gap.ruleId },
+    { label: "Title", value: gap.title },
+    { label: "Evidence status", value: gap.evidenceStatus },
+    { label: "Why it matters", value: gap.whyItMatters },
+    { label: "Required action", value: gap.requiredAction },
+  ];
+}
+
+function buildPriorityGap(gap: ReportPriorityGap): MarcondesPriorityGapPresentation {
+  const presentation = {
+    ruleId: gap.displayRuleId,
+    title: gap.title,
+    evidenceStatus: gap.state,
+    whyItMatters: priorityGapWhyItMatters(gap),
+    requiredAction: gap.action ?? "Reviewer action is recorded in the Evidence Map.",
+  };
+  return { ...presentation, fields: priorityGapFields(presentation) };
+}
+
+export function buildMarcondesPriorityGapPresentation(report: MarcondesPreValidationReadinessReport): MarcondesPriorityGapPresentation[] {
+  const gaps = report.priorityGaps.map(buildPriorityGap);
+  return [
+    ...gaps.filter((gap) => gap.evidenceStatus === "MISSING"),
+    ...gaps.filter((gap) => gap.evidenceStatus === "UNCLEAR"),
+    ...gaps.filter((gap) => gap.evidenceStatus !== "MISSING" && gap.evidenceStatus !== "UNCLEAR"),
+  ];
+}
+
+export function marcondesPriorityGapFields(gap: MarcondesPriorityGapPresentation): MarcondesPriorityGapField[] {
+  return gap.fields;
+}

--- a/tests/lib/preverif/marcondesPriorityGapPresentation.test.ts
+++ b/tests/lib/preverif/marcondesPriorityGapPresentation.test.ts
@@ -1,0 +1,75 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import MarcondesPreValidationReadinessPage from "@/app/internal/reports/prevalidation/marcondes/[auditId]/page";
+import { buildMarcondesPreValidationReadinessReport } from "@/lib/preverif/marcondesPreValidationReport";
+import {
+  buildMarcondesPriorityGapPresentation,
+  marcondesPriorityGapFields,
+  PRIORITY_GAP_HEADINGS,
+} from "@/lib/preverif/marcondesPriorityGapPresentation";
+import { buildMarcondesPreValidationPdf } from "@/lib/preverif/marcondesPreValidationPdf";
+
+function visibleText(html: string): string {
+  return html.replace(/<[^>]+>/g, "").replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&#x27;/g, "'").replace(/&quot;/g, '"');
+}
+
+function decodePdfText(pdf: string): string {
+  const unicodeMaps = [...pdf.matchAll(/\/CIDInit[\s\S]*?endcmap/g)].map((match) => {
+    const map = new Map<number, number>();
+    for (const [, source, target] of match[0].matchAll(/<([0-9A-Fa-f]{4})> <([0-9A-Fa-f]{4})>/g)) map.set(Number.parseInt(source, 16), Number.parseInt(target, 16));
+    return map;
+  });
+  return [...pdf.matchAll(/\/F[12] \d+ Tf|(\((?:\\.|[^\\)])*\)|<[0-9A-F]+>) Tj/g)].flatMap(([, encoded]) => {
+    if (!encoded) return [];
+    if (encoded.startsWith("(")) return [encoded.slice(1, -1).replace(/\\([\\()])/g, "$1")];
+    const bytes = Buffer.from(encoded.slice(1, -1), "hex");
+    let text = "";
+    for (let index = 0; index < bytes.length; index += 2) text += String.fromCodePoint(unicodeMaps[0]?.get(bytes[index] * 256 + bytes[index + 1]) ?? 0xfffd);
+    return [text];
+  }).join(" ");
+}
+
+function appearsInOrder(text: string, values: string[]): boolean {
+  let offset = 0;
+  for (const value of values) {
+    const index = text.indexOf(value, offset);
+    if (index < 0) return false;
+    offset = index + value.length;
+  }
+  return true;
+}
+
+describe("Marcondes Priority Gap presentation parity", () => {
+  it("defines the required shared field order and values", () => {
+    const gaps = buildMarcondesPriorityGapPresentation(buildMarcondesPreValidationReadinessReport());
+
+    expect(gaps).toHaveLength(30);
+    for (const gap of gaps) {
+      expect(marcondesPriorityGapFields(gap).map(({ label }) => label)).toEqual(PRIORITY_GAP_HEADINGS);
+      expect(marcondesPriorityGapFields(gap).map(({ value }) => value)).toEqual([
+        gap.ruleId,
+        gap.title,
+        gap.evidenceStatus,
+        gap.whyItMatters,
+        gap.requiredAction,
+      ]);
+    }
+  });
+
+  it("uses the same ordered fields in the website and PDF renderers", async () => {
+    const report = buildMarcondesPreValidationReadinessReport();
+    const gaps = buildMarcondesPriorityGapPresentation(report);
+    const html = visibleText(renderToStaticMarkup(await MarcondesPreValidationReadinessPage({ params: Promise.resolve({ auditId: "marcondes-redd-5953" }) })));
+    const pdf = decodePdfText(buildMarcondesPreValidationPdf(report).toString("latin1"));
+
+    const expectedHtmlFields = gaps.flatMap((gap) => marcondesPriorityGapFields(gap).map(({ label, value }) => `${label}: ${value}`));
+    expect(appearsInOrder(html, expectedHtmlFields)).toBe(true);
+
+    const priorityGapPdf = pdf.slice(pdf.indexOf("Priority Gaps"), pdf.indexOf("Rule Appendix"));
+    const normalizedPriorityGapPdf = priorityGapPdf.replace(/\s+/g, " ");
+    expect((normalizedPriorityGapPdf.match(/Rule ID:/g) ?? []).length).toBe(gaps.length);
+    expect((normalizedPriorityGapPdf.match(/Title:/g) ?? []).length).toBe(gaps.length);
+    expect((normalizedPriorityGapPdf.match(/Evidence status:/g) ?? []).length).toBe(gaps.length);
+    expect((normalizedPriorityGapPdf.match(/Why it matters:/g) ?? []).length).toBe(gaps.length);
+    expect((normalizedPriorityGapPdf.match(/Required action:/g) ?? []).length).toBe(gaps.length);
+  });
+});


### PR DESCRIPTION
Make Priority Gap presentation match the shared contract already used by the appendix.

This moves Priority Gaps to one shared presentation model consumed by both the website renderer and the PDF renderer, so both surfaces emit the same field order and strings without touching appendix rendering or truth artifacts.

Checks: focused Priority Gap parity tests, existing presentation tests, typecheck, targeted lint, git diff --check, and a local dev-server smoke test.
