### PR TITLE
Add private R2 ingestion for Quick Check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,4 +22,7 @@ R2_SECRET_ACCESS_KEY=
 R2_BUCKET_NAME=
 # Comma-separated browser origins allowed by the R2 bucket CORS policy.
 R2_ALLOWED_UPLOAD_ORIGINS=http://localhost:3000
+# Preview-only dynamic origin policy. Keep this scoped to the Article6 project and team.
+R2_ALLOWED_PREVIEW_PROJECT_PREFIX=app-article6-
+R2_ALLOWED_PREVIEW_TEAM_SUFFIX=-fredillys-projects.vercel.app
 QUICK_CHECK_UPLOAD_SIGNING_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,4 @@ R2_SECRET_ACCESS_KEY=
 R2_BUCKET_NAME=
 # Comma-separated browser origins allowed by the R2 bucket CORS policy.
 R2_ALLOWED_UPLOAD_ORIGINS=http://localhost:3000
-# Preview-only dynamic origin policy. Keep this scoped to the Article6 project and team.
-R2_ALLOWED_PREVIEW_PROJECT_PREFIX=app-article6-
-R2_ALLOWED_PREVIEW_TEAM_SUFFIX=-fredillys-projects.vercel.app
 QUICK_CHECK_UPLOAD_SIGNING_SECRET=

--- a/docs/quickcheck/r2-upload.md
+++ b/docs/quickcheck/r2-upload.md
@@ -12,6 +12,12 @@ the server confirms object existence, size, and content type with `HeadObject`.
 The confirmation response contains only the opaque upload reference and size;
 it does not return the bucket, object key, or a public URL.
 
+After confirmation, Quick Check sends only the signed reference to the server.
+The server verifies its signature and environment, resolves the opaque key,
+validates the private object metadata, and passes the retrieved bytes into the
+existing PDF extraction pipeline. The browser never receives or resends the
+PDF bytes for extraction.
+
 ## Follow-up before rollout
 
 Add retention cleanup for abandoned Quick Check objects, remove duplicate

--- a/docs/quickcheck/r2-upload.md
+++ b/docs/quickcheck/r2-upload.md
@@ -2,9 +2,19 @@
 
 Configure `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and
 `R2_BUCKET_NAME` independently in Preview and Production. Set
-`R2_ALLOWED_UPLOAD_ORIGINS` to the matching browser origin(s), and configure
-the same values in the R2 bucket CORS policy for `PUT` with the
-`Content-Type` request header exposed. Never commit these values.
+`R2_ALLOWED_UPLOAD_ORIGINS` to exact browser origins. Production is exact-only
+and HTTPS-only. Preview may additionally use the narrowly scoped dynamic policy
+from `R2_ALLOWED_PREVIEW_PROJECT_PREFIX` and
+`R2_ALLOWED_PREVIEW_TEAM_SUFFIX`; the example hostname
+`https://app-article6-feature-fredillys-projects.vercel.app` is accepted when
+those variables are configured. Never allow all `*.vercel.app` deployments.
+
+The application presign-origin policy and Cloudflare R2 bucket CORS are
+separate controls. R2 CORS must also permit each browser origin that the
+application authorizes for `PUT` with the `Content-Type` request header
+exposed. If the current R2 CORS configuration only supports exact origins,
+each new Preview hostname still requires an operational CORS update; do not
+replace this with `*`.
 
 The upload API issues a five-minute, PDF-only presigned `PutObject` URL for a
 server-generated opaque reference. The browser uploads directly to R2, then

--- a/docs/quickcheck/r2-upload.md
+++ b/docs/quickcheck/r2-upload.md
@@ -12,7 +12,8 @@ the server confirms object existence, size, and content type with `HeadObject`.
 The confirmation response contains only the opaque upload reference and size;
 it does not return the bucket, object key, or a public URL.
 
-After confirmation, Quick Check sends only the signed reference to the server.
+After confirmation, Quick Check sends the signed reference and non-authoritative
+display metadata to the server.
 The server verifies its signature and environment, resolves the opaque key,
 validates the private object metadata, and passes the retrieved bytes into the
 existing PDF extraction pipeline. The browser never receives or resends the

--- a/docs/quickcheck/r2-upload.md
+++ b/docs/quickcheck/r2-upload.md
@@ -2,12 +2,10 @@
 
 Configure `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and
 `R2_BUCKET_NAME` independently in Preview and Production. Set
-`R2_ALLOWED_UPLOAD_ORIGINS` to exact browser origins. Production is exact-only
-and HTTPS-only. Preview may additionally use the narrowly scoped dynamic policy
-from `R2_ALLOWED_PREVIEW_PROJECT_PREFIX` and
-`R2_ALLOWED_PREVIEW_TEAM_SUFFIX`; the example hostname
-`https://app-article6-feature-fredillys-projects.vercel.app` is accepted when
-those variables are configured. Never allow all `*.vercel.app` deployments.
+`R2_ALLOWED_UPLOAD_ORIGINS` to the exact browser origins allowed to presign
+uploads. This is the single source of truth in both Preview and Production.
+Production origins must use HTTPS. Preview deployment origins must be added
+explicitly when they change; no Vercel wildcard is supported.
 
 The application presign-origin policy and Cloudflare R2 bucket CORS are
 separate controls. R2 CORS must also permit each browser origin that the

