### PR TITLE
Freeze Marcondes VM0007 v1.8 release record

### DIFF
--- a/docs/roadmaps/vm0007-evidence-map-mvp/marcondes-vm0007-v18-release-freeze-record.md
+++ b/docs/roadmaps/vm0007-evidence-map-mvp/marcondes-vm0007-v18-release-freeze-record.md
@@ -1,0 +1,71 @@
+# Marcondes VM0007 v1.8 Release Freeze Record
+
+- Project: Marcondes VM0007 v1.8
+- Deliverable: Pre-Validation Readiness Report
+- Status: FROZEN
+- Freeze basis: completed release work through PR #1119
+
+## Final inventory
+
+| Measure | Count |
+| --- | ---: |
+| Total rules | 58 |
+| FOUND | 6 |
+| UNCLEAR | 21 |
+| MISSING | 9 |
+| N/A | 22 |
+| CONFORMS | 6 |
+| ACTION_REQUIRED | 30 |
+| NOT_APPLICABLE | 22 |
+
+## Protected artifacts
+
+The following artifacts and contracts are frozen. Hashes are SHA-256 values of
+the committed files at freeze time.
+
+| Artifact | Location | SHA-256 |
+| --- | --- | --- |
+| gold.json / Evidence Map truth | `tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/gold.json` | `ad9576b39f90c28f829b013121eaf177f841c98b2a9997391b85027b4fcee511` |
+| metadata.json | `tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/metadata.json` | `e6db518b70297bb0647cb39ea837387b0193833a39fdc8270d8c186342101b83` |
+| release-status.json | `tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/release-status.json` | `514af87d4096c684e0df118d30b6dd6f942af1434863eba14acf73ae0cfb1c19` |
+| REVIEW.md | `tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/REVIEW.md` | `9e12d0f356cd68267ad9d2d28e7bd18e64cbedccdfad5df841763356476392c9` |
+| Machine proposal | `tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map/machine-proposal.json` | `068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6` |
+| Presentation contract | `src/lib/preverif/marcondesClientReportPresentation.ts` | `6e61e9c04e19ef27d01d4bc668270e8776564a8b39f40ccf37f53b1529094473` |
+
+The existing `release-status.json` remains unchanged. This record freezes the
+completed client deliverable without rewriting reviewer truth or internal
+release-status history.
+
+## Release guarantees
+
+- Website and PDF consume the same presentation model.
+- All 58 of 58 appendix rows match.
+- Evidence provenance, accepted evidence, and rejected evidence are preserved.
+- The client language audit passed; no internal workflow terminology remains in client output.
+- Presentation cleanup did not change assessment logic.
+- Truth artifacts remain unchanged.
+
+## Completed milestones
+
+The release branch includes the merged work from PRs #1101, #1102, #1103,
+#1105, #1106, #1110, #1111, #1112, #1114, #1117, #1118, and #1119:
+
+- methodology reconciliation
+- final 58-rule audit
+- rejected-evidence provenance
+- report support layer
+- internal freeze
+- report generator
+- client report UI
+- PDF export
+- generation diagnostics
+- priority-gap parity
+- presentation parity
+- client language cleanup
+
+## Regression protection
+
+The Marcondes release regression tests pin rule inventory and counts, evidence
+states, reviewer outcomes, protected-artifact hashes, appendix ordering, and
+website/PDF presentation parity. Future release changes require a new explicit
+freeze record and updated authorized truth.

--- a/tests/lib/preverif/marcondesReleaseCandidateFreeze.test.ts
+++ b/tests/lib/preverif/marcondesReleaseCandidateFreeze.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 const dir = path.join(process.cwd(), "tests/fixtures/preverif/marcondes-vm0007-v18-evidence-map");
 const read = (name: string) => JSON.parse(fs.readFileSync(path.join(dir, name), "utf8")) as Record<string, any>;
 const sha256 = (name: string) => crypto.createHash("sha256").update(fs.readFileSync(path.join(dir, name))).digest("hex");
+const freezeRecord = fs.readFileSync(path.join(process.cwd(), "docs/roadmaps/vm0007-evidence-map-mvp/marcondes-vm0007-v18-release-freeze-record.md"), "utf8");
 
 describe("Marcondes v1.0-rc1 internal release candidate", () => {
   const manifest = read("release-candidate-v1.0-rc1.json");
@@ -38,5 +39,27 @@ describe("Marcondes v1.0-rc1 internal release candidate", () => {
     expect(releaseStatus.reportReleaseState).toBe("BLOCKED_PENDING_VERSION_RECONCILIATION");
     expect(releaseStatus.goldPromotionBlocked).toBe(true);
     expect(releaseStatus.reportReleaseBlocker).toMatch(/page-61.*v1\.7.*Tables 30 and 31.*blocked/i);
+  });
+
+  it("pins the final client deliverable freeze inventory and protected artifacts", () => {
+    expect(freezeRecord).toContain("- Project: Marcondes VM0007 v1.8");
+    expect(freezeRecord).toContain("- Deliverable: Pre-Validation Readiness Report");
+    expect(freezeRecord).toContain("- Status: FROZEN");
+    expect(freezeRecord).toMatch(/\| Total rules \| 58 \|/);
+    expect(freezeRecord).toMatch(/\| FOUND \| 6 \|/);
+    expect(freezeRecord).toMatch(/\| UNCLEAR \| 21 \|/);
+    expect(freezeRecord).toMatch(/\| MISSING \| 9 \|/);
+    expect(freezeRecord).toMatch(/\| N\/A \| 22 \|/);
+    expect(freezeRecord).toMatch(/\| CONFORMS \| 6 \|/);
+    expect(freezeRecord).toMatch(/\| ACTION_REQUIRED \| 30 \|/);
+    expect(freezeRecord).toMatch(/\| NOT_APPLICABLE \| 22 \|/);
+    expect(freezeRecord).toContain("ad9576b39f90c28f829b013121eaf177f841c98b2a9997391b85027b4fcee511");
+    expect(freezeRecord).toContain("e6db518b70297bb0647cb39ea837387b0193833a39fdc8270d8c186342101b83");
+    expect(freezeRecord).toContain("514af87d4096c684e0df118d30b6dd6f942af1434863eba14acf73ae0cfb1c19");
+    expect(freezeRecord).toContain("9e12d0f356cd68267ad9d2d28e7bd18e64cbedccdfad5df841763356476392c9");
+    expect(freezeRecord).toContain("068731582d28bd73b35af18b67724fd45ef35964a2965de5aaf2cfb26ff65bf6");
+    expect(freezeRecord).toContain("6e61e9c04e19ef27d01d4bc668270e8776564a8b39f40ccf37f53b1529094473");
+    expect(freezeRecord).toContain("All 58 of 58 appendix rows match.");
+    expect(freezeRecord).toContain("Website and PDF consume the same presentation model.");
   });
 });


### PR DESCRIPTION
## Summary

Create the final Marcondes VM0007 v1.8 release freeze record for the Pre-Validation Readiness Report.

- Records the FROZEN deliverable inventory and protected artifact SHA-256 values.
- Documents merged milestones through PR #1119 and the release guarantees.
- Extends the existing Marcondes freeze regression test for counts, statuses, outcomes, protected hashes, and website/PDF parity.
- Does not modify truth artifacts, report logic, PDF generation, or website presentation logic.

## Validation

- Focused Marcondes presentation, PDF, and freeze tests: 15 passed.
- `git diff --check`: passed.
- Pre-push lint: passed.
- Pre-push typecheck: passed.