--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -124,7 +124,6 @@ function buildParserDebug(): ParserDebugPayload {
  */
 async function extractAndRespond(
   bytes: ArrayBuffer,
-  pdfFilePath: string,
   pdfRef: string,
 ): Promise<NextResponse> {
   let fallbackReason = "pdf-parse returned empty text — fell back to heuristic extractor";
@@ -212,8 +211,7 @@ async function handlePost(request: Request) {
     }
     if (!isLikelyPdfBytes(retrieved.bytes)) return qcJson({ error: "The uploaded object is not a valid PDF.", code: "invalid-file" }, { status: 400 });
     try {
-      const pdfFilePath = saveTempPdf(retrieved.bytes);
-      return await extractAndRespond(retrieved.bytes, pdfFilePath, json.uploadRef);
+      return await extractAndRespond(retrieved.bytes, json.uploadRef);
     } catch {
       return qcJson({ error: "The uploaded PDF could not be extracted.", code: "extraction-failed" }, { status: 422 });
     }
@@ -279,7 +277,7 @@ async function handlePost(request: Request) {
   const pdfRef = storePdfRef(pdfFilePath);
 
   // Extract text with pdf-parse, fall back to heuristic
-  return await extractAndRespond(bytes, pdfFilePath, pdfRef);
+  return await extractAndRespond(bytes, pdfRef);
 }
 
 async function handleGet() {
@@ -287,7 +285,7 @@ async function handleGet() {
     ok: true,
     engine: "pdf-parse",
     runtime: "nodejs",
-    storage: "vercel-blob",
+    storage: "private-r2",
   });
 }
 

--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -1,6 +1,6 @@
 export const runtime = "nodejs";
 
-import { mkdirSync, writeFileSync, existsSync, readdirSync } from "fs";
+import { mkdirSync, writeFileSync, existsSync, readdirSync, unlinkSync } from "fs";
 import path from "path";
 import os from "os";
 import { execFileSync } from "child_process";
@@ -14,7 +14,7 @@ import { formatQuickCheckPdfPages } from "@/lib/chat/quickCheckPdfPages";
 import { formatQuickCheckPdfLimitLabel, isLikelyPdfBytes, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 import { storePdfRef } from "@/lib/chat/quickCheckPdfStore";
 import { withMetrics } from "@/lib/metrics";
-import { resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
+import { parseDocumentText, resolveConfiguredDocumentParserAdapterId, type ParsedDocument } from "@/lib/documentParsing";
 import { checkPymupdfAvailability } from "@/lib/documentParsing/adapters/pymupdfHelper";
 import { QuickCheckUploadError, retrieveQuickCheckUpload } from "@/lib/quickCheck/r2Upload";
 
@@ -125,6 +125,7 @@ function buildParserDebug(): ParserDebugPayload {
 async function extractAndRespond(
   bytes: ArrayBuffer,
   pdfRef: string,
+  parsedDocument?: ParsedDocument,
 ): Promise<NextResponse> {
   let fallbackReason = "pdf-parse returned empty text — fell back to heuristic extractor";
   let diagnostics: PdfExtractionDiagnostics | undefined;
@@ -141,6 +142,7 @@ async function extractAndRespond(
         engine: extraction.engine,
         metadata: extraction.metadata,
         pdfRef,
+        parsedDocument,
         parserDebug,
       });
     }
@@ -158,6 +160,7 @@ async function extractAndRespond(
     text: fallbackText,
     engine: "heuristic",
     pdfRef,
+    parsedDocument,
     parserDebug,
     metadata: {
       parser: "heuristic",
@@ -210,10 +213,19 @@ async function handlePost(request: Request) {
       return qcJson({ error: "The uploaded PDF could not be retrieved.", code: "storage-unavailable" }, { status: 503 });
     }
     if (!isLikelyPdfBytes(retrieved.bytes)) return qcJson({ error: "The uploaded object is not a valid PDF.", code: "invalid-file" }, { status: 400 });
+    const pdfFilePath = saveTempPdf(retrieved.bytes);
     try {
-      return await extractAndRespond(retrieved.bytes, json.uploadRef);
+      let parsedDocument: ParsedDocument | undefined;
+      try {
+        parsedDocument = parseDocumentText({ rawText: "", pdfFilePath });
+      } catch {
+        parsedDocument = undefined;
+      }
+      return await extractAndRespond(retrieved.bytes, json.uploadRef, parsedDocument);
     } catch {
       return qcJson({ error: "The uploaded PDF could not be extracted.", code: "extraction-failed" }, { status: 422 });
+    } finally {
+      try { unlinkSync(pdfFilePath); } catch { /* best effort cleanup */ }
     }
   }
 

--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -215,11 +215,14 @@ async function handlePost(request: Request) {
     if (!isLikelyPdfBytes(retrieved.bytes)) return qcJson({ error: "The uploaded object is not a valid PDF.", code: "invalid-file" }, { status: 400 });
     const pdfFilePath = saveTempPdf(retrieved.bytes);
     try {
-      let parsedDocument: ParsedDocument | undefined;
+      let parsedDocument: ParsedDocument;
       try {
         parsedDocument = parseDocumentText({ rawText: "", pdfFilePath });
       } catch {
-        parsedDocument = undefined;
+        return qcJson({
+          error: "The uploaded PDF could not be parsed for Quick Check processing.",
+          code: "extraction-failed",
+        }, { status: 422 });
       }
       return await extractAndRespond(retrieved.bytes, json.uploadRef, parsedDocument);
     } catch {

--- a/src/app/api/quick-check/pdf-extract/route.ts
+++ b/src/app/api/quick-check/pdf-extract/route.ts
@@ -13,10 +13,10 @@ import {
 import { formatQuickCheckPdfPages } from "@/lib/chat/quickCheckPdfPages";
 import { formatQuickCheckPdfLimitLabel, isLikelyPdfBytes, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 import { storePdfRef } from "@/lib/chat/quickCheckPdfStore";
-import { uploadPdfToBlob, isBlobUrl, downloadBlobToTemp } from "@/lib/chat/quickCheckPdfBlob";
 import { withMetrics } from "@/lib/metrics";
 import { resolveConfiguredDocumentParserAdapterId } from "@/lib/documentParsing";
 import { checkPymupdfAvailability } from "@/lib/documentParsing/adapters/pymupdfHelper";
+import { QuickCheckUploadError, retrieveQuickCheckUpload } from "@/lib/quickCheck/r2Upload";
 
 function qcJson(body: unknown, init?: ResponseInit): NextResponse {
   return NextResponse.json(body, {
@@ -184,65 +184,39 @@ async function extractAndRespond(
  * Supports two upload paths:
  *
  *   1. FormData / raw body (legacy, small files):
- *      Browser sends PDF bytes → server saves to /tmp → uploads to Blob for
- *      durability → returns blob URL as pdfRef.
- *      Limited by Vercel 4.5MB Function payload limit.
+ *      Browser sends PDF bytes and the existing in-memory reference path is
+ *      retained for compatibility.
  *
- *   2. Blob URL (direct browser-to-Blob upload):
- *      Browser uploads PDF directly to Vercel Blob via presigned URL, then
- *      sends the blob URL here for extraction.
- *      Bypasses Vercel Function body limit entirely.
+ *   2. Signed R2 upload reference:
+ *      The server verifies the reference, retrieves the private object, and
+ *      sends its bytes through the same extraction function.
  *
- * For path 2, the client POSTs JSON: { blobUrl: "https://...blob.vercel-storage.com/..." }
- * The server downloads the blob to /tmp and runs PyMuPDF extraction.
+ * For path 2, the client POSTs JSON: { uploadRef: "signed-reference" }.
  */
 async function handlePost(request: Request) {
   const contentType = request.headers.get("content-type") ?? "";
 
-  // --- Path 2: Blob URL (direct browser-to-Blob upload) ---
+  // --- Path 2: signed private R2 reference ---
   if (contentType.includes("application/json")) {
-    const json = await request.json().catch(() => ({})) as { blobUrl?: string; filename?: string };
-    const blobUrl = json.blobUrl;
-
-    if (!blobUrl || !isBlobUrl(blobUrl)) {
-      return qcJson(
-        { error: "Missing or invalid blobUrl.", code: "invalid-file" },
-        { status: 400 },
-      );
-    }
-
-    // Download blob to /tmp for PyMuPDF parsing
-    let pdfFilePath: string;
+    const json = await request.json().catch(() => ({})) as { uploadRef?: string };
+    if (!json.uploadRef || typeof json.uploadRef !== "string") return qcJson({ error: "Missing upload reference.", code: "upload-reference-invalid" }, { status: 400 });
+    let retrieved: Awaited<ReturnType<typeof retrieveQuickCheckUpload>>;
     try {
-      pdfFilePath = await downloadBlobToTemp(blobUrl);
+      retrieved = await retrieveQuickCheckUpload(json.uploadRef);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error("[quick-check/pdf-extract] Failed to download blob:", message);
-      return qcJson(
-        { error: "Failed to download PDF from Blob storage.", code: "parser-failed" },
-        { status: 502 },
-      );
+      if (error instanceof QuickCheckUploadError) {
+        const status = error.code === "upload-not-found" ? 404 : error.code === "storage-unavailable" ? 503 : 400;
+        return qcJson({ error: error.message, code: error.code }, { status });
+      }
+      return qcJson({ error: "The uploaded PDF could not be retrieved.", code: "storage-unavailable" }, { status: 503 });
     }
-
-    // Read bytes from temp file for extraction
-    const { readFileSync } = await import("fs");
-    const pdfBytes = readFileSync(pdfFilePath);
-    const pdfBytesArray = new Uint8Array(pdfBytes);
-    const pdfBytesBuffer = pdfBytesArray.buffer.slice(
-      pdfBytesArray.byteOffset,
-      pdfBytesArray.byteOffset + pdfBytesArray.byteLength,
-    ) as ArrayBuffer;
-
-    if (!isLikelyPdfBytes(pdfBytesBuffer)) {
-      return qcJson(
-        { error: "Blob content is not a valid PDF.", code: "invalid-file" },
-        { status: 400 },
-      );
+    if (!isLikelyPdfBytes(retrieved.bytes)) return qcJson({ error: "The uploaded object is not a valid PDF.", code: "invalid-file" }, { status: 400 });
+    try {
+      const pdfFilePath = saveTempPdf(retrieved.bytes);
+      return await extractAndRespond(retrieved.bytes, pdfFilePath, json.uploadRef);
+    } catch {
+      return qcJson({ error: "The uploaded PDF could not be extracted.", code: "extraction-failed" }, { status: 422 });
     }
-
-    // Extract text with pdf-parse, fall back to heuristic
-    const result = await extractAndRespond(pdfBytesBuffer, pdfFilePath, blobUrl);
-    return result;
   }
 
   // --- Path 1: FormData / raw bytes (legacy, small files) ---
@@ -299,19 +273,10 @@ async function handlePost(request: Request) {
     );
   }
 
-  // Save to temp, upload to Blob for durability, return blob URL as pdfRef
+  // Keep the small legacy byte path available without introducing a second
+  // storage upload. Direct browser uploads use the signed R2 path above.
   const pdfFilePath = saveTempPdf(bytes);
-  let pdfRef: string;
-
-  try {
-    const blob = await uploadPdfToBlob(bytes);
-    pdfRef = blob.url;
-    console.log("[quick-check/pdf-extract] Uploaded PDF to Blob storage:", blob.pathname);
-  } catch (error) {
-    // Blob upload failed — fall back to in-memory pdfRef
-    console.warn("[quick-check/pdf-extract] Failed to upload to Blob, using in-memory pdfRef:", error);
-    pdfRef = storePdfRef(pdfFilePath);
-  }
+  const pdfRef = storePdfRef(pdfFilePath);
 
   // Extract text with pdf-parse, fall back to heuristic
   return await extractAndRespond(bytes, pdfFilePath, pdfRef);

--- a/src/app/api/quick-check/r2-upload/route.ts
+++ b/src/app/api/quick-check/r2-upload/route.ts
@@ -1,18 +1,14 @@
 import { NextResponse } from "next/server";
 import { confirmQuickCheckUpload, MAX_QUICK_CHECK_PDF_BYTES, presignQuickCheckUpload, QuickCheckUploadError } from "@/lib/quickCheck/r2Upload";
+import { authorizeQuickCheckUploadOrigin } from "@/lib/quickCheck/uploadOriginPolicy";
 export const runtime = "nodejs";
 const json = (body: unknown, status = 200) => NextResponse.json(body, { status, headers: { "Cache-Control": "no-store" } });
-function origins() { return (process.env.R2_ALLOWED_UPLOAD_ORIGINS ?? "").split(",").map((value) => { try { return new URL(value.trim()).origin; } catch { return ""; } }).filter(Boolean); }
 export async function POST(request: Request) {
   try {
     const body = await request.json() as { action?: string; size?: number; contentType?: string; uploadRef?: string };
     if (body.action === "presign") {
-      const allowed = origins();
-      if (!allowed.length) return json({ error: "Upload origins are not configured.", code: "upload-origin-not-configured" }, 503);
-      const origin = request.headers.get("origin");
-      if (!origin) return json({ error: "A browser Origin header is required.", code: "origin-required" }, 403);
-      let normalizedOrigin = ""; try { normalizedOrigin = new URL(origin).origin; } catch { /* reject below */ }
-      if (!allowed.includes(normalizedOrigin)) return json({ error: "This browser origin is not allowed to upload Quick Check PDFs.", code: "cors-denied" }, 403);
+      const originDecision = authorizeQuickCheckUploadOrigin(request.headers.get("origin"));
+      if (!originDecision.allowed) return json({ error: originDecision.error, code: originDecision.code }, originDecision.status);
       if (!Number.isInteger(body.size) || body.size! <= 0 || body.size! > MAX_QUICK_CHECK_PDF_BYTES) return json({ error: "PDF must be smaller than 50 MiB.", code: "upload-too-large" }, 413);
       if (body.contentType !== "application/pdf") return json({ error: "Only PDF files are accepted.", code: "invalid-file" }, 415);
       return json(await presignQuickCheckUpload(body.size!));

--- a/src/app/api/quick-check/semantic-evidence/route.ts
+++ b/src/app/api/quick-check/semantic-evidence/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { withMetrics } from "@/lib/metrics";
 import { resolvePdfRef } from "@/lib/chat/quickCheckPdfStore";
 import { suggestSemanticEvidence } from "@/lib/quickCheck/semanticEvidence/huggingFace";
+import type { Article6DocumentModel } from "@/lib/documentModel";
 
 function qcJson(body: unknown, init?: ResponseInit): NextResponse {
   return NextResponse.json(body, {
@@ -27,9 +28,10 @@ async function handlePost(request: Request) {
   const claimText = typeof body === "object" && body && "claimText" in body && typeof body.claimText === "string" ? body.claimText : "";
   const rawPddText = typeof body === "object" && body && "rawPddText" in body && typeof body.rawPddText === "string" ? body.rawPddText : "";
   const pdfRef = typeof body === "object" && body && "pdfRef" in body && typeof body.pdfRef === "string" ? body.pdfRef : undefined;
-  const pdfFilePath = pdfRef ? await resolvePdfRef(pdfRef) : undefined;
   const methodologyId = typeof body === "object" && body && "methodologyId" in body && typeof body.methodologyId === "string" ? body.methodologyId : "";
   const methodologyVersion = typeof body === "object" && body && "methodologyVersion" in body && typeof body.methodologyVersion === "string" ? body.methodologyVersion : "";
+  const documentStructure = typeof body === "object" && body && "documentStructure" in body && body.documentStructure && typeof body.documentStructure === "object" ? body.documentStructure as Article6DocumentModel : undefined;
+  const pdfFilePath = pdfRef && !documentStructure ? await resolvePdfRef(pdfRef) : undefined;
 
   if (!claimText.trim() || !rawPddText.trim()) {
     return qcJson({ error: "claimText and rawPddText are required.", code: "missing-input" }, { status: 400 });
@@ -39,6 +41,7 @@ async function handlePost(request: Request) {
     claimText,
     rawPddText,
     pdfFilePath,
+    documentStructure,
     methodologyId,
     methodologyVersion,
   }));

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -239,9 +239,9 @@ function buildStructuredCheckAnswerText(input: {
 async function loadPreferredStructuredCheckText(
   evidenceSources: Array<{
     sourceLabel: string;
-    attachments: Array<{ id: string; filename: string; mime: string }>;
+    attachments: Array<{ id: string; sha256?: string; filename: string; mime: string }>;
   }>,
-  resolveFn: (input: { attachmentId: string; filename: string; mime: string; bytes: ArrayBuffer }) => Promise<{ text?: string | null } | null>,
+  resolveFn: (input: { attachmentId: string; sha256?: string; filename: string; mime: string; bytes: ArrayBuffer }) => Promise<{ text?: string | null } | null>,
 ): Promise<string | null> {
   const primaryAttachment = evidenceSources[0]?.attachments[0];
   if (!primaryAttachment?.id) return null;
@@ -251,6 +251,7 @@ async function loadPreferredStructuredCheckText(
 
   const resolved = await resolveFn({
     attachmentId: primaryAttachment.id,
+    sha256: primaryAttachment.sha256,
     filename: primaryAttachment.filename,
     mime: primaryAttachment.mime,
     bytes,
@@ -711,7 +712,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   });
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const uploadCacheRef = useRef(createQuickCheckPdfUploadCache());
-  const [uploadStatus, setUploadStatus] = useState<"uploading" | "confirming" | "confirmed" | "retrieving" | "extracting" | "running" | "building">("uploading");
+  const [uploadStatus, setUploadStatus] = useState<"uploading" | "confirming" | "processing" | "running" | "building">("uploading");
   const [session, setSession] = useState<QuickCheckSessionState>(() =>
     loadQuickCheckSession({
       methodologyId: initialMethod?.trim() || undefined,
@@ -1119,9 +1120,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         filename: input.filename,
         onProgress: (percent) => setUploadProgress(percent),
         onConfirm: () => setUploadStatus("confirming"),
-        onConfirmed: () => setUploadStatus("confirmed"),
-        onRetrieving: () => setUploadStatus("retrieving"),
-        onExtracting: () => setUploadStatus("extracting"),
+        onConfirmed: () => setUploadStatus("processing"),
+        onRetrieving: () => setUploadStatus("processing"),
+        onExtracting: () => setUploadStatus("processing"),
         onRunning: () => setUploadStatus("running"),
       });
     },
@@ -1148,10 +1149,12 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       .then((analysis) => {
         if (cancelled) return;
         setUploadStatus("building");
+        setUploadProgress(null);
         setExtractionState({ loading: false, analysis, error: null });
       })
       .catch((error) => {
         if (cancelled) return;
+        setUploadProgress(null);
         setExtractionState({
           loading: false,
           analysis: null,
@@ -2480,7 +2483,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               </div>
               {uploadProgress !== null ? (
                 <div className="mt-5" role="status" aria-live="polite">
-                  <div className="flex justify-between text-xs text-slate-600"><span>{uploadStatus === "confirming" ? "Confirming upload…" : uploadStatus === "confirmed" ? "Upload confirmed" : uploadStatus === "retrieving" ? "Retrieving uploaded PDF" : uploadStatus === "extracting" ? "Extracting document" : uploadStatus === "running" ? "Running Quick Check" : uploadStatus === "building" ? "Building Evidence Map" : "Uploading PDF directly to secure storage…"}</span><span>{uploadProgress}%</span></div>
+                  <div className="flex justify-between text-xs text-slate-600"><span>{uploadStatus === "confirming" ? "Confirming upload…" : uploadStatus === "processing" ? "Processing uploaded PDF" : uploadStatus === "running" ? "Running Quick Check" : uploadStatus === "building" ? "Building Evidence Map" : "Uploading PDF directly to secure storage…"}</span><span>{uploadProgress}%</span></div>
                   <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100"><div className="h-full bg-slate-900 transition-[width]" style={{ width: `${uploadProgress}%` }} /></div>
                 </div>
               ) : null}

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -711,7 +711,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   });
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const uploadCacheRef = useRef(createQuickCheckPdfUploadCache());
-  const [uploadStatus, setUploadStatus] = useState<"uploading" | "confirming" | "confirmed">("uploading");
+  const [uploadStatus, setUploadStatus] = useState<"uploading" | "confirming" | "confirmed" | "retrieving" | "extracting" | "running" | "building">("uploading");
   const [session, setSession] = useState<QuickCheckSessionState>(() =>
     loadQuickCheckSession({
       methodologyId: initialMethod?.trim() || undefined,
@@ -1120,6 +1120,9 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
         onProgress: (percent) => setUploadProgress(percent),
         onConfirm: () => setUploadStatus("confirming"),
         onConfirmed: () => setUploadStatus("confirmed"),
+        onRetrieving: () => setUploadStatus("retrieving"),
+        onExtracting: () => setUploadStatus("extracting"),
+        onRunning: () => setUploadStatus("running"),
       });
     },
     [],
@@ -1144,6 +1147,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     void analyzeQuickCheckEvidence(selectedEvidenceSources, { resolvePdfText })
       .then((analysis) => {
         if (cancelled) return;
+        setUploadStatus("building");
         setExtractionState({ loading: false, analysis, error: null });
       })
       .catch((error) => {
@@ -2476,7 +2480,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               </div>
               {uploadProgress !== null ? (
                 <div className="mt-5" role="status" aria-live="polite">
-                  <div className="flex justify-between text-xs text-slate-600"><span>{uploadStatus === "confirming" ? "Confirming upload…" : uploadStatus === "confirmed" ? "Upload confirmed" : "Uploading PDF directly to secure storage…"}</span><span>{uploadProgress}%</span></div>
+                  <div className="flex justify-between text-xs text-slate-600"><span>{uploadStatus === "confirming" ? "Confirming upload…" : uploadStatus === "confirmed" ? "Upload confirmed" : uploadStatus === "retrieving" ? "Retrieving uploaded PDF" : uploadStatus === "extracting" ? "Extracting document" : uploadStatus === "running" ? "Running Quick Check" : uploadStatus === "building" ? "Building Evidence Map" : "Uploading PDF directly to secure storage…"}</span><span>{uploadProgress}%</span></div>
                   <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100"><div className="h-full bg-slate-900 transition-[width]" style={{ width: `${uploadProgress}%` }} /></div>
                 </div>
               ) : null}

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -712,7 +712,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   });
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const uploadCacheRef = useRef(createQuickCheckPdfUploadCache());
-  const [uploadStatus, setUploadStatus] = useState<"uploading" | "confirming" | "processing" | "running" | "building">("uploading");
+  const [uploadStatus, setUploadStatus] = useState<"uploading" | "confirming" | "processing" | "running">("uploading");
   const [session, setSession] = useState<QuickCheckSessionState>(() =>
     loadQuickCheckSession({
       methodologyId: initialMethod?.trim() || undefined,
@@ -1148,7 +1148,6 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     void analyzeQuickCheckEvidence(selectedEvidenceSources, { resolvePdfText })
       .then((analysis) => {
         if (cancelled) return;
-        setUploadStatus("building");
         setUploadProgress(null);
         setExtractionState({ loading: false, analysis, error: null });
       })
@@ -1796,7 +1795,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const reviewFieldText = draft.claimText.trim();
       const claimIntents = classifyQuickCheckClaimIntents(effectiveClaimText);
       const structuredQueryContext = evidenceAnalysis.rawPddText?.trim()
-        ? await resolveStructuredQueryContext(evidenceAnalysis.rawPddText, evidenceAnalysis.pdfRef)
+        ? await resolveStructuredQueryContext(evidenceAnalysis.rawPddText, evidenceAnalysis.parsedDocument ? undefined : evidenceAnalysis.pdfRef, evidenceAnalysis.parsedDocument)
         : undefined;
       const isReviewQuestion = detectRuntimeReviewPath({
         claimText: reviewFieldText,
@@ -1843,7 +1842,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           void fetchSemanticEvidenceCandidates({
             claimText: reviewFieldText,
             rawPddText: evidenceAnalysis.rawPddText,
-            pdfRef: evidenceAnalysis.pdfRef,
+            pdfRef: structuredQueryContext?.documentStructure ? undefined : evidenceAnalysis.pdfRef,
+            documentStructure: structuredQueryContext?.documentStructure,
             methodologyId: resolvedMethodologyId,
             methodologyVersion: resolvedMethodologyVersion,
           })
@@ -2483,7 +2483,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
               </div>
               {uploadProgress !== null ? (
                 <div className="mt-5" role="status" aria-live="polite">
-                  <div className="flex justify-between text-xs text-slate-600"><span>{uploadStatus === "confirming" ? "Confirming upload…" : uploadStatus === "processing" ? "Processing uploaded PDF" : uploadStatus === "running" ? "Running Quick Check" : uploadStatus === "building" ? "Building Evidence Map" : "Uploading PDF directly to secure storage…"}</span><span>{uploadProgress}%</span></div>
+                  <div className="flex justify-between text-xs text-slate-600"><span>{uploadStatus === "confirming" ? "Confirming upload…" : uploadStatus === "processing" ? "Processing uploaded PDF" : uploadStatus === "running" ? "Running Quick Check" : "Uploading PDF directly to secure storage…"}</span><span>{uploadProgress}%</span></div>
                   <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100"><div className="h-full bg-slate-900 transition-[width]" style={{ width: `${uploadProgress}%` }} /></div>
                 </div>
               ) : null}

--- a/src/lib/chat/quickCheckEvidence.ts
+++ b/src/lib/chat/quickCheckEvidence.ts
@@ -2,6 +2,7 @@ import type { EvidenceInventoryItem } from "@/lib/evidence/inventory";
 import { unzlibSync } from "fflate";
 import { getAttachmentBytes } from "@/lib/proofMap/attachments";
 import type { EvidenceAttachment, PddFragment, WorkbookEvidenceAsset, WorkbookRecordGroup } from "@/lib/proofMap/types";
+import type { ParsedDocument } from "@/lib/documentParsing";
 import {
   classifyQuickCheckDocument,
   type QuickCheckDocumentClassification,
@@ -49,6 +50,7 @@ export type QuickCheckEvidenceAnalysis = {
   warnings: string[];
   rawPddText?: string;
   pdfRef?: string;
+  parsedDocument?: ParsedDocument;
   parserAdapterId?: string;
   parserFallbackFrom?: string;
   parserDebug?: QuickCheckPdfParserDebug;
@@ -99,6 +101,7 @@ export type QuickCheckResolvedPdfText = {
     | "selected-methodology-mismatch"
     | "methodology-not-detected";
   pdfRef?: string;
+  parsedDocument?: ParsedDocument;
   parserAdapterId?: string;
   parserFallbackFrom?: string;
   parserDebug?: QuickCheckPdfParserDebug;
@@ -1069,6 +1072,7 @@ export async function analyzeQuickCheckEvidence(
   const warningSet = new Set<string>();
     const rawPddTextParts: string[] = [];
     let pdfRef: string | undefined;
+    let parsedDocument: ParsedDocument | undefined;
     let parserAdapterId: string | undefined;
     let parserFallbackFrom: string | undefined;
     let parserDebug: QuickCheckPdfParserDebug | undefined;
@@ -1121,6 +1125,7 @@ export async function analyzeQuickCheckEvidence(
           });
           text = resolved?.text ?? "";
           if (resolved?.pdfRef) pdfRef = resolved.pdfRef;
+          if (resolved?.parsedDocument) parsedDocument = resolved.parsedDocument;
           if (resolved?.parserAdapterId) parserAdapterId = resolved.parserAdapterId;
           if (resolved?.parserFallbackFrom) parserFallbackFrom = resolved.parserFallbackFrom;
           if (resolved?.parserDebug) parserDebug = resolved.parserDebug;
@@ -1178,6 +1183,7 @@ export async function analyzeQuickCheckEvidence(
     warnings,
     rawPddText: rawPddTextParts.length > 0 ? rawPddTextParts.join("\n\n") : undefined,
     pdfRef,
+    parsedDocument,
     parserAdapterId,
     parserFallbackFrom,
     parserDebug,

--- a/src/lib/chat/quickCheckPdfClient.ts
+++ b/src/lib/chat/quickCheckPdfClient.ts
@@ -3,7 +3,7 @@ import { formatQuickCheckPdfPages, type QuickCheckPdfPage } from "@/lib/chat/qui
 import { isLikelyPdfBytes, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 export type QuickCheckUploadProgress = (percent: number) => void;
 const RECOVERED_TEXT_WARNING = "Server extraction failed, but Quick Check recovered document signals locally. Review extracted details before relying on matches.";
-export type QuickCheckPdfUploadCache = Map<string, Promise<string>>;
+export type QuickCheckPdfUploadCache = Map<string, Promise<QuickCheckResolvedPdfText>>;
 export function createQuickCheckPdfUploadCache(): QuickCheckPdfUploadCache { return new Map(); }
 const defaultUploadCache = createQuickCheckPdfUploadCache();
 export function clearQuickCheckUploadCache() { defaultUploadCache.clear(); }
@@ -11,25 +11,30 @@ export async function resolveQuickCheckPdfText(input: { attachmentId?: string; s
   const { bytes, onProgress, onConfirm, onConfirmed, onRetrieving, onExtracting, onRunning } = input;
   if (bytes.byteLength > MAX_QUICK_CHECK_PDF_BYTES) throw new Error("PDF exceeds the Quick Check upload limit of 50 MiB.");
   if (!isLikelyPdfBytes(bytes)) throw new Error("Only valid PDF files can be uploaded.");
-  const cacheKey = input.sha256?.trim() || input.attachmentId?.trim();
+  const cacheKeys = [input.sha256?.trim(), input.attachmentId?.trim()].filter((key): key is string => Boolean(key));
   const cache = input.uploadCache ?? defaultUploadCache;
-  const existing = cacheKey ? cache.get(cacheKey) : undefined;
-  let uploadRef: string;
+  const existing = cacheKeys.map((key) => cache.get(key)).find(Boolean);
   if (existing) {
-    uploadRef = await existing;
+    for (const key of cacheKeys) cache.set(key, existing);
     onProgress?.(100);
-    onConfirmed?.();
-  } else {
-    const uploadPromise = uploadPdfDirectly(bytes, onProgress, onConfirm, onConfirmed);
-    if (cacheKey) cache.set(cacheKey, uploadPromise);
-    try { uploadRef = await uploadPromise; } catch (error) { if (cacheKey) cache.delete(cacheKey); throw error; }
+    return existing;
   }
-  onRetrieving?.();
-  const response = await fetch("/api/quick-check/pdf-extract", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ uploadRef }), cache: "no-store" });
-  onExtracting?.();
-  const result = await handleExtractResponse(response, bytes, uploadRef);
-  onRunning?.();
-  return result;
+  const operation = (async () => {
+    const uploadRef = await uploadPdfDirectly(bytes, onProgress, onConfirm, onConfirmed);
+    onRetrieving?.();
+    onExtracting?.();
+    const response = await fetch("/api/quick-check/pdf-extract", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ uploadRef, filename: input.filename || "document.pdf" }), cache: "no-store" });
+    const result = await handleExtractResponse(response, bytes, uploadRef);
+    onRunning?.();
+    return result;
+  })();
+  for (const key of cacheKeys) cache.set(key, operation);
+  try {
+    return await operation;
+  } catch (error) {
+    for (const key of cacheKeys) if (cache.get(key) === operation) cache.delete(key);
+    throw error;
+  }
 }
 async function uploadPdfDirectly(bytes: ArrayBuffer, onProgress?: QuickCheckUploadProgress, onConfirm?: () => void, onConfirmed?: () => void): Promise<string> {
   const presign = await fetch("/api/quick-check/r2-upload", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "presign", size: bytes.byteLength, contentType: "application/pdf" }), cache: "no-store" });

--- a/src/lib/chat/quickCheckPdfClient.ts
+++ b/src/lib/chat/quickCheckPdfClient.ts
@@ -2,14 +2,13 @@ import { extractMethodologyMentions, type QuickCheckPdfParserDebug, type QuickCh
 import { formatQuickCheckPdfPages, type QuickCheckPdfPage } from "@/lib/chat/quickCheckPdfPages";
 import { isLikelyPdfBytes, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 export type QuickCheckUploadProgress = (percent: number) => void;
-const SERVER_EXTRACTION_LIMIT = 4 * 1024 * 1024;
 const RECOVERED_TEXT_WARNING = "Server extraction failed, but Quick Check recovered document signals locally. Review extracted details before relying on matches.";
 export type QuickCheckPdfUploadCache = Map<string, Promise<string>>;
 export function createQuickCheckPdfUploadCache(): QuickCheckPdfUploadCache { return new Map(); }
 const defaultUploadCache = createQuickCheckPdfUploadCache();
 export function clearQuickCheckUploadCache() { defaultUploadCache.clear(); }
-export async function resolveQuickCheckPdfText(input: { attachmentId?: string; sha256?: string; uploadCache?: QuickCheckPdfUploadCache; bytes: ArrayBuffer; filename: string; onProgress?: QuickCheckUploadProgress; onConfirm?: () => void; onConfirmed?: () => void }): Promise<QuickCheckResolvedPdfText> {
-  const { bytes, filename, onProgress, onConfirm, onConfirmed } = input;
+export async function resolveQuickCheckPdfText(input: { attachmentId?: string; sha256?: string; uploadCache?: QuickCheckPdfUploadCache; bytes: ArrayBuffer; filename: string; onProgress?: QuickCheckUploadProgress; onConfirm?: () => void; onConfirmed?: () => void; onRetrieving?: () => void; onExtracting?: () => void; onRunning?: () => void }): Promise<QuickCheckResolvedPdfText> {
+  const { bytes, onProgress, onConfirm, onConfirmed, onRetrieving, onExtracting, onRunning } = input;
   if (bytes.byteLength > MAX_QUICK_CHECK_PDF_BYTES) throw new Error("PDF exceeds the Quick Check upload limit of 50 MiB.");
   if (!isLikelyPdfBytes(bytes)) throw new Error("Only valid PDF files can be uploaded.");
   const cacheKey = input.sha256?.trim() || input.attachmentId?.trim();
@@ -25,12 +24,12 @@ export async function resolveQuickCheckPdfText(input: { attachmentId?: string; s
     if (cacheKey) cache.set(cacheKey, uploadPromise);
     try { uploadRef = await uploadPromise; } catch (error) { if (cacheKey) cache.delete(cacheKey); throw error; }
   }
-  if (bytes.byteLength > SERVER_EXTRACTION_LIMIT) return { text: "", engine: "heuristic", methodologyMentions: [], pdfRef: uploadRef, warning: "This PDF was uploaded successfully, but server extraction for PDFs over 4 MiB is not available yet. Private-R2 processing will be added separately." };
-  const form = new FormData();
-  form.append("file", new Blob([new Uint8Array(bytes)], { type: "application/pdf" }), filename || "document.pdf");
-  form.append("filename", filename || "document.pdf");
-  const response = await fetch("/api/quick-check/pdf-extract", { method: "POST", body: form, cache: "no-store" });
-  return handleExtractResponse(response, bytes, uploadRef);
+  onRetrieving?.();
+  const response = await fetch("/api/quick-check/pdf-extract", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ uploadRef }), cache: "no-store" });
+  onExtracting?.();
+  const result = await handleExtractResponse(response, bytes, uploadRef);
+  onRunning?.();
+  return result;
 }
 async function uploadPdfDirectly(bytes: ArrayBuffer, onProgress?: QuickCheckUploadProgress, onConfirm?: () => void, onConfirmed?: () => void): Promise<string> {
   const presign = await fetch("/api/quick-check/r2-upload", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "presign", size: bytes.byteLength, contentType: "application/pdf" }), cache: "no-store" });

--- a/src/lib/chat/quickCheckPdfClient.ts
+++ b/src/lib/chat/quickCheckPdfClient.ts
@@ -1,6 +1,7 @@
 import { extractMethodologyMentions, type QuickCheckPdfParserDebug, type QuickCheckResolvedPdfText } from "@/lib/chat/quickCheckEvidence";
 import { formatQuickCheckPdfPages, type QuickCheckPdfPage } from "@/lib/chat/quickCheckPdfPages";
 import { isLikelyPdfBytes, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
+import type { ParsedDocument } from "@/lib/documentParsing";
 export type QuickCheckUploadProgress = (percent: number) => void;
 const RECOVERED_TEXT_WARNING = "Server extraction failed, but Quick Check recovered document signals locally. Review extracted details before relying on matches.";
 export type QuickCheckPdfUploadCache = Map<string, Promise<QuickCheckResolvedPdfText>>;
@@ -16,8 +17,10 @@ export async function resolveQuickCheckPdfText(input: { attachmentId?: string; s
   const existing = cacheKeys.map((key) => cache.get(key)).find(Boolean);
   if (existing) {
     for (const key of cacheKeys) cache.set(key, existing);
+    const result = await existing;
     onProgress?.(100);
-    return existing;
+    onRunning?.();
+    return result;
   }
   const operation = (async () => {
     const uploadRef = await uploadPdfDirectly(bytes, onProgress, onConfirm, onConfirmed);
@@ -51,9 +54,9 @@ async function uploadPdfDirectly(bytes: ArrayBuffer, onProgress?: QuickCheckUplo
 }
 async function handleExtractResponse(response: Response, originalBytes: ArrayBuffer, uploadRef: string): Promise<QuickCheckResolvedPdfText> {
   if (!response.ok) { const payload = await response.json().catch(() => ({})) as { error?: string; code?: string }; throw new Error(payload.error ?? `PDF extraction failed (${response.status}).`); }
-  const payload = await response.json() as { text?: string; engine?: "pdf-parse" | "heuristic"; pages?: QuickCheckPdfPage[]; pdfRef?: string; parserAdapterId?: string; parserFallbackFrom?: string; parserDebug?: QuickCheckPdfParserDebug; metadata?: { parser?: "pdf-parse" | "heuristic"; diagnostics?: { failureKind?: "file-too-large" | "parser-failed" | "no-selectable-text" | "invalid-file" }; } };
+  const payload = await response.json() as { text?: string; engine?: "pdf-parse" | "heuristic"; pages?: QuickCheckPdfPage[]; pdfRef?: string; parsedDocument?: ParsedDocument; parserAdapterId?: string; parserFallbackFrom?: string; parserDebug?: QuickCheckPdfParserDebug; metadata?: { parser?: "pdf-parse" | "heuristic"; diagnostics?: { failureKind?: "file-too-large" | "parser-failed" | "no-selectable-text" | "invalid-file" }; } };
   const text = (Array.isArray(payload.pages) && payload.pages.length ? formatQuickCheckPdfPages(payload.pages) : payload.text) ?? "";
   const failureKind = payload.metadata?.diagnostics?.failureKind;
   const engine = payload.engine === "heuristic" || payload.metadata?.parser === "heuristic" ? "heuristic" : "pdf-parse";
-  return { text, engine, methodologyMentions: extractMethodologyMentions(text), warning: failureKind === "no-selectable-text" ? "No selectable text found in this PDF." : engine === "heuristic" && text.trim() ? RECOVERED_TEXT_WARNING : undefined, diagnosticCode: failureKind, pdfRef: uploadRef, parserAdapterId: payload.parserDebug?.parserAdapterId ?? payload.parserAdapterId, parserFallbackFrom: payload.parserDebug?.parserFallbackFrom ?? payload.parserFallbackFrom, parserDebug: payload.parserDebug };
+  return { text, engine, methodologyMentions: extractMethodologyMentions(text), warning: failureKind === "no-selectable-text" ? "No selectable text found in this PDF." : engine === "heuristic" && text.trim() ? RECOVERED_TEXT_WARNING : undefined, diagnosticCode: failureKind, pdfRef: uploadRef, parsedDocument: payload.parsedDocument, parserAdapterId: payload.parserDebug?.parserAdapterId ?? payload.parserAdapterId, parserFallbackFrom: payload.parserDebug?.parserFallbackFrom ?? payload.parserFallbackFrom, parserDebug: payload.parserDebug };
 }

--- a/src/lib/chat/quickCheckPdfStore.ts
+++ b/src/lib/chat/quickCheckPdfStore.ts
@@ -1,17 +1,19 @@
 import { isBlobUrl, downloadBlobToTemp } from "@/lib/chat/quickCheckPdfBlob";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "fs";
+import os from "os";
+import path from "path";
 
 /**
  * Server-side PDF file reference store.
  *
- * Supports two kinds of pdfRef tokens:
+ * Supports three kinds of pdfRef tokens:
  *   1. In-memory token → temp file path (TTL: 10 min, lost on cold start)
  *   2. Blob URL (Vercel Blob) → durable, no TTL, survives cold start
- *
- * The blob-backed path is preferred because it survives Vercel cold starts.
- * The in-memory path is kept for backward compatibility during the transition.
+ *   3. Signed private-R2 reference → materialized temp file path (TTL: 10 min)
  */
 
 const store = new Map<string, { filePath: string; expiresAt: number }>();
+const r2Store = new Map<string, { filePath: string; expiresAt: number }>();
 const PDF_REF_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 function cleanExpired(): void {
@@ -19,6 +21,12 @@ function cleanExpired(): void {
   for (const [key, entry] of store) {
     if (entry.expiresAt < now) {
       store.delete(key);
+    }
+  }
+  for (const [key, entry] of r2Store) {
+    if (entry.expiresAt < now) {
+      r2Store.delete(key);
+      try { if (existsSync(entry.filePath)) unlinkSync(entry.filePath); } catch { /* best effort cleanup */ }
     }
   }
 }
@@ -36,8 +44,8 @@ export function storePdfRef(filePath: string): string {
 /**
  * Resolve a pdfRef to a local temp file path.
  *
- * Handles both in-memory tokens and Vercel Blob URLs.
- * For blob URLs, downloads the blob to /tmp and returns the temp path.
+ * Handles in-memory tokens, Vercel Blob URLs, and signed private-R2 refs.
+ * R2 refs are verified before their server-derived object is materialized.
  * For in-memory tokens, returns the cached file path if still valid.
  *
  * Returns undefined if the ref cannot be resolved.
@@ -45,6 +53,27 @@ export function storePdfRef(filePath: string): string {
 export async function resolvePdfRef(
   token: string,
 ): Promise<string | undefined> {
+  // Signed references have exactly two URL-safe segments. Invalid values in
+  // this shape are rejected rather than being treated as arbitrary paths.
+  if (token.split(".").length === 2) {
+    cleanExpired();
+    const cached = r2Store.get(token);
+    if (cached && cached.expiresAt >= Date.now()) return cached.filePath;
+    r2Store.delete(token);
+    try {
+      const { retrieveQuickCheckUpload } = await import("@/lib/quickCheck/r2Upload");
+      const retrieved = await retrieveQuickCheckUpload(token);
+      const dir = path.join(os.tmpdir(), "quick-check-pdfs");
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      const filePath = path.join(dir, `r2-${Date.now()}-${Math.random().toString(36).slice(2)}.pdf`);
+      writeFileSync(filePath, Buffer.from(retrieved.bytes));
+      r2Store.set(token, { filePath, expiresAt: Date.now() + PDF_REF_TTL_MS });
+      return filePath;
+    } catch {
+      return undefined;
+    }
+  }
+
   // Blob URL path: durable, survives cold starts
   if (isBlobUrl(token)) {
     try {

--- a/src/lib/chat/quickCheckPdfStore.ts
+++ b/src/lib/chat/quickCheckPdfStore.ts
@@ -14,6 +14,7 @@ import path from "path";
 
 const store = new Map<string, { filePath: string; expiresAt: number }>();
 const r2Store = new Map<string, { filePath: string; expiresAt: number }>();
+const r2Inflight = new Map<string, Promise<string | undefined>>();
 const PDF_REF_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 function cleanExpired(): void {
@@ -56,19 +57,40 @@ export async function resolvePdfRef(
   // Signed references have exactly two URL-safe segments. Invalid values in
   // this shape are rejected rather than being treated as arbitrary paths.
   if (token.split(".").length === 2) {
-    cleanExpired();
-    const cached = r2Store.get(token);
-    if (cached && cached.expiresAt >= Date.now()) return cached.filePath;
-    r2Store.delete(token);
     try {
-      const { retrieveQuickCheckUpload } = await import("@/lib/quickCheck/r2Upload");
-      const retrieved = await retrieveQuickCheckUpload(token);
-      const dir = path.join(os.tmpdir(), "quick-check-pdfs");
-      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-      const filePath = path.join(dir, `r2-${Date.now()}-${Math.random().toString(36).slice(2)}.pdf`);
-      writeFileSync(filePath, Buffer.from(retrieved.bytes));
-      r2Store.set(token, { filePath, expiresAt: Date.now() + PDF_REF_TTL_MS });
-      return filePath;
+      const { retrieveQuickCheckUpload, verifyUploadReference } = await import("@/lib/quickCheck/r2Upload");
+      const claims = verifyUploadReference(token);
+      cleanExpired();
+      const cached = r2Store.get(token);
+      if (cached && cached.expiresAt >= Date.now() && existsSync(cached.filePath)) return cached.filePath;
+      if (cached) {
+        r2Store.delete(token);
+        try { unlinkSync(cached.filePath); } catch { /* best effort cleanup */ }
+      }
+      const existing = r2Inflight.get(token);
+      if (existing) return existing;
+      const pending = (async () => {
+        try {
+          const retrieved = await retrieveQuickCheckUpload(token);
+          const dir = path.join(os.tmpdir(), "quick-check-pdfs");
+          if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+          const filePath = path.join(dir, `r2-${Date.now()}-${Math.random().toString(36).slice(2)}.pdf`);
+          writeFileSync(filePath, Buffer.from(retrieved.bytes));
+          const expiresAt = Math.min(claims.expiresAt * 1000, Date.now() + PDF_REF_TTL_MS);
+          if (expiresAt <= Date.now()) {
+            try { unlinkSync(filePath); } catch { /* best effort cleanup */ }
+            return undefined;
+          }
+          r2Store.set(token, { filePath, expiresAt });
+          return filePath;
+        } catch {
+          return undefined;
+        } finally {
+          r2Inflight.delete(token);
+        }
+      })();
+      r2Inflight.set(token, pending);
+      return pending;
     } catch {
       return undefined;
     }

--- a/src/lib/chat/quickCheckStructuredQuery.ts
+++ b/src/lib/chat/quickCheckStructuredQuery.ts
@@ -4,20 +4,20 @@ import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
 import type { StructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
 import type { ProjectFactField } from "@/lib/quickCheck/projectFacts/types";
 import { resolvePdfRef } from "@/lib/chat/quickCheckPdfStore";
-import { parseDocumentText } from "@/lib/documentParsing";
+import { parseDocumentText, type ParsedDocument } from "@/lib/documentParsing";
 import { initPymupdfAdapterRuntime } from "@/lib/documentParsing/adapters/pymupdfInit";
 
 initPymupdfAdapterRuntime();
 
 export { type StructuredQueryContext };
 
-export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?: string): Promise<StructuredQueryContext> {
-  const pdfFilePath = pdfRef ? await resolvePdfRef(pdfRef) : undefined;
+export async function resolveStructuredQueryContext(rawPddText: string, pdfRef?: string, parsedDocument?: ParsedDocument): Promise<StructuredQueryContext> {
+  const pdfFilePath = parsedDocument ? undefined : pdfRef ? await resolvePdfRef(pdfRef) : undefined;
 
   // When we have a real PDF path, parse with it to get PyMuPDF structure.
   // Otherwise, fall through to rawText-only parsing.
-  if (pdfFilePath) {
-    const parsed = parseDocumentText({ rawText: rawPddText, pdfFilePath });
+  if (parsedDocument || pdfFilePath) {
+    const parsed = parsedDocument ?? parseDocumentText({ rawText: rawPddText, pdfFilePath });
     const { buildArticle6DocumentModel } = await import("@/lib/documentModel");
     const { compileEvidenceDocumentFromStructure } = await import(
       "@/lib/quickCheck/evidence/compileEvidenceDocument"

--- a/src/lib/quickCheck/r2Upload.ts
+++ b/src/lib/quickCheck/r2Upload.ts
@@ -1,12 +1,12 @@
 import { createHmac, randomUUID, timingSafeEqual } from "crypto";
-import { DeleteObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { DeleteObjectCommand, GetObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 
 const PREFIX = "quick-check/";
 const REFERENCE_TTL_SECONDS = 600;
 const PRESIGNED_URL_TTL_SECONDS = 300;
-export type UploadErrorCode = "storage-not-configured" | "upload-reference-invalid" | "upload-reference-expired" | "upload-not-found" | "upload-too-large" | "upload-metadata-mismatch" | "storage-unavailable";
+export type UploadErrorCode = "storage-not-configured" | "upload-reference-invalid" | "upload-reference-expired" | "upload-environment-mismatch" | "upload-not-found" | "upload-too-large" | "upload-unsupported-content-type" | "upload-metadata-mismatch" | "storage-unavailable";
 export class QuickCheckUploadError extends Error { constructor(public readonly code: UploadErrorCode, message: string) { super(message); } }
 type Claims = { objectId: string; expectedSize: number; contentType: "application/pdf"; environment: string; issuedAt: number; expiresAt: number };
 function envName() { return process.env.VERCEL_ENV || process.env.NODE_ENV || "development"; }
@@ -33,7 +33,8 @@ export function verifyUploadReference(reference: string): Claims {
     const actual = Buffer.from(signature);
     if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) throw new Error();
     const claims = JSON.parse(decode(payload)) as Claims;
-    if (claims.contentType !== "application/pdf" || !Number.isInteger(claims.expectedSize) || claims.expectedSize <= 0 || claims.expectedSize > MAX_QUICK_CHECK_PDF_BYTES || typeof claims.objectId !== "string" || claims.environment !== envName()) throw new Error();
+    if (claims.contentType !== "application/pdf" || !Number.isInteger(claims.expectedSize) || claims.expectedSize <= 0 || claims.expectedSize > MAX_QUICK_CHECK_PDF_BYTES || typeof claims.objectId !== "string") throw new Error();
+    if (claims.environment !== envName()) throw new QuickCheckUploadError("upload-environment-mismatch", "This upload reference belongs to a different environment.");
     if (!Number.isInteger(claims.issuedAt) || !Number.isInteger(claims.expiresAt) || claims.expiresAt <= Math.floor(Date.now() / 1000)) throw new QuickCheckUploadError("upload-reference-expired", "The upload reference has expired.");
     return claims;
   } catch (error) {
@@ -60,6 +61,42 @@ export async function confirmQuickCheckUpload(reference: string) {
       throw new QuickCheckUploadError(actualSize && actualSize > MAX_QUICK_CHECK_PDF_BYTES ? "upload-too-large" : "upload-metadata-mismatch", "The uploaded PDF metadata did not match the requested upload.");
     }
     return { uploadRef: reference, size: actualSize };
+  } catch (error) {
+    if (error instanceof QuickCheckUploadError) throw error;
+    if ((error as { name?: string }).name === "NotFound" || (error as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode === 404) throw new QuickCheckUploadError("upload-not-found", "The uploaded PDF was not found.");
+    throw new QuickCheckUploadError("storage-unavailable", "Upload storage is temporarily unavailable.");
+  }
+}
+
+async function bodyToBuffer(body: unknown): Promise<Buffer> {
+  if (body && typeof body === "object" && "transformToByteArray" in body && typeof body.transformToByteArray === "function") {
+    return Buffer.from(await body.transformToByteArray());
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of body as AsyncIterable<Uint8Array | string>) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+/** Resolve and retrieve an upload without exposing the bucket or server-only object key. */
+export async function retrieveQuickCheckUpload(reference: string): Promise<{ bytes: ArrayBuffer; size: number }> {
+  const claims = verifyUploadReference(reference);
+  const { bucket, client } = config();
+  const key = objectKey(claims);
+  try {
+    const head = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    const size = head.ContentLength;
+    const contentType = head.ContentType?.toLowerCase();
+    if (size === undefined || size <= 0) throw new QuickCheckUploadError("upload-not-found", "The uploaded PDF was not found.");
+    if (size > MAX_QUICK_CHECK_PDF_BYTES || size !== claims.expectedSize) throw new QuickCheckUploadError("upload-too-large", "The uploaded PDF exceeds the Quick Check upload limit.");
+    if (contentType !== claims.contentType) throw new QuickCheckUploadError("upload-unsupported-content-type", "The uploaded object is not a PDF.");
+
+    const object = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    if (object.ContentLength !== undefined && object.ContentLength !== size) throw new QuickCheckUploadError("upload-metadata-mismatch", "The uploaded PDF metadata did not match the upload reference.");
+    if (object.ContentType && object.ContentType.toLowerCase() !== claims.contentType) throw new QuickCheckUploadError("upload-unsupported-content-type", "The uploaded object is not a PDF.");
+    if (!object.Body) throw new QuickCheckUploadError("storage-unavailable", "The uploaded PDF could not be retrieved.");
+    const bytes = await bodyToBuffer(object.Body);
+    if (bytes.length !== size) throw new QuickCheckUploadError("upload-metadata-mismatch", "The uploaded PDF metadata did not match the upload reference.");
+    return { bytes: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer, size };
   } catch (error) {
     if (error instanceof QuickCheckUploadError) throw error;
     if ((error as { name?: string }).name === "NotFound" || (error as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode === 404) throw new QuickCheckUploadError("upload-not-found", "The uploaded PDF was not found.");

--- a/src/lib/quickCheck/r2Upload.ts
+++ b/src/lib/quickCheck/r2Upload.ts
@@ -56,9 +56,13 @@ export async function confirmQuickCheckUpload(reference: string) {
   try {
     const head = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: objectKey(claims) }));
     const actualSize = head.ContentLength;
-    if (actualSize === undefined || actualSize <= 0 || actualSize > MAX_QUICK_CHECK_PDF_BYTES || actualSize !== claims.expectedSize || head.ContentType?.toLowerCase() !== claims.contentType) {
+    if (actualSize !== undefined && actualSize > MAX_QUICK_CHECK_PDF_BYTES) {
       await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: objectKey(claims) })).catch(() => undefined);
-      throw new QuickCheckUploadError(actualSize && actualSize > MAX_QUICK_CHECK_PDF_BYTES ? "upload-too-large" : "upload-metadata-mismatch", "The uploaded PDF metadata did not match the requested upload.");
+      throw new QuickCheckUploadError("upload-too-large", "The uploaded PDF exceeds the Quick Check upload limit.");
+    }
+    if (actualSize === undefined || actualSize <= 0 || actualSize !== claims.expectedSize || head.ContentType?.toLowerCase() !== claims.contentType) {
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: objectKey(claims) })).catch(() => undefined);
+      throw new QuickCheckUploadError("upload-metadata-mismatch", "The uploaded PDF metadata did not match the requested upload.");
     }
     return { uploadRef: reference, size: actualSize };
   } catch (error) {
@@ -87,7 +91,8 @@ export async function retrieveQuickCheckUpload(reference: string): Promise<{ byt
     const size = head.ContentLength;
     const contentType = head.ContentType?.toLowerCase();
     if (size === undefined || size <= 0) throw new QuickCheckUploadError("upload-not-found", "The uploaded PDF was not found.");
-    if (size > MAX_QUICK_CHECK_PDF_BYTES || size !== claims.expectedSize) throw new QuickCheckUploadError("upload-too-large", "The uploaded PDF exceeds the Quick Check upload limit.");
+    if (size > MAX_QUICK_CHECK_PDF_BYTES) throw new QuickCheckUploadError("upload-too-large", "The uploaded PDF exceeds the Quick Check upload limit.");
+    if (size !== claims.expectedSize) throw new QuickCheckUploadError("upload-metadata-mismatch", "The uploaded PDF metadata did not match the upload reference.");
     if (contentType !== claims.contentType) throw new QuickCheckUploadError("upload-unsupported-content-type", "The uploaded object is not a PDF.");
 
     const object = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));

--- a/src/lib/quickCheck/semanticEvidence/client.ts
+++ b/src/lib/quickCheck/semanticEvidence/client.ts
@@ -10,6 +10,7 @@ export async function fetchSemanticEvidenceCandidates(input: {
   claimText: string;
   rawPddText: string;
   pdfRef?: string;
+  documentStructure?: unknown;
   methodologyId: string;
   methodologyVersion: string;
 }): Promise<SemanticEvidenceResponse> {

--- a/src/lib/quickCheck/semanticEvidence/huggingFace.ts
+++ b/src/lib/quickCheck/semanticEvidence/huggingFace.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { buildArticle6DocumentModel } from "@/lib/documentModel";
+import type { Article6DocumentModel } from "@/lib/documentModel";
 import { parseDocumentText } from "@/lib/documentParsing";
 import { initDoclingAdapterRuntime } from "@/lib/documentParsing/adapters/doclingInit";
 import { initPymupdfAdapterRuntime } from "@/lib/documentParsing/adapters/pymupdfInit";
@@ -24,6 +25,7 @@ type SuggestInput = {
   claimText: string;
   rawPddText: string;
   pdfFilePath?: string;
+  documentStructure?: Article6DocumentModel;
   methodologyId?: string;
   methodologyVersion?: string;
 };
@@ -49,8 +51,7 @@ function extractKeywords(claimText: string): string[] {
 }
 
 function buildCandidateBlocks(input: SuggestInput) {
-  const parsedDocument = parseDocumentText({ rawText: input.rawPddText, pdfFilePath: input.pdfFilePath });
-  const model = buildArticle6DocumentModel({ parsedDocument });
+  const model = input.documentStructure ?? buildArticle6DocumentModel({ parsedDocument: parseDocumentText({ rawText: input.rawPddText, pdfFilePath: input.pdfFilePath }) });
   const sectionById = new Map(model.sections.map((section) => [section.id, section]));
   const keywords = extractKeywords(input.claimText);
 

--- a/src/lib/quickCheck/uploadOriginPolicy.ts
+++ b/src/lib/quickCheck/uploadOriginPolicy.ts
@@ -1,6 +1,5 @@
 type OriginPolicyFailureCode =
   | "upload-origin-not-configured"
-  | "preview-origin-policy-not-configured"
   | "origin-required"
   | "origin-invalid"
   | "cors-denied";
@@ -33,13 +32,6 @@ function configuredOrigins(): string[] {
     .map((url) => url.origin);
 }
 
-function previewHostnamePolicy(): { prefix: string; suffix: string } | undefined {
-  const prefix = process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX?.trim();
-  const suffix = process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX?.trim().toLowerCase();
-  if (!prefix || !suffix || suffix.length <= ".vercel.app".length || !suffix.endsWith(".vercel.app")) return undefined;
-  return { prefix, suffix };
-}
-
 export function authorizeQuickCheckUploadOrigin(originHeader: string | null): UploadOriginDecision {
   if (!originHeader) return { allowed: false, code: "origin-required", status: 403, error: "A browser Origin header is required." };
   const origin = parseOrigin(originHeader);
@@ -48,18 +40,6 @@ export function authorizeQuickCheckUploadOrigin(originHeader: string | null): Up
   const exactOrigins = configuredOrigins();
   if (exactOrigins.includes(origin.origin) && (environment() !== "production" || origin.protocol === "https:")) return { allowed: true, normalizedOrigin: origin.origin };
 
-  if (environment() !== "preview") {
-    if (environment() === "production" && !exactOrigins.some((value) => value.startsWith("https://"))) {
-      return { allowed: false, code: "upload-origin-not-configured", status: 503, error: "HTTPS upload origins are not configured for Production." };
-    }
-    return { allowed: false, code: exactOrigins.length ? "cors-denied" : "upload-origin-not-configured", status: exactOrigins.length ? 403 : 503, error: exactOrigins.length ? "This browser origin is not allowed to upload Quick Check PDFs." : "Upload origins are not configured." };
-  }
-
-  const policy = previewHostnamePolicy();
-  if (!policy) return { allowed: false, code: "preview-origin-policy-not-configured", status: 503, error: "Preview upload origin policy is not configured. Set R2_ALLOWED_PREVIEW_PROJECT_PREFIX and R2_ALLOWED_PREVIEW_TEAM_SUFFIX." };
-  const hostname = origin.hostname.toLowerCase();
-  if (origin.protocol === "https:" && !origin.port && hostname.startsWith(policy.prefix.toLowerCase()) && hostname.endsWith(policy.suffix)) {
-    return { allowed: true, normalizedOrigin: origin.origin };
-  }
+  if (!exactOrigins.length) return { allowed: false, code: "upload-origin-not-configured", status: 503, error: "Upload origins are not configured. Set R2_ALLOWED_UPLOAD_ORIGINS." };
   return { allowed: false, code: "cors-denied", status: 403, error: "This browser origin is not allowed to upload Quick Check PDFs." };
 }

--- a/src/lib/quickCheck/uploadOriginPolicy.ts
+++ b/src/lib/quickCheck/uploadOriginPolicy.ts
@@ -1,0 +1,65 @@
+type OriginPolicyFailureCode =
+  | "upload-origin-not-configured"
+  | "preview-origin-policy-not-configured"
+  | "origin-required"
+  | "origin-invalid"
+  | "cors-denied";
+
+export type UploadOriginDecision =
+  | { allowed: true; normalizedOrigin: string }
+  | { allowed: false; code: OriginPolicyFailureCode; status: 403 | 503; error: string };
+
+function environment(): string {
+  return process.env.VERCEL_ENV || process.env.NODE_ENV || "development";
+}
+
+function parseOrigin(value: string): URL | undefined {
+  try {
+    const url = new URL(value.trim());
+    if (!url.protocol || !url.hostname || url.username || url.password) return undefined;
+    if (url.pathname !== "/" || url.search || url.hash) return undefined;
+    if (url.protocol !== "https:" && url.protocol !== "http:") return undefined;
+    return url;
+  } catch {
+    return undefined;
+  }
+}
+
+function configuredOrigins(): string[] {
+  return (process.env.R2_ALLOWED_UPLOAD_ORIGINS ?? "")
+    .split(",")
+    .map((value) => parseOrigin(value))
+    .filter((url): url is URL => Boolean(url))
+    .map((url) => url.origin);
+}
+
+function previewHostnamePolicy(): { prefix: string; suffix: string } | undefined {
+  const prefix = process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX?.trim();
+  const suffix = process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX?.trim().toLowerCase();
+  if (!prefix || !suffix || suffix.length <= ".vercel.app".length || !suffix.endsWith(".vercel.app")) return undefined;
+  return { prefix, suffix };
+}
+
+export function authorizeQuickCheckUploadOrigin(originHeader: string | null): UploadOriginDecision {
+  if (!originHeader) return { allowed: false, code: "origin-required", status: 403, error: "A browser Origin header is required." };
+  const origin = parseOrigin(originHeader);
+  if (!origin) return { allowed: false, code: "origin-invalid", status: 403, error: "The browser Origin header is invalid." };
+
+  const exactOrigins = configuredOrigins();
+  if (exactOrigins.includes(origin.origin) && (environment() !== "production" || origin.protocol === "https:")) return { allowed: true, normalizedOrigin: origin.origin };
+
+  if (environment() !== "preview") {
+    if (environment() === "production" && !exactOrigins.some((value) => value.startsWith("https://"))) {
+      return { allowed: false, code: "upload-origin-not-configured", status: 503, error: "HTTPS upload origins are not configured for Production." };
+    }
+    return { allowed: false, code: exactOrigins.length ? "cors-denied" : "upload-origin-not-configured", status: exactOrigins.length ? 403 : 503, error: exactOrigins.length ? "This browser origin is not allowed to upload Quick Check PDFs." : "Upload origins are not configured." };
+  }
+
+  const policy = previewHostnamePolicy();
+  if (!policy) return { allowed: false, code: "preview-origin-policy-not-configured", status: 503, error: "Preview upload origin policy is not configured. Set R2_ALLOWED_PREVIEW_PROJECT_PREFIX and R2_ALLOWED_PREVIEW_TEAM_SUFFIX." };
+  const hostname = origin.hostname.toLowerCase();
+  if (origin.protocol === "https:" && !origin.port && hostname.startsWith(policy.prefix.toLowerCase()) && hostname.endsWith(policy.suffix)) {
+    return { allowed: true, normalizedOrigin: origin.origin };
+  }
+  return { allowed: false, code: "cors-denied", status: 403, error: "This browser origin is not allowed to upload Quick Check PDFs." };
+}

--- a/tests/api/quick-check.pdf-extract.route.test.ts
+++ b/tests/api/quick-check.pdf-extract.route.test.ts
@@ -39,6 +39,7 @@ describe("POST /api/quick-check/pdf-extract", () => {
     expect(response.status).toBe(200);
     const payload = await response.json();
     expect(payload.pdfRef).toBe(reference);
+    expect(payload.parsedDocument).toBeDefined();
     expect(payload.text).toContain("Project");
   }, 15000);
 

--- a/tests/api/quick-check.pdf-extract.route.test.ts
+++ b/tests/api/quick-check.pdf-extract.route.test.ts
@@ -18,6 +18,11 @@ describe("POST /api/quick-check/pdf-extract", () => {
     process.env.R2_SECRET_ACCESS_KEY = "secret-key";
   });
 
+  it("reports private R2 as the configured extraction storage", async () => {
+    const response = await (await import("@/app/api/quick-check/pdf-extract/route")).GET();
+    await expect(response.json()).resolves.toMatchObject({ storage: "private-r2" });
+  });
+
   it("retrieves a confirmed private-R2 PDF and sends its bytes to the existing extractor", async () => {
     const bytes = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf"));
     const reference = issueUploadReference(bytes.length);
@@ -159,7 +164,7 @@ describe("POST /api/quick-check/pdf-extract", () => {
     const response = await POST(
       new NextRequest("http://localhost/api/quick-check/pdf-extract", {
         method: "POST",
-        body: form as any, // NextRequest accepts FormData in test env
+        body: form, // NextRequest accepts FormData in test env
       }),
     );
 

--- a/tests/api/quick-check.pdf-extract.route.test.ts
+++ b/tests/api/quick-check.pdf-extract.route.test.ts
@@ -1,14 +1,41 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { NextRequest } from "next/server";
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import fs from "fs";
 import path from "path";
 
 import { POST } from "@/app/api/quick-check/pdf-extract/route";
+import { issueUploadReference } from "@/lib/quickCheck/r2Upload";
 
 describe("POST /api/quick-check/pdf-extract", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    process.env.QUICK_CHECK_UPLOAD_SIGNING_SECRET = "test-signing-secret";
+    process.env.VERCEL_ENV = "preview";
+    process.env.R2_ACCOUNT_ID = "account";
+    process.env.R2_BUCKET_NAME = "preview-bucket";
+    process.env.R2_ACCESS_KEY_ID = "access-key";
+    process.env.R2_SECRET_ACCESS_KEY = "secret-key";
   });
+
+  it("retrieves a confirmed private-R2 PDF and sends its bytes to the existing extractor", async () => {
+    const bytes = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf"));
+    const reference = issueUploadReference(bytes.length);
+    jest.spyOn(S3Client.prototype, "send").mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf" } as never;
+      if (command instanceof GetObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf", Body: { transformToByteArray: async () => new Uint8Array(bytes) } } as never;
+      throw new Error("unexpected command");
+    });
+    const response = await POST(new NextRequest("http://localhost/api/quick-check/pdf-extract", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ uploadRef: reference, objectKey: "client-controlled-key" }),
+    }));
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.pdfRef).toBe(reference);
+    expect(payload.text).toContain("Project");
+  }, 15000);
 
   it("returns extracted text for a small valid pdf upload (raw application/pdf path)", async () => {
     const bytes = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf"));

--- a/tests/api/quick-check.r2-ingestion.orchestration.test.ts
+++ b/tests/api/quick-check.r2-ingestion.orchestration.test.ts
@@ -1,0 +1,80 @@
+import fs from "fs";
+import path from "path";
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { NextRequest } from "next/server";
+import { POST as postUpload } from "@/app/api/quick-check/r2-upload/route";
+import { POST as postExtract } from "@/app/api/quick-check/pdf-extract/route";
+import { resolveStructuredQueryContext } from "@/lib/chat/quickCheckStructuredQuery";
+
+describe("Quick Check private R2 orchestration", () => {
+  it("performs one upload, retrieval, extraction, and Evidence Map build", async () => {
+    process.env.QUICK_CHECK_UPLOAD_SIGNING_SECRET = "test-signing-secret";
+    process.env.VERCEL_ENV = "preview";
+    process.env.R2_ACCOUNT_ID = "account";
+    process.env.R2_BUCKET_NAME = "preview-bucket";
+    process.env.R2_ACCESS_KEY_ID = "access-key";
+    process.env.R2_SECRET_ACCESS_KEY = "secret-key";
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://preview.article6.example";
+
+    const bytes = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf"));
+    let presignCount = 0;
+    let putCount = 0;
+    let confirmationCount = 0;
+    let getObjectCount = 0;
+    let extractionCount = 0;
+    jest.spyOn(S3Client.prototype, "send").mockImplementation(async (command) => {
+      if (command instanceof GetObjectCommand) {
+        getObjectCount += 1;
+        return { ContentLength: bytes.length, ContentType: "application/pdf", Body: { transformToByteArray: async () => new Uint8Array(bytes) } } as never;
+      }
+      if (command instanceof HeadObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf" } as never;
+      throw new Error("unexpected R2 command");
+    });
+
+    const presign = await postUpload(new NextRequest("https://preview.article6.example/api/quick-check/r2-upload", {
+      method: "POST",
+      headers: { origin: "https://preview.article6.example", "content-type": "application/json" },
+      body: JSON.stringify({ action: "presign", size: bytes.length, contentType: "application/pdf" }),
+    }));
+    presignCount += 1;
+    const presigned = await presign.json() as { uploadRef: string; url: string };
+
+    global.fetch = jest.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      if (String(url) === presigned.url && init?.method === "PUT") {
+        putCount += 1;
+        return new Response(null, { status: 200 });
+      }
+      throw new Error("unexpected browser request");
+    }) as typeof fetch;
+    await fetch(presigned.url, { method: "PUT", body: bytes });
+
+    const confirmation = await postUpload(new NextRequest("https://preview.article6.example/api/quick-check/r2-upload", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "confirm", uploadRef: presigned.uploadRef }),
+    }));
+    expect(confirmation.status).toBe(200);
+    confirmationCount += 1;
+
+    const extraction = await postExtract(new NextRequest("https://preview.article6.example/api/quick-check/pdf-extract", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ uploadRef: presigned.uploadRef }),
+    }));
+    extractionCount += 1;
+    expect(extraction.status).toBe(200);
+    const extracted = await extraction.json() as { text: string; parsedDocument: Parameters<typeof resolveStructuredQueryContext>[2] };
+    expect(extracted.text).toContain("Project");
+    expect(extracted.parsedDocument).toBeDefined();
+
+    const context = await resolveStructuredQueryContext(extracted.text, presigned.uploadRef, extracted.parsedDocument);
+    expect(context.evidenceDocument).toBeDefined();
+    expect({ presignCount, putCount, confirmationCount, getObjectCount, extractionCount }).toEqual({
+      presignCount: 1,
+      putCount: 1,
+      confirmationCount: 1,
+      getObjectCount: 1,
+      extractionCount: 1,
+    });
+  }, 30000);
+});

--- a/tests/api/quick-check.r2-ingestion.orchestration.test.ts
+++ b/tests/api/quick-check.r2-ingestion.orchestration.test.ts
@@ -5,6 +5,7 @@ import { NextRequest } from "next/server";
 import { POST as postUpload } from "@/app/api/quick-check/r2-upload/route";
 import { POST as postExtract } from "@/app/api/quick-check/pdf-extract/route";
 import { resolveStructuredQueryContext } from "@/lib/chat/quickCheckStructuredQuery";
+import { resolveQuickCheckPdfText } from "@/lib/chat/quickCheckPdfClient";
 
 describe("Quick Check private R2 orchestration", () => {
   it("performs one upload, retrieval, extraction, and Evidence Map build", async () => {
@@ -31,43 +32,50 @@ describe("Quick Check private R2 orchestration", () => {
       throw new Error("unexpected R2 command");
     });
 
-    const presign = await postUpload(new NextRequest("https://preview.article6.example/api/quick-check/r2-upload", {
-      method: "POST",
-      headers: { origin: "https://preview.article6.example", "content-type": "application/json" },
-      body: JSON.stringify({ action: "presign", size: bytes.length, contentType: "application/pdf" }),
-    }));
-    presignCount += 1;
-    const presigned = await presign.json() as { uploadRef: string; url: string };
-
     global.fetch = jest.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
-      if (String(url) === presigned.url && init?.method === "PUT") {
-        putCount += 1;
-        return new Response(null, { status: 200 });
+      const requestUrl = String(url);
+      if (requestUrl === "/api/quick-check/r2-upload") {
+        const body = typeof init?.body === "string" ? init.body : "{}";
+        const action = JSON.parse(body).action;
+        if (action === "presign") presignCount += 1;
+        if (action === "confirm") confirmationCount += 1;
+        return postUpload(new NextRequest(`https://preview.article6.example${requestUrl}`, {
+          method: "POST",
+          headers: { origin: "https://preview.article6.example", "content-type": "application/json" },
+          body,
+        }));
       }
-      throw new Error("unexpected browser request");
+      if (requestUrl === "/api/quick-check/pdf-extract") {
+        extractionCount += 1;
+        return postExtract(new NextRequest(`https://preview.article6.example${requestUrl}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: init?.body,
+        }));
+      }
+      throw new Error(`unexpected browser request: ${requestUrl}`);
     }) as typeof fetch;
-    await fetch(presigned.url, { method: "PUT", body: bytes });
 
-    const confirmation = await postUpload(new NextRequest("https://preview.article6.example/api/quick-check/r2-upload", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ action: "confirm", uploadRef: presigned.uploadRef }),
-    }));
-    expect(confirmation.status).toBe(200);
-    confirmationCount += 1;
+    class MockUploadXhr {
+      upload = { onprogress: undefined as ((event: ProgressEvent) => void) | undefined };
+      onload?: () => void;
+      onerror?: () => void;
+      status = 200;
+      open() {}
+      setRequestHeader() {}
+      send() {
+        putCount += 1;
+        this.upload.onprogress?.({ lengthComputable: true, loaded: bytes.length, total: bytes.length } as ProgressEvent);
+        this.onload?.();
+      }
+    }
+    global.XMLHttpRequest = MockUploadXhr as unknown as typeof XMLHttpRequest;
 
-    const extraction = await postExtract(new NextRequest("https://preview.article6.example/api/quick-check/pdf-extract", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ uploadRef: presigned.uploadRef }),
-    }));
-    extractionCount += 1;
-    expect(extraction.status).toBe(200);
-    const extracted = await extraction.json() as { text: string; parsedDocument: Parameters<typeof resolveStructuredQueryContext>[2] };
+    const extracted = await resolveQuickCheckPdfText({ bytes: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength), filename: "project.pdf" });
     expect(extracted.text).toContain("Project");
     expect(extracted.parsedDocument).toBeDefined();
 
-    const context = await resolveStructuredQueryContext(extracted.text, presigned.uploadRef, extracted.parsedDocument);
+    const context = await resolveStructuredQueryContext(extracted.text, extracted.pdfRef, extracted.parsedDocument);
     expect(context.evidenceDocument).toBeDefined();
     expect({ presignCount, putCount, confirmationCount, getObjectCount, extractionCount }).toEqual({
       presignCount: 1,

--- a/tests/api/quick-check.semantic-evidence.route.test.ts
+++ b/tests/api/quick-check.semantic-evidence.route.test.ts
@@ -1,0 +1,41 @@
+import fs from "fs";
+import path from "path";
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { NextRequest } from "next/server";
+import { issueUploadReference } from "@/lib/quickCheck/r2Upload";
+
+jest.mock("@/lib/quickCheck/semanticEvidence/huggingFace", () => ({
+  suggestSemanticEvidence: jest.fn(async (input: { pdfFilePath?: string }) => ({
+    status: "ok",
+    pdfFilePath: input.pdfFilePath,
+  })),
+}));
+
+import { POST } from "@/app/api/quick-check/semantic-evidence/route";
+import { suggestSemanticEvidence } from "@/lib/quickCheck/semanticEvidence/huggingFace";
+
+describe("POST /api/quick-check/semantic-evidence with signed R2 pdfRef", () => {
+  it("passes a server-materialized R2 PDF path to the semantic evidence consumer", async () => {
+    process.env.QUICK_CHECK_UPLOAD_SIGNING_SECRET = "test-signing-secret";
+    process.env.VERCEL_ENV = "preview";
+    process.env.R2_ACCOUNT_ID = "account";
+    process.env.R2_BUCKET_NAME = "preview-bucket";
+    process.env.R2_ACCESS_KEY_ID = "access-key";
+    process.env.R2_SECRET_ACCESS_KEY = "secret-key";
+    const bytes = fs.readFileSync(path.join(process.cwd(), "tests/fixtures/quick-check/plum-verra-demo-excerpt.pdf"));
+    const reference = issueUploadReference(bytes.length);
+    jest.spyOn(S3Client.prototype, "send").mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf" } as never;
+      if (command instanceof GetObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf", Body: { transformToByteArray: async () => new Uint8Array(bytes) } } as never;
+      throw new Error("unexpected command");
+    });
+    const response = await POST(new NextRequest("http://localhost/api/quick-check/semantic-evidence", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ claimText: "What is the project?", rawPddText: "Project Description", pdfRef: reference }),
+    }));
+    expect(response.status).toBe(200);
+    expect((await response.json()).status).toBe("ok");
+    expect(jest.mocked(suggestSemanticEvidence)).toHaveBeenCalledWith(expect.objectContaining({ pdfFilePath: expect.stringContaining("quick-check-pdfs") }));
+  });
+});

--- a/tests/api/quick-check.semantic-evidence.route.test.ts
+++ b/tests/api/quick-check.semantic-evidence.route.test.ts
@@ -38,4 +38,20 @@ describe("POST /api/quick-check/semantic-evidence with signed R2 pdfRef", () => 
     expect((await response.json()).status).toBe("ok");
     expect(jest.mocked(suggestSemanticEvidence)).toHaveBeenCalledWith(expect.objectContaining({ pdfFilePath: expect.stringContaining("quick-check-pdfs") }));
   });
+
+  it("uses the initial parser artifact without resolving a deferred R2 reference", async () => {
+    jest.mocked(suggestSemanticEvidence).mockClear();
+    const response = await POST(new NextRequest("http://localhost/api/quick-check/semantic-evidence", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        claimText: "What is the project?",
+        rawPddText: "Project Description",
+        pdfRef: "invalid.reference",
+        documentStructure: { sections: [], blocks: [] },
+      }),
+    }));
+    expect(response.status).toBe(200);
+    expect(jest.mocked(suggestSemanticEvidence)).toHaveBeenCalledWith(expect.objectContaining({ pdfFilePath: undefined, documentStructure: { sections: [], blocks: [] } }));
+  });
 });

--- a/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
+++ b/tests/components/quickCheckPanel.upload-integration-smoke.test.tsx
@@ -58,6 +58,7 @@ jest.mock("@/lib/chat/quickCheckPdfClient", () => {
     extractMethodologyMentions: (text: string) => string[];
   };
   return {
+    createQuickCheckPdfUploadCache: () => new Map(),
     resolveQuickCheckPdfText: async ({ filename }: { filename: string }) => {
       const text = PDF_TEXT_BY_FILENAME[filename] ?? "";
       return {

--- a/tests/components/quickCheckPanel.upload-regression.test.tsx
+++ b/tests/components/quickCheckPanel.upload-regression.test.tsx
@@ -37,6 +37,7 @@ jest.mock("@/lib/proofMap/attachments", () => ({
 }));
 
 jest.mock("@/lib/chat/quickCheckPdfClient", () => ({
+  createQuickCheckPdfUploadCache: () => new Map(),
   resolveQuickCheckPdfText: async ({ filename }: { filename: string }) => ({
     text:
       filename === "fresh-monitoring-report.pdf"
@@ -169,7 +170,9 @@ describe("QuickCheckPanel upload regression", () => {
             ? filenameField
             : fileField && typeof fileField === "object" && "name" in fileField
               ? String((fileField as File).name)
-              : "";
+              : typeof init?.body === "string"
+                ? String((JSON.parse(init.body) as { filename?: string }).filename ?? "")
+                : "";
         return new Response(
           JSON.stringify({
             text:

--- a/tests/lib/quickCheck/pdfRefParserTrace.test.ts
+++ b/tests/lib/quickCheck/pdfRefParserTrace.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, unlinkSync } from "fs";
 import { execFileSync } from "child_process";
 import path from "path";
 import { describe, expect, it } from "@jest/globals";
@@ -166,6 +166,64 @@ describe("resolveStructuredQueryContext with pdfRef → PyMuPDF", () => {
     const ctx = await resolveStructuredQueryContext("Project Description", reference);
     expect(ctx.parsedDocument.rawText).toBeTruthy();
     expect((await resolvePdfRef(reference))).toBe(resolved);
+  });
+
+  it("does not use a cached R2 path after signed-reference expiry", async () => {
+    const bytes = readFileSync(FIXTURE);
+    process.env.QUICK_CHECK_UPLOAD_SIGNING_SECRET = "test-signing-secret";
+    process.env.VERCEL_ENV = "preview";
+    process.env.R2_ACCOUNT_ID = "account";
+    process.env.R2_BUCKET_NAME = "preview-bucket";
+    process.env.R2_ACCESS_KEY_ID = "access-key";
+    process.env.R2_SECRET_ACCESS_KEY = "secret-key";
+    const reference = issueUploadReference(bytes.length);
+    jest.spyOn(S3Client.prototype, "send").mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf" } as never;
+      if (command instanceof GetObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf", Body: { transformToByteArray: async () => new Uint8Array(bytes) } } as never;
+      throw new Error("unexpected command");
+    });
+    expect(await resolvePdfRef(reference)).toBeTruthy();
+    process.env.VERCEL_ENV = "production";
+    expect(await resolvePdfRef(reference)).toBeUndefined();
+    process.env.VERCEL_ENV = "preview";
+    const now = Date.now;
+    Date.now = () => now() + 601_000;
+    try { expect(await resolvePdfRef(reference)).toBeUndefined(); } finally { Date.now = now; }
+  });
+
+  it("rematerializes a deleted cached file and deduplicates concurrent resolution", async () => {
+    const bytes = readFileSync(FIXTURE);
+    process.env.QUICK_CHECK_UPLOAD_SIGNING_SECRET = "test-signing-secret";
+    process.env.VERCEL_ENV = "preview";
+    process.env.R2_ACCOUNT_ID = "account";
+    process.env.R2_BUCKET_NAME = "preview-bucket";
+    process.env.R2_ACCESS_KEY_ID = "access-key";
+    process.env.R2_SECRET_ACCESS_KEY = "secret-key";
+    const reference = issueUploadReference(bytes.length);
+    let gets = 0;
+    jest.spyOn(S3Client.prototype, "send").mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf" } as never;
+      if (command instanceof GetObjectCommand) {
+        gets += 1;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return { ContentLength: bytes.length, ContentType: "application/pdf", Body: { transformToByteArray: async () => new Uint8Array(bytes) } } as never;
+      }
+      throw new Error("unexpected command");
+    });
+    const first = await resolvePdfRef(reference);
+    expect(first).toBeTruthy();
+    unlinkSync(first!);
+    const [second, third] = await Promise.all([resolvePdfRef(reference), resolvePdfRef(reference)]);
+    expect(second).toBe(third);
+    expect(gets).toBe(2);
+  });
+
+  it("uses the initial parsed artifact without resolving R2 again", async () => {
+    const parsed = parseDocumentText({ rawText: "Project Description", pdfFilePath: FIXTURE });
+    jest.restoreAllMocks();
+    const retrieve = jest.spyOn(S3Client.prototype, "send");
+    await resolveStructuredQueryContext("Project Description", "not-used-after-extraction", parsed);
+    expect(retrieve).not.toHaveBeenCalled();
   });
 
   it("resolveStructuredQueryContext without pdfRef falls back to current-extractor", async () => {

--- a/tests/lib/quickCheck/pdfRefParserTrace.test.ts
+++ b/tests/lib/quickCheck/pdfRefParserTrace.test.ts
@@ -1,12 +1,14 @@
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { execFileSync } from "child_process";
 import path from "path";
 import { describe, expect, it } from "@jest/globals";
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { parseDocumentText } from "@/lib/documentParsing";
 import { initPymupdfAdapterRuntime } from "@/lib/documentParsing/adapters/pymupdfInit";
 import { getStructuredQueryContext } from "@/lib/chat/quickCheckReviewQuestion";
 import { resolveStructuredQueryContext } from "@/lib/chat/quickCheckStructuredQuery";
 import { storePdfRef, resolvePdfRef } from "@/lib/chat/quickCheckPdfStore";
+import { issueUploadReference } from "@/lib/quickCheck/r2Upload";
 
 function isPymupdfAvailable(): boolean {
   const python3 = process.env.PYTHON3
@@ -143,6 +145,27 @@ describe("resolveStructuredQueryContext with pdfRef → PyMuPDF", () => {
       expect(ctx.parserAdapterId).toBe("pymupdf");
       expect(ctx.parserFallbackFrom).toBe("pymupdf");
     }
+  });
+
+  it("resolves a signed R2 pdfRef to a parser-compatible temporary path", async () => {
+    const bytes = readFileSync(FIXTURE);
+    process.env.QUICK_CHECK_UPLOAD_SIGNING_SECRET = "test-signing-secret";
+    process.env.VERCEL_ENV = "preview";
+    process.env.R2_ACCOUNT_ID = "account";
+    process.env.R2_BUCKET_NAME = "preview-bucket";
+    process.env.R2_ACCESS_KEY_ID = "access-key";
+    process.env.R2_SECRET_ACCESS_KEY = "secret-key";
+    const reference = issueUploadReference(bytes.length);
+    jest.spyOn(S3Client.prototype, "send").mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf" } as never;
+      if (command instanceof GetObjectCommand) return { ContentLength: bytes.length, ContentType: "application/pdf", Body: { transformToByteArray: async () => new Uint8Array(bytes) } } as never;
+      throw new Error("unexpected command");
+    });
+    const resolved = await resolvePdfRef(reference);
+    expect(resolved).toMatch(/quick-check-pdfs/);
+    const ctx = await resolveStructuredQueryContext("Project Description", reference);
+    expect(ctx.parsedDocument.rawText).toBeTruthy();
+    expect((await resolvePdfRef(reference))).toBe(resolved);
   });
 
   it("resolveStructuredQueryContext without pdfRef falls back to current-extractor", async () => {

--- a/tests/lib/quickCheckPdfClient.test.ts
+++ b/tests/lib/quickCheckPdfClient.test.ts
@@ -26,14 +26,13 @@ describe("Quick Check PDF client", () => {
     const result = await resolveQuickCheckPdfText({ bytes: pdfBytes(5 * 1024 * 1024), filename: "large.pdf" });
     expect(result.text).toContain("Large project description");
     const extractionCall = (global.fetch as jest.Mock).mock.calls.find(([url]) => String(url).includes("pdf-extract"));
-    expect(JSON.parse(extractionCall[1].body)).toEqual({ uploadRef: "signed-reference" });
+    expect(JSON.parse(extractionCall[1].body)).toEqual({ uploadRef: "signed-reference", filename: "large.pdf" });
   });
 
   it("accepts a 48.95 MiB PDF and completes direct upload and extraction", async () => {
     const urls: string[] = [];
     global.fetch = jest.fn(async (url: RequestInfo | URL) => { urls.push(String(url)); return new Response(JSON.stringify(String(url).includes("r2-upload") ? { uploadRef: "signed-reference", url: "https://r2.example/signed", size: 48_950_000 } : { text: "extracted content", engine: "pdf-parse" })); }) as typeof fetch;
     const result = await resolveQuickCheckPdfText({ bytes: pdfBytes(48_950_000), filename: "large-pdd.pdf" });
-    expect(urls).toEqual(["/api/quick-check/r2-upload", "/api/quick-check/r2-upload"]);
     expect(result.pdfRef).toBe("signed-reference");
     expect(result.text).toContain("extracted content");
     expect(urls).toEqual(["/api/quick-check/r2-upload", "/api/quick-check/r2-upload", "/api/quick-check/pdf-extract"]);
@@ -58,11 +57,26 @@ describe("Quick Check PDF client", () => {
     }) as typeof fetch;
     const input = { attachmentId: "attachment-1", sha256: "sha-same", bytes: pdfBytes(100), filename: "same.pdf" };
     const [first, second] = await Promise.all([resolveQuickCheckPdfText(input), resolveQuickCheckPdfText(input)]);
-    await resolveQuickCheckPdfText({ ...input, filename: "renamed.pdf" });
+    await resolveQuickCheckPdfText({ ...input, sha256: undefined, filename: "renamed.pdf" });
     expect(first.pdfRef).toBe("shared-reference");
     expect(second.pdfRef).toBe("shared-reference");
     expect(presigns).toBe(1);
     expect(confirmations).toBe(1);
+    expect((global.fetch as jest.Mock).mock.calls.filter(([url]) => String(url).includes("pdf-extract")).length).toBe(1);
+  });
+
+  it("clears a failed extraction so the same attachment can retry", async () => {
+    let extractionAttempts = 0;
+    global.fetch = jest.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("r2-upload")) return new Response(JSON.stringify({ uploadRef: "retry-extraction", url: "https://r2.example/signed", size: 100 }));
+      extractionAttempts += 1;
+      if (extractionAttempts === 1) return new Response(JSON.stringify({ error: "temporary extraction failure" }), { status: 503 });
+      return new Response(JSON.stringify({ text: "retried text", engine: "pdf-parse" }));
+    }) as typeof fetch;
+    const input = { attachmentId: "attachment-extraction-retry", sha256: "sha-extraction-retry", bytes: pdfBytes(100), filename: "retry.pdf" };
+    await expect(resolveQuickCheckPdfText(input)).rejects.toThrow("temporary extraction failure");
+    await expect(resolveQuickCheckPdfText(input)).resolves.toMatchObject({ text: "retried text" });
+    expect(extractionAttempts).toBe(2);
   });
 
   it("removes a failed cache entry so a later retry can upload", async () => {

--- a/tests/lib/quickCheckPdfClient.test.ts
+++ b/tests/lib/quickCheckPdfClient.test.ts
@@ -21,19 +21,22 @@ describe("Quick Check PDF client", () => {
     expect(JSON.parse(calls[1]!.body!)).toEqual({ action: "confirm", uploadRef: "signed-reference" });
   });
 
-  it("reports the temporary large-file extraction limitation after upload confirmation", async () => {
-    global.fetch = jest.fn(async (url: RequestInfo | URL) => new Response(JSON.stringify(String(url).includes("r2-upload") ? { uploadRef: "signed-reference", url: "https://r2.example/signed", size: 5 * 1024 * 1024 } : {}))) as typeof fetch;
+  it("retrieves and extracts a large PDF through the signed reference", async () => {
+    global.fetch = jest.fn(async (url: RequestInfo | URL) => new Response(JSON.stringify(String(url).includes("r2-upload") ? { uploadRef: "signed-reference", url: "https://r2.example/signed", size: 5 * 1024 * 1024 } : { pages: [{ pageNumber: 1, text: "Large project description" }], engine: "pdf-parse", metadata: { parser: "pdf-parse" } }))) as typeof fetch;
     const result = await resolveQuickCheckPdfText({ bytes: pdfBytes(5 * 1024 * 1024), filename: "large.pdf" });
-    expect(result.warning).toContain("server extraction for PDFs over 4 MiB is not available yet");
+    expect(result.text).toContain("Large project description");
+    const extractionCall = (global.fetch as jest.Mock).mock.calls.find(([url]) => String(url).includes("pdf-extract"));
+    expect(JSON.parse(extractionCall[1].body)).toEqual({ uploadRef: "signed-reference" });
   });
 
-  it("accepts a 48.95 MiB PDF and completes direct upload before the limitation", async () => {
+  it("accepts a 48.95 MiB PDF and completes direct upload and extraction", async () => {
     const urls: string[] = [];
-    global.fetch = jest.fn(async (url: RequestInfo | URL) => { urls.push(String(url)); return new Response(JSON.stringify({ uploadRef: "signed-reference", url: "https://r2.example/signed", size: 48_950_000 })); }) as typeof fetch;
+    global.fetch = jest.fn(async (url: RequestInfo | URL) => { urls.push(String(url)); return new Response(JSON.stringify(String(url).includes("r2-upload") ? { uploadRef: "signed-reference", url: "https://r2.example/signed", size: 48_950_000 } : { text: "extracted content", engine: "pdf-parse" })); }) as typeof fetch;
     const result = await resolveQuickCheckPdfText({ bytes: pdfBytes(48_950_000), filename: "large-pdd.pdf" });
     expect(urls).toEqual(["/api/quick-check/r2-upload", "/api/quick-check/r2-upload"]);
-    expect(result.warning).toContain("server extraction for PDFs over 4 MiB is not available yet");
     expect(result.pdfRef).toBe("signed-reference");
+    expect(result.text).toContain("extracted content");
+    expect(urls).toEqual(["/api/quick-check/r2-upload", "/api/quick-check/r2-upload", "/api/quick-check/pdf-extract"]);
   });
 
   it("accepts exactly 50 MiB and rejects 50 MiB plus one byte before presign", async () => {

--- a/tests/lib/quickCheckR2Upload.test.ts
+++ b/tests/lib/quickCheckR2Upload.test.ts
@@ -75,4 +75,15 @@ describe("Quick Check R2 upload references", () => {
     send.mockResolvedValueOnce({ ContentLength: 10, ContentType: "text/plain" } as never);
     await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-unsupported-content-type" });
   });
+
+  it("distinguishes size mismatches from objects that exceed the limit", async () => {
+    const reference = issueUploadReference(10);
+    const send = jest.spyOn(S3Client.prototype, "send");
+    send.mockResolvedValueOnce({ ContentLength: 9, ContentType: "application/pdf" } as never);
+    await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-metadata-mismatch" });
+    send.mockResolvedValueOnce({ ContentLength: 11, ContentType: "application/pdf" } as never);
+    await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-metadata-mismatch" });
+    send.mockResolvedValueOnce({ ContentLength: 50 * 1024 * 1024 + 1, ContentType: "application/pdf" } as never);
+    await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-too-large" });
+  });
 });

--- a/tests/lib/quickCheckR2Upload.test.ts
+++ b/tests/lib/quickCheckR2Upload.test.ts
@@ -1,9 +1,15 @@
-import { issueUploadReference, verifyUploadReference } from "@/lib/quickCheck/r2Upload";
+import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { issueUploadReference, retrieveQuickCheckUpload, verifyUploadReference } from "@/lib/quickCheck/r2Upload";
 
 describe("Quick Check R2 upload references", () => {
   beforeEach(() => {
     process.env.QUICK_CHECK_UPLOAD_SIGNING_SECRET = "test-signing-secret";
     process.env.VERCEL_ENV = "preview";
+    process.env.R2_ACCOUNT_ID = "account";
+    process.env.R2_BUCKET_NAME = "preview-bucket";
+    process.env.R2_ACCESS_KEY_ID = "access-key";
+    process.env.R2_SECRET_ACCESS_KEY = "secret-key";
+    jest.restoreAllMocks();
   });
 
   it("binds size, content type, environment, and expiry to a signed reference", () => {
@@ -16,7 +22,7 @@ describe("Quick Check R2 upload references", () => {
     const [payload, signature] = reference.split(".");
     expect(() => verifyUploadReference(`${payload}x.${signature}`)).toThrow("invalid");
     process.env.VERCEL_ENV = "production";
-    expect(() => verifyUploadReference(reference)).toThrow("invalid");
+    expect(() => verifyUploadReference(reference)).toThrow("different environment");
   });
 
   it("rejects expired references", () => {
@@ -28,5 +34,45 @@ describe("Quick Check R2 upload references", () => {
     } finally {
       Date.now = now;
     }
+  });
+
+  it("retrieves the signed object and never trusts a client-supplied key", async () => {
+    const reference = issueUploadReference(10);
+    const send = jest.spyOn(S3Client.prototype, "send");
+    send.mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) return { ContentLength: 10, ContentType: "application/pdf" } as never;
+      if (command instanceof GetObjectCommand) return { ContentLength: 10, ContentType: "application/pdf", Body: { transformToByteArray: async () => new Uint8Array(10) } } as never;
+      throw new Error("unexpected command");
+    });
+    const result = await retrieveQuickCheckUpload(reference);
+    expect(result.size).toBe(10);
+    expect(send.mock.calls.map(([command]) => command.input.Key)).toEqual([
+      expect.stringMatching(/^quick-check\/preview\//),
+      expect.stringMatching(/^quick-check\/preview\//),
+    ]);
+  });
+
+  it("rejects invalid and expired references before R2 retrieval", async () => {
+    const send = jest.spyOn(S3Client.prototype, "send");
+    expect(() => verifyUploadReference("not-a-reference")).toThrow("invalid");
+    expect(send).not.toHaveBeenCalled();
+    const reference = issueUploadReference(10);
+    const now = Date.now;
+    Date.now = () => now() + 601_000;
+    try {
+      await expect(retrieveQuickCheckUpload(reference)).rejects.toThrow("expired");
+      expect(send).not.toHaveBeenCalled();
+    } finally { Date.now = now; }
+  });
+
+  it("returns safe errors for missing, oversized, and non-PDF objects", async () => {
+    const reference = issueUploadReference(10);
+    const send = jest.spyOn(S3Client.prototype, "send");
+    send.mockRejectedValueOnce(Object.assign(new Error("not found"), { name: "NotFound" }));
+    await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-not-found" });
+    send.mockResolvedValueOnce({ ContentLength: 51 * 1024 * 1024, ContentType: "application/pdf" } as never);
+    await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-too-large" });
+    send.mockResolvedValueOnce({ ContentLength: 10, ContentType: "text/plain" } as never);
+    await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-unsupported-content-type" });
   });
 });

--- a/tests/lib/quickCheckUploadOriginPolicy.test.ts
+++ b/tests/lib/quickCheckUploadOriginPolicy.test.ts
@@ -3,72 +3,52 @@ import { authorizeQuickCheckUploadOrigin } from "@/lib/quickCheck/uploadOriginPo
 describe("Quick Check upload origin policy", () => {
   beforeEach(() => {
     delete process.env.R2_ALLOWED_UPLOAD_ORIGINS;
-    delete process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX;
-    delete process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX;
     process.env.VERCEL_ENV = "preview";
   });
 
   afterEach(() => {
     delete process.env.VERCEL_ENV;
     delete process.env.R2_ALLOWED_UPLOAD_ORIGINS;
-    delete process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX;
-    delete process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX;
   });
 
-  it("accepts exact HTTPS Production origins and rejects unconfigured origins", () => {
-    process.env.VERCEL_ENV = "production";
+  it("accepts a configured origin in Preview and Production", () => {
     process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
     expect(authorizeQuickCheckUploadOrigin("https://app.article6.example").allowed).toBe(true);
+    process.env.VERCEL_ENV = "production";
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.example").allowed).toBe(true);
+  });
+
+  it("rejects an unconfigured origin", () => {
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
     expect(authorizeQuickCheckUploadOrigin("https://other.example").code).toBe("cors-denied");
   });
 
-  it("keeps Production strict even when a dynamic Preview policy is configured", () => {
+  it("rejects malformed origins", () => {
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
+    expect(authorizeQuickCheckUploadOrigin("not an origin").code).toBe("origin-invalid");
+  });
+
+  it("rejects HTTP when HTTPS is configured", () => {
     process.env.VERCEL_ENV = "production";
     process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
-    process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX = "app-article6-";
-    process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX = "-fredillys-projects.vercel.app";
+    expect(authorizeQuickCheckUploadOrigin("http://app.article6.example").allowed).toBe(false);
+  });
+
+  it("rejects paths and credentials and normalizes the configured origin", () => {
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example/";
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.example/")).toMatchObject({ allowed: true, normalizedOrigin: "https://app.article6.example" });
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.example/path").code).toBe("origin-invalid");
+    expect(authorizeQuickCheckUploadOrigin("https://user:pass@app.article6.example").code).toBe("origin-invalid");
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.example:444").allowed).toBe(false);
+  });
+
+  it("does not allow Vercel wildcard origins", () => {
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
     expect(authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app").allowed).toBe(false);
   });
 
-  it("accepts a narrowly matched Article6 Preview hostname", () => {
-    process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX = "app-article6-";
-    process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX = "-fredillys-projects.vercel.app";
-    expect(authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app").allowed).toBe(true);
-  });
-
-  it.each([
-    "https://evil-project.vercel.app",
-    "https://evil-app-article6-fredillys-projects.vercel.app",
-    "https://app-article6-fredillys-projects.vercel.app.evil.com",
-    "https://app-article6-attacker.vercel.app.evil.com",
-    "http://app-article6-example-fredillys-projects.vercel.app",
-    "https://app-article6-example-fredillys-projects.vercel.app:444",
-    "not an origin",
-  ])("rejects unsafe Preview origin %s", (origin) => {
-    process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX = "app-article6-";
-    process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX = "-fredillys-projects.vercel.app";
-    expect(authorizeQuickCheckUploadOrigin(origin).allowed).toBe(false);
-  });
-
-  it("continues to accept exact configured origins in Preview", () => {
-    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://stable-preview.example";
-    expect(authorizeQuickCheckUploadOrigin("https://stable-preview.example").allowed).toBe(true);
-  });
-
-  it("requires Preview policy configuration for an unlisted Preview origin", () => {
-    const decision = authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app");
-    expect(decision).toMatchObject({ allowed: false, code: "preview-origin-policy-not-configured", status: 503 });
-  });
-
-  it("does not implicitly allow localhost or configured paths", () => {
-    expect(authorizeQuickCheckUploadOrigin("http://localhost:3000").allowed).toBe(false);
-    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "http://localhost:3000/path";
-    expect(authorizeQuickCheckUploadOrigin("http://localhost:3000").allowed).toBe(false);
-  });
-
-  it("rejects missing and malformed Origin headers distinctly", () => {
+  it("requires an Origin header and configured allowlist", () => {
     expect(authorizeQuickCheckUploadOrigin(null).code).toBe("origin-required");
-    expect(authorizeQuickCheckUploadOrigin("https://app-article6.example/path").code).toBe("origin-invalid");
-    expect(authorizeQuickCheckUploadOrigin("https://user:pass@app-article6.example").code).toBe("origin-invalid");
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.example")).toMatchObject({ allowed: false, code: "upload-origin-not-configured", status: 503 });
   });
 });

--- a/tests/lib/quickCheckUploadOriginPolicy.test.ts
+++ b/tests/lib/quickCheckUploadOriginPolicy.test.ts
@@ -1,0 +1,74 @@
+import { authorizeQuickCheckUploadOrigin } from "@/lib/quickCheck/uploadOriginPolicy";
+
+describe("Quick Check upload origin policy", () => {
+  beforeEach(() => {
+    delete process.env.R2_ALLOWED_UPLOAD_ORIGINS;
+    delete process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX;
+    delete process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX;
+    process.env.VERCEL_ENV = "preview";
+  });
+
+  afterEach(() => {
+    delete process.env.VERCEL_ENV;
+    delete process.env.R2_ALLOWED_UPLOAD_ORIGINS;
+    delete process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX;
+    delete process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX;
+  });
+
+  it("accepts exact HTTPS Production origins and rejects unconfigured origins", () => {
+    process.env.VERCEL_ENV = "production";
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.example").allowed).toBe(true);
+    expect(authorizeQuickCheckUploadOrigin("https://other.example").code).toBe("cors-denied");
+  });
+
+  it("keeps Production strict even when a dynamic Preview policy is configured", () => {
+    process.env.VERCEL_ENV = "production";
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
+    process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX = "app-article6-";
+    process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX = "-fredillys-projects.vercel.app";
+    expect(authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app").allowed).toBe(false);
+  });
+
+  it("accepts a narrowly matched Article6 Preview hostname", () => {
+    process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX = "app-article6-";
+    process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX = "-fredillys-projects.vercel.app";
+    expect(authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app").allowed).toBe(true);
+  });
+
+  it.each([
+    "https://evil-project.vercel.app",
+    "https://evil-app-article6-fredillys-projects.vercel.app",
+    "https://app-article6-fredillys-projects.vercel.app.evil.com",
+    "https://app-article6-attacker.vercel.app.evil.com",
+    "http://app-article6-example-fredillys-projects.vercel.app",
+    "https://app-article6-example-fredillys-projects.vercel.app:444",
+    "not an origin",
+  ])("rejects unsafe Preview origin %s", (origin) => {
+    process.env.R2_ALLOWED_PREVIEW_PROJECT_PREFIX = "app-article6-";
+    process.env.R2_ALLOWED_PREVIEW_TEAM_SUFFIX = "-fredillys-projects.vercel.app";
+    expect(authorizeQuickCheckUploadOrigin(origin).allowed).toBe(false);
+  });
+
+  it("continues to accept exact configured origins in Preview", () => {
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://stable-preview.example";
+    expect(authorizeQuickCheckUploadOrigin("https://stable-preview.example").allowed).toBe(true);
+  });
+
+  it("requires Preview policy configuration for an unlisted Preview origin", () => {
+    const decision = authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app");
+    expect(decision).toMatchObject({ allowed: false, code: "preview-origin-policy-not-configured", status: 503 });
+  });
+
+  it("does not implicitly allow localhost or configured paths", () => {
+    expect(authorizeQuickCheckUploadOrigin("http://localhost:3000").allowed).toBe(false);
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "http://localhost:3000/path";
+    expect(authorizeQuickCheckUploadOrigin("http://localhost:3000").allowed).toBe(false);
+  });
+
+  it("rejects missing and malformed Origin headers distinctly", () => {
+    expect(authorizeQuickCheckUploadOrigin(null).code).toBe("origin-required");
+    expect(authorizeQuickCheckUploadOrigin("https://app-article6.example/path").code).toBe("origin-invalid");
+    expect(authorizeQuickCheckUploadOrigin("https://user:pass@app-article6.example").code).toBe("origin-invalid");
+  });
+});


### PR DESCRIPTION
## Summary
- verify signed Quick Check upload references server-side and retrieve private R2 objects
- validate environment, size, content type, and retrieved bytes before using the existing PDF extractor
- remove the large-file stop path and expose retrieval/extraction/analysis processing states

## Validation
- `npx tsc --noEmit`
- focused R2, PDF extraction, client, and Quick Check upload tests
- changed-file ESLint
- `git diff --check`

## Preview verification
Manual Preview verification with `CCB_VCS_PD_5415_v2-1.pdf` was not run from this workspace because the Preview deployment and R2 credentials/object are external to the local test environment.