### PR TITLE
fix: prune VM0007 browser storage pairs

### DIFF
--- a/src/lib/preverif/vm0007EvidenceMapDraftStore.ts
+++ b/src/lib/preverif/vm0007EvidenceMapDraftStore.ts
@@ -3,12 +3,17 @@ import {
   type Vm0007EvidenceMapDraftPackage,
 } from "./vm0007EvidenceMapDraft";
 import type { ReviewerWorkflowState } from "@/lib/evidence/readinessReport";
+import {
+  VM0007_EVIDENCE_MAP_DRAFT_PREFIX,
+  Vm0007StorageWriteError,
+  writeVm0007Storage,
+} from "@/lib/preverif/vm0007Storage";
 
-const PREFIX = "article6:vm0007-evidence-map-draft:v1:";
+const PREFIX = VM0007_EVIDENCE_MAP_DRAFT_PREFIX;
 export const VM0007_EVIDENCE_MAP_DRAFT_EVENT = "vm0007-evidence-map-draft";
 export type Vm0007EvidenceMapDraftSaveResult =
   | { ok: true }
-  | { ok: false; reason: "draft_validation_failed" | "storage_unavailable" | "storage_write_failed" };
+  | { ok: false; reason: "draft_validation_failed" | "storage_unavailable" | "storage_write_failed"; serializedBytes?: number };
 const storage = () => typeof window === "undefined" ? null : window.localStorage;
 const key = (auditId: string) => `${PREFIX}${auditId.trim()}`;
 
@@ -69,9 +74,9 @@ export function saveVm0007EvidenceMapDraft(pkg: Vm0007EvidenceMapDraftPackage): 
   const target = storage();
   if (!target) return { ok: false, reason: "storage_unavailable" };
   try {
-    target.setItem(key(normalized.auditId), JSON.stringify(normalized));
-  } catch {
-    return { ok: false, reason: "storage_write_failed" };
+    writeVm0007Storage(target, key(normalized.auditId), JSON.stringify(normalized), normalized.auditId.trim());
+  } catch (error) {
+    return { ok: false, reason: "storage_write_failed", ...(error instanceof Vm0007StorageWriteError && error.serializedBytes !== null ? { serializedBytes: error.serializedBytes } : {}) };
   }
   window.dispatchEvent(new CustomEvent(VM0007_EVIDENCE_MAP_DRAFT_EVENT, { detail: { auditId: normalized.auditId, state: "saved", package: normalized } }));
   return { ok: true };

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -75,7 +75,7 @@ export function completeVm0007EvidenceMapGeneration(input: {
   try {
     const saveResult = saveDraft(input.draft.package);
     if (!saveResult.ok) {
-      clearVm0007GapReportAudit(input.audit.auditId);
+      if (saveResult.reason !== "draft_validation_failed") clearVm0007GapReportAudit(input.audit.auditId);
       const error = saveResult.reason === "storage_write_failed" && saveResult.serializedBytes !== undefined
         ? classifyEvidenceMapGenerationError({ error: `storage_write_failed; serialized_bytes=${saveResult.serializedBytes}`, blockedBy: [saveResult.reason], ...context, stage: "draft_persistence" })
         : undefined;

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -5,7 +5,7 @@ import {
 import type { MethodologyEvidenceAuditSummary } from "@/lib/preverif/evidenceAudit";
 import type { EvidenceMapSourceDocumentIdentity } from "@/lib/evidence/evidenceMapDependencyContract";
 import { type DraftBuildResult, type Vm0007EvidenceMapDraftPackage } from "@/lib/preverif/vm0007EvidenceMapDraft";
-import { loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft, type Vm0007EvidenceMapDraftSaveResult } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
+import { clearVm0007EvidenceMapDraft, loadVm0007EvidenceMapDraft, saveVm0007EvidenceMapDraft, type Vm0007EvidenceMapDraftSaveResult } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import { buildVm0007MachineProposal } from "@/lib/preverif/vm0007MachineProposal";
 import {
   classifyEvidenceMapGenerationError,
@@ -87,10 +87,12 @@ export function completeVm0007EvidenceMapGeneration(input: {
   }
   try {
     if (!loadDraft(input.audit.auditId)) {
+      clearVm0007EvidenceMapDraft(input.audit.auditId);
       clearVm0007GapReportAudit(input.audit.auditId);
       return { ...failedGeneration(["draft_reload_verification_failed"], undefined, { ...context, stage: "draft_reload_verification" }), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
     }
   } catch (error) {
+    clearVm0007EvidenceMapDraft(input.audit.auditId);
     clearVm0007GapReportAudit(input.audit.auditId);
     return { ...failedGeneration(["draft_reload_verification_failed"], classifyEvidenceMapGenerationError({ error, ...context, stage: "draft_reload_verification" })), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
   }

--- a/src/lib/preverif/vm0007GapReportStore.ts
+++ b/src/lib/preverif/vm0007GapReportStore.ts
@@ -12,8 +12,10 @@ import {
   type EvidenceMapGenerationError,
   type EvidenceMapGenerationStage,
 } from "@/lib/preverif/evidenceMapGenerationError";
-
-const VM0007_GAP_REPORT_AUDIT_PREFIX = "a6:vm0007-gap-report-audit:v1:";
+import {
+  VM0007_GAP_REPORT_AUDIT_PREFIX,
+  writeVm0007Storage,
+} from "@/lib/preverif/vm0007Storage";
 
 export type Vm0007GapReportAuditRecord = {
   auditId: string;
@@ -50,15 +52,7 @@ type GenerationContext = {
 const failedGeneration = (blockedBy: string[] = [], error?: EvidenceMapGenerationError, context: GenerationContext = {}): Vm0007EvidenceMapGenerationResult => {
   const resolvedError = error ?? classifyEvidenceMapGenerationError({ blockedBy, ...context });
   console.error("VM0007 Evidence Map generation diagnostic", resolvedError.diagnostic);
-  return {
-  auditSaved: false,
-  draftBuilt: false,
-  draftSaved: false,
-  blockedBy,
-  auditId: null,
-  audit: null,
-  error: resolvedError,
-  };
+  return { auditSaved: false, draftBuilt: false, draftSaved: false, blockedBy, auditId: null, audit: null, error: resolvedError };
 };
 
 export function completeVm0007EvidenceMapGeneration(input: {
@@ -81,36 +75,24 @@ export function completeVm0007EvidenceMapGeneration(input: {
   try {
     const saveResult = saveDraft(input.draft.package);
     if (!saveResult.ok) {
-      return {
-        ...failedGeneration([saveResult.reason], undefined, { ...context, stage: saveResult.reason === "draft_validation_failed" ? "draft_validation" : "draft_persistence" }),
-        auditSaved: true,
-        draftBuilt: true,
-        draftSaved: false,
-        auditId: input.audit.auditId,
-        audit: input.audit,
-      };
+      clearVm0007GapReportAudit(input.audit.auditId);
+      const error = saveResult.reason === "storage_write_failed" && saveResult.serializedBytes !== undefined
+        ? classifyEvidenceMapGenerationError({ error: `storage_write_failed; serialized_bytes=${saveResult.serializedBytes}`, blockedBy: [saveResult.reason], ...context, stage: "draft_persistence" })
+        : undefined;
+      return { ...failedGeneration([saveResult.reason], error, { ...context, stage: saveResult.reason === "draft_validation_failed" ? "draft_validation" : "draft_persistence" }), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
     }
   } catch (error) {
-    return {
-      ...failedGeneration(["draft_persistence_failed"], classifyEvidenceMapGenerationError({ error, ...context, stage: "draft_persistence" })),
-      auditSaved: true,
-      draftBuilt: true,
-      draftSaved: false,
-      auditId: input.audit.auditId,
-      audit: input.audit,
-    };
+    clearVm0007GapReportAudit(input.audit.auditId);
+    return { ...failedGeneration(["draft_persistence_failed"], classifyEvidenceMapGenerationError({ error, ...context, stage: "draft_persistence" })), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
   }
   try {
-    if (!loadDraft(input.audit.auditId)) return { ...failedGeneration(["draft_reload_verification_failed"], undefined, { ...context, stage: "draft_reload_verification" }), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
+    if (!loadDraft(input.audit.auditId)) {
+      clearVm0007GapReportAudit(input.audit.auditId);
+      return { ...failedGeneration(["draft_reload_verification_failed"], undefined, { ...context, stage: "draft_reload_verification" }), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
+    }
   } catch (error) {
-    return {
-      ...failedGeneration(["draft_reload_verification_failed"], classifyEvidenceMapGenerationError({ error, ...context, stage: "draft_reload_verification" })),
-      auditSaved: true,
-      draftBuilt: true,
-      draftSaved: false,
-      auditId: input.audit.auditId,
-      audit: input.audit,
-    };
+    clearVm0007GapReportAudit(input.audit.auditId);
+    return { ...failedGeneration(["draft_reload_verification_failed"], classifyEvidenceMapGenerationError({ error, ...context, stage: "draft_reload_verification" })), auditSaved: true, draftBuilt: true, draftSaved: false, auditId: input.audit.auditId, audit: input.audit };
   }
   return { auditSaved: true, draftBuilt: true, draftSaved: true, blockedBy: [], auditId: input.audit.auditId, audit: input.audit };
 }
@@ -142,7 +124,14 @@ export function buildVm0007GapReportHref(auditId: string): string {
 export function saveVm0007GapReportAudit(record: Vm0007GapReportAuditRecord): void {
   const storage = getStorage();
   if (!storage) return;
-  storage.setItem(storageKey(record.auditId), JSON.stringify(record));
+  writeVm0007Storage(storage, storageKey(record.auditId), JSON.stringify(record), record.auditId.trim());
+}
+
+export function clearVm0007GapReportAudit(auditId: string): boolean {
+  const storage = getStorage();
+  if (!storage) return false;
+  storage.removeItem(storageKey(auditId));
+  return true;
 }
 
 export function loadVm0007GapReportAudit(auditId: string): Vm0007GapReportAuditRecord | null {

--- a/src/lib/preverif/vm0007Storage.ts
+++ b/src/lib/preverif/vm0007Storage.ts
@@ -46,15 +46,16 @@ export function pruneOldVm0007Pairs(storage: Storage, currentId: string, retain 
     if (storageKey?.startsWith(VM0007_EVIDENCE_MAP_DRAFT_PREFIX)) draftIds.add(storageKey.slice(VM0007_EVIDENCE_MAP_DRAFT_PREFIX.length));
   }
 
-  const completePairs = [...auditIds].filter((auditId) => draftIds.has(auditId) && auditId !== currentId).map((auditId) => ({
+  const completePairs = [...auditIds].filter((auditId) => draftIds.has(auditId)).map((auditId) => ({
     auditId,
     timestamp: Math.max(
       readTimestamp(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId}`)),
       readTimestamp(storage.getItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${auditId}`)),
     ),
-  })).sort((left, right) => right.timestamp - left.timestamp || right.auditId.localeCompare(left.auditId));
+  })).map((pair) => pair.auditId === currentId ? { ...pair, timestamp: Number.POSITIVE_INFINITY } : pair)
+    .sort((left, right) => right.timestamp - left.timestamp || right.auditId.localeCompare(left.auditId));
 
-  for (const pair of completePairs.slice(retain)) {
+  for (const pair of completePairs.slice(retain).filter((pair) => pair.auditId !== currentId)) {
     storage.removeItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${pair.auditId}`);
     storage.removeItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${pair.auditId}`);
   }

--- a/src/lib/preverif/vm0007Storage.ts
+++ b/src/lib/preverif/vm0007Storage.ts
@@ -1,0 +1,108 @@
+export const VM0007_GAP_REPORT_AUDIT_PREFIX = "a6:vm0007-gap-report-audit:v1:";
+export const VM0007_EVIDENCE_MAP_DRAFT_PREFIX = "article6:vm0007-evidence-map-draft:v1:";
+export const VM0007_RETAINED_COMPLETE_PAIRS = 3;
+
+export class Vm0007StorageWriteError extends Error {
+  readonly code = "storage_write_failed" as const;
+  readonly serializedBytes: number | null;
+
+  constructor(cause: unknown, serializedBytes: number | null = null) {
+    const message = cause instanceof Error ? cause.message : String(cause ?? "Unknown storage error");
+    super(`storage_write_failed: ${message}`);
+    this.name = "Vm0007StorageWriteError";
+    this.serializedBytes = serializedBytes;
+  }
+}
+
+export function approximateSerializedSize(serialized: string): number {
+  // localStorage quotas are byte-oriented in browsers; UTF-16 gives a useful
+  // conservative estimate before attempting the write.
+  return serialized.length * 2;
+}
+
+export function isQuotaExceededError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { name?: unknown; code?: unknown; message?: unknown };
+  return candidate.name === "QuotaExceededError" || candidate.code === 22 || candidate.code === 1014 || /quota|storage full/i.test(String(candidate.message ?? ""));
+}
+
+function readTimestamp(raw: string | null): number {
+  if (!raw) return 0;
+  try {
+    const value = JSON.parse(raw) as { generatedAt?: unknown; updatedAt?: unknown };
+    const timestamp = Date.parse(String(value.generatedAt ?? value.updatedAt ?? ""));
+    return Number.isNaN(timestamp) ? 0 : timestamp;
+  } catch {
+    return 0;
+  }
+}
+
+export function pruneOldVm0007Pairs(storage: Storage, currentId: string, retain = VM0007_RETAINED_COMPLETE_PAIRS): void {
+  const auditIds = new Set<string>();
+  const draftIds = new Set<string>();
+  for (let index = 0; index < storage.length; index += 1) {
+    const storageKey = storage.key(index);
+    if (storageKey?.startsWith(VM0007_GAP_REPORT_AUDIT_PREFIX)) auditIds.add(storageKey.slice(VM0007_GAP_REPORT_AUDIT_PREFIX.length));
+    if (storageKey?.startsWith(VM0007_EVIDENCE_MAP_DRAFT_PREFIX)) draftIds.add(storageKey.slice(VM0007_EVIDENCE_MAP_DRAFT_PREFIX.length));
+  }
+
+  const completePairs = [...auditIds].filter((auditId) => draftIds.has(auditId) && auditId !== currentId).map((auditId) => ({
+    auditId,
+    timestamp: Math.max(
+      readTimestamp(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId}`)),
+      readTimestamp(storage.getItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${auditId}`)),
+    ),
+  })).sort((left, right) => right.timestamp - left.timestamp || right.auditId.localeCompare(left.auditId));
+
+  for (const pair of completePairs.slice(retain)) {
+    storage.removeItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${pair.auditId}`);
+    storage.removeItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${pair.auditId}`);
+  }
+}
+
+function removeOldestVm0007Pair(storage: Storage, currentId: string): boolean {
+  const auditIds = new Set<string>();
+  const draftIds = new Set<string>();
+  for (let index = 0; index < storage.length; index += 1) {
+    const storageKey = storage.key(index);
+    if (storageKey?.startsWith(VM0007_GAP_REPORT_AUDIT_PREFIX)) auditIds.add(storageKey.slice(VM0007_GAP_REPORT_AUDIT_PREFIX.length));
+    if (storageKey?.startsWith(VM0007_EVIDENCE_MAP_DRAFT_PREFIX)) draftIds.add(storageKey.slice(VM0007_EVIDENCE_MAP_DRAFT_PREFIX.length));
+  }
+  const eligible = [...auditIds].filter((auditId) => draftIds.has(auditId) && auditId !== currentId).map((auditId) => ({
+    auditId,
+    timestamp: Math.max(readTimestamp(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId}`)), readTimestamp(storage.getItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${auditId}`))),
+  })).sort((left, right) => left.timestamp - right.timestamp || left.auditId.localeCompare(right.auditId));
+  const oldest = eligible[0];
+  if (!oldest) return false;
+  storage.removeItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${oldest.auditId}`);
+  storage.removeItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${oldest.auditId}`);
+  return true;
+}
+
+export function writeVm0007Storage(storage: Storage, storageKey: string, serialized: string, currentId: string): void {
+  const serializedBytes = approximateSerializedSize(serialized);
+  const write = () => storage.setItem(storageKey, serialized);
+  try {
+    write();
+    pruneOldVm0007Pairs(storage, currentId);
+    return;
+  } catch (error) {
+    if (!isQuotaExceededError(error)) throw new Vm0007StorageWriteError(String(error), serializedBytes);
+    while (removeOldestVm0007Pair(storage, currentId)) {
+      try {
+        write();
+        pruneOldVm0007Pairs(storage, currentId);
+        return;
+      } catch (retryError) {
+        if (!isQuotaExceededError(retryError)) throw new Vm0007StorageWriteError(String(retryError), serializedBytes);
+      }
+    }
+    try {
+      write();
+      pruneOldVm0007Pairs(storage, currentId);
+      return;
+    } catch (retryError) {
+      throw new Vm0007StorageWriteError(String(retryError), serializedBytes);
+    }
+  }
+}

--- a/tests/lib/preverif/vm0007GapReportStore.orchestration.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.orchestration.test.ts
@@ -1,13 +1,17 @@
-import { describe, expect, test, jest } from "@jest/globals";
+/** @jest-environment jsdom */
+
+import { beforeEach, describe, expect, test, jest } from "@jest/globals";
 import type { Vm0007EvidenceMapDraftPackage, DraftBuildResult } from "@/lib/preverif/vm0007EvidenceMapDraft";
 import type { Vm0007EvidenceMapDraftSaveResult } from "@/lib/preverif/vm0007EvidenceMapDraftStore";
 import { completeVm0007EvidenceMapGeneration, type Vm0007GapReportAuditRecord } from "@/lib/preverif/vm0007GapReportStore";
+import { EVIDENCE_MAP_GENERATION_STAGES, classifyEvidenceMapGenerationError } from "@/lib/preverif/evidenceMapGenerationError";
 
 const audit = { auditId: "audit-1", generatedAt: "2026-07-01T00:00:00Z", evidenceFileName: "pdd.pdf", audit: { totalRules: 58 } } as Vm0007GapReportAuditRecord;
 const draftPackage = {} as Vm0007EvidenceMapDraftPackage;
 const builtDraft: DraftBuildResult = { ok: true, package: draftPackage };
 
 describe("VM0007 Evidence Map generation orchestration", () => {
+  beforeEach(() => localStorage.clear());
   test("keeps audit success separate when draft build is blocked", () => {
     const result = completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: { ok: false, blockedBy: ["pdd_declared_version_mismatch"] } });
     expect(result).toMatchObject({ auditSaved: true, draftBuilt: false, draftSaved: false, blockedBy: ["pdd_declared_version_mismatch"], auditId: "audit-1" });
@@ -23,42 +27,39 @@ describe("VM0007 Evidence Map generation orchestration", () => {
   });
 
   test("distinguishes draft validation and storage failures", () => {
-    expect(completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: false, reason: "draft_validation_failed" }), loadDraft: () => draftPackage })).toMatchObject({ draftBuilt: true, draftSaved: false, blockedBy: ["draft_validation_failed"], error: { category: "VALIDATION_ERROR", diagnostic: { stage: "draft_validation" } } });
-    expect(completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: false, reason: "storage_unavailable" }), loadDraft: () => draftPackage })).toMatchObject({ draftBuilt: true, draftSaved: false, blockedBy: ["storage_unavailable"], error: { category: "PERSISTENCE_ERROR", diagnostic: { stage: "draft_persistence" } } });
-    expect(completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: true }), loadDraft: () => null })).toMatchObject({ draftBuilt: true, draftSaved: false, blockedBy: ["draft_reload_verification_failed"], error: { category: "PERSISTENCE_ERROR", diagnostic: { stage: "draft_reload_verification" } } });
+    expect(completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: false, reason: "draft_validation_failed" }), loadDraft: () => draftPackage })).toMatchObject({ blockedBy: ["draft_validation_failed"], error: { category: "VALIDATION_ERROR", diagnostic: { stage: "draft_validation" } } });
+    expect(completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: false, reason: "storage_unavailable" }), loadDraft: () => draftPackage })).toMatchObject({ blockedBy: ["storage_unavailable"], error: { category: "PERSISTENCE_ERROR", diagnostic: { stage: "draft_persistence" } } });
+    expect(completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: false, reason: "storage_write_failed" }), loadDraft: () => draftPackage })).toMatchObject({ blockedBy: ["storage_write_failed"], error: { category: "PERSISTENCE_ERROR", diagnostic: { stage: "draft_persistence" } } });
+    expect(completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: true }), loadDraft: () => null })).toMatchObject({ blockedBy: ["draft_reload_verification_failed"], error: { category: "PERSISTENCE_ERROR", diagnostic: { stage: "draft_reload_verification" } } });
   });
 
   test("converts a thrown draft persistence error into the structured generation contract", () => {
-    const result = completeVm0007EvidenceMapGeneration({
-      audit,
-      auditSaved: true,
-      draft: builtDraft,
-      saveDraft: () => {
-        throw new Error("Quota exceeded while writing localStorage");
-      },
-      loadDraft: () => draftPackage,
-    });
-
-    expect(result).toMatchObject({
-      draftBuilt: true,
-      draftSaved: false,
-      blockedBy: ["draft_persistence_failed"],
-      error: {
-        category: "PERSISTENCE_ERROR",
-        userMessage: expect.stringContaining("could not be saved"),
-        diagnostic: { stage: "draft_persistence" },
-      },
-    });
-    expect(result.error?.userMessage).not.toContain("Evidence Map could not be created. You can retry.");
+    const result = completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => { throw new Error("Quota exceeded while writing localStorage"); }, loadDraft: () => draftPackage });
+    expect(result).toMatchObject({ draftBuilt: true, draftSaved: false, blockedBy: ["draft_persistence_failed"], error: { category: "PERSISTENCE_ERROR", userMessage: expect.stringContaining("could not be saved"), diagnostic: { stage: "draft_persistence" } } });
   });
 
-  test("keeps save and reload exceptions in their exact stages regardless of wording", () => {
+  test("keeps save and reload exceptions in their exact stages", () => {
     const saveResult = completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => { throw new Error("not a load error"); }, loadDraft: () => draftPackage });
     expect(saveResult.error?.diagnostic.stage).toBe("draft_persistence");
     const reloadResult = completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: true }), loadDraft: () => { throw new Error("write wording only"); } });
     expect(reloadResult.error?.diagnostic.stage).toBe("draft_reload_verification");
   });
 
+  test("removes only the new orphan audit when terminal draft persistence fails", () => {
+    localStorage.setItem("a6:vm0007-gap-report-audit:v1:audit-1", "new audit");
+    localStorage.setItem("a6:vm0007-gap-report-audit:v1:previous", "previous audit");
+    localStorage.setItem("article6:vm0007-evidence-map-draft:v1:previous", "previous draft");
+    const result = completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: false, reason: "storage_write_failed" }), loadDraft: () => draftPackage });
+    expect(result.blockedBy).toEqual(["storage_write_failed"]);
+    expect(localStorage.getItem("a6:vm0007-gap-report-audit:v1:audit-1")).toBeNull();
+    expect(localStorage.getItem("a6:vm0007-gap-report-audit:v1:previous")).toBe("previous audit");
+    expect(localStorage.getItem("article6:vm0007-evidence-map-draft:v1:previous")).toBe("previous draft");
+  });
+
+  test("preserves every PR #1127 diagnostic stage", () => {
+    expect(EVIDENCE_MAP_GENERATION_STAGES).toEqual(["input_validation", "machine_proposal_generation", "audit_persistence", "draft_validation", "draft_persistence", "draft_reload_verification"]);
+    for (const stage of EVIDENCE_MAP_GENERATION_STAGES) expect(classifyEvidenceMapGenerationError({ stage }).diagnostic.stage).toBe(stage);
+  });
 
   test("preserves internal blocker reasons while failing an unsaved audit", () => {
     const result = completeVm0007EvidenceMapGeneration({ audit, auditSaved: false, draft: builtDraft });

--- a/tests/lib/preverif/vm0007GapReportStore.orchestration.test.ts
+++ b/tests/lib/preverif/vm0007GapReportStore.orchestration.test.ts
@@ -45,15 +45,19 @@ describe("VM0007 Evidence Map generation orchestration", () => {
     expect(reloadResult.error?.diagnostic.stage).toBe("draft_reload_verification");
   });
 
-  test("removes only the new orphan audit when terminal draft persistence fails", () => {
+  test.each(["null", "exception"])("removes both new records on terminal draft reload %s", (failure) => {
     localStorage.setItem("a6:vm0007-gap-report-audit:v1:audit-1", "new audit");
+    localStorage.setItem("article6:vm0007-evidence-map-draft:v1:audit-1", "new draft");
     localStorage.setItem("a6:vm0007-gap-report-audit:v1:previous", "previous audit");
     localStorage.setItem("article6:vm0007-evidence-map-draft:v1:previous", "previous draft");
-    const result = completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: false, reason: "storage_write_failed" }), loadDraft: () => draftPackage });
-    expect(result.blockedBy).toEqual(["storage_write_failed"]);
+    localStorage.setItem("article6:unrelated", "keep");
+    const result = completeVm0007EvidenceMapGeneration({ audit, auditSaved: true, draft: builtDraft, saveDraft: () => ({ ok: true }), loadDraft: failure === "null" ? () => null : () => { throw new Error("reload failed"); } });
+    expect(result.blockedBy).toEqual(["draft_reload_verification_failed"]);
     expect(localStorage.getItem("a6:vm0007-gap-report-audit:v1:audit-1")).toBeNull();
+    expect(localStorage.getItem("article6:vm0007-evidence-map-draft:v1:audit-1")).toBeNull();
     expect(localStorage.getItem("a6:vm0007-gap-report-audit:v1:previous")).toBe("previous audit");
     expect(localStorage.getItem("article6:vm0007-evidence-map-draft:v1:previous")).toBe("previous draft");
+    expect(localStorage.getItem("article6:unrelated")).toBe("keep");
   });
 
   test("preserves every PR #1127 diagnostic stage", () => {

--- a/tests/lib/preverif/vm0007Storage.test.ts
+++ b/tests/lib/preverif/vm0007Storage.test.ts
@@ -76,6 +76,18 @@ test("retries a quota failure exactly once", () => {
   expect(storage.getItem("a6:vm0007-gap-report-audit:v1:retry")).toBe("value");
 });
 
+test("retains exactly three complete pairs after saving the fourth, including the newest pair", () => {
+  const storage = makeStorage();
+  seedPair(storage, "pair-1", "2026-01-01T00:00:00.000Z");
+  seedPair(storage, "pair-2", "2026-01-02T00:00:00.000Z");
+  seedPair(storage, "pair-3", "2026-01-03T00:00:00.000Z");
+  writeVm0007Storage(storage, `${VM0007_GAP_REPORT_AUDIT_PREFIX}pair-4`, JSON.stringify({ generatedAt: "2026-01-04T00:00:00.000Z" }), "pair-4");
+  writeVm0007Storage(storage, `${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}pair-4`, JSON.stringify({ generatedAt: "2026-01-04T00:00:00.000Z" }), "pair-4");
+
+  const completeIds = ["pair-1", "pair-2", "pair-3", "pair-4"].filter((auditId) => storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId}`) && storage.getItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${auditId}`));
+  expect(completeIds).toEqual(["pair-2", "pair-3", "pair-4"]);
+});
+
 test("progressively evicts the oldest eligible pairs until a quota retry succeeds", () => {
   const storage = makeStorage();
   seedPair(storage, "old-1", "2026-01-01T00:00:00.000Z");

--- a/tests/lib/preverif/vm0007Storage.test.ts
+++ b/tests/lib/preverif/vm0007Storage.test.ts
@@ -1,0 +1,116 @@
+import { expect, jest, test } from "@jest/globals";
+import {
+  VM0007_EVIDENCE_MAP_DRAFT_PREFIX,
+  VM0007_GAP_REPORT_AUDIT_PREFIX,
+  Vm0007StorageWriteError,
+  writeVm0007Storage,
+} from "@/lib/preverif/vm0007Storage";
+
+function makeStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() { return values.size; },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => { values.set(key, String(value)); },
+  } as Storage;
+}
+
+function seedPair(storage: Storage, auditId: string, generatedAt: string): void {
+  storage.setItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId}`, JSON.stringify({ generatedAt }));
+  storage.setItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${auditId}`, JSON.stringify({ generatedAt }));
+}
+
+function quotaError(): Error {
+  const error = new Error("localStorage quota exceeded") as Error & { name: string };
+  error.name = "QuotaExceededError";
+  return error;
+}
+
+test("prunes oldest complete pairs first, retains newest three, and leaves unrelated keys untouched", () => {
+  const storage = makeStorage();
+  seedPair(storage, "oldest", "2026-01-01T00:00:00.000Z");
+  seedPair(storage, "second-oldest", "2026-01-02T00:00:00.000Z");
+  seedPair(storage, "middle", "2026-01-03T00:00:00.000Z");
+  seedPair(storage, "newest-1", "2026-01-04T00:00:00.000Z");
+  seedPair(storage, "newest-2", "2026-01-05T00:00:00.000Z");
+  seedPair(storage, "newest-3", "2026-01-06T00:00:00.000Z");
+  storage.setItem("article6:unrelated", "keep me");
+
+  let writes = 0;
+  const originalSetItem = storage.setItem.bind(storage);
+  jest.spyOn(storage, "setItem").mockImplementation((key, value) => {
+    writes += 1;
+    if (writes === 1) throw quotaError();
+    originalSetItem(key, value);
+  });
+
+  writeVm0007Storage(storage, `${VM0007_GAP_REPORT_AUDIT_PREFIX}current`, "large-audit", "current");
+
+  expect(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}oldest`)).toBeNull();
+  expect(storage.getItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}oldest`)).toBeNull();
+  expect(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}second-oldest`)).toBeNull();
+  expect(storage.getItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}second-oldest`)).toBeNull();
+  expect(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}middle`)).toBeNull();
+  for (const auditId of ["newest-1", "newest-2", "newest-3", "current"]) {
+    expect(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId}`)).not.toBeNull();
+  }
+  expect(storage.getItem("article6:unrelated")).toBe("keep me");
+  expect(writes).toBe(2);
+});
+
+test("retries a quota failure exactly once", () => {
+  const storage = makeStorage();
+  let writes = 0;
+  const originalSetItem = storage.setItem.bind(storage);
+  jest.spyOn(storage, "setItem").mockImplementation((key, value) => {
+    writes += 1;
+    if (writes === 1) throw quotaError();
+    originalSetItem(key, value);
+  });
+
+  writeVm0007Storage(storage, "a6:vm0007-gap-report-audit:v1:retry", "value", "retry");
+  expect(writes).toBe(2);
+  expect(storage.getItem("a6:vm0007-gap-report-audit:v1:retry")).toBe("value");
+});
+
+test("progressively evicts the oldest eligible pairs until a quota retry succeeds", () => {
+  const storage = makeStorage();
+  seedPair(storage, "old-1", "2026-01-01T00:00:00.000Z");
+  seedPair(storage, "old-2", "2026-01-02T00:00:00.000Z");
+  seedPair(storage, "old-3", "2026-01-03T00:00:00.000Z");
+  seedPair(storage, "new-1", "2026-01-04T00:00:00.000Z");
+  let writes = 0;
+  const originalSetItem = storage.setItem.bind(storage);
+  jest.spyOn(storage, "setItem").mockImplementation((key, value) => {
+    writes += 1;
+    if (writes < 4) throw quotaError();
+    originalSetItem(key, value);
+  });
+
+  writeVm0007Storage(storage, `${VM0007_GAP_REPORT_AUDIT_PREFIX}current`, "large-audit", "current");
+
+  for (const auditId of ["old-1", "old-2", "old-3"]) {
+    expect(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}${auditId}`)).toBeNull();
+    expect(storage.getItem(`${VM0007_EVIDENCE_MAP_DRAFT_PREFIX}${auditId}`)).toBeNull();
+  }
+  expect(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}new-1`)).not.toBeNull();
+  expect(storage.getItem(`${VM0007_GAP_REPORT_AUDIT_PREFIX}current`)).toBe("large-audit");
+  expect(writes).toBe(4);
+});
+
+test("returns storage_write_failed when the retry also fails", () => {
+  const storage = makeStorage();
+  const setItem = jest.spyOn(storage, "setItem").mockImplementation(() => { throw quotaError(); });
+
+  try {
+    writeVm0007Storage(storage, "a6:vm0007-gap-report-audit:v1:failed", "value", "failed");
+    throw new Error("expected write to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(Vm0007StorageWriteError);
+    expect((error as Vm0007StorageWriteError).code).toBe("storage_write_failed");
+  }
+  expect(setItem).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
## What changed

Adds bounded VM0007 localStorage persistence for audits and Evidence Map drafts. On quota pressure, it estimates the serialized payload, removes the oldest complete VM0007 audit/draft pairs progressively, protects the record currently being generated, and keeps at most the newest three complete pairs.

Terminal draft save or reload failures clean up the newly-created incomplete audit/draft pair so orphaned browser records do not accumulate.

## Root cause

Evidence Map generation completed, but accumulated VM0007 audit/draft records could exhaust browser localStorage. Preview used a clean origin, masking the production-only storage failure.

## Impact and safety

Existing diagnostic IDs, persistence stages, structured save results, and PR #1127 error categories are preserved. Unrelated localStorage keys, evidence matching, classifications, reviewed truth, totals, and R2 behavior are unchanged.

## Checks

- Focused VM0007 storage, orchestration, and draft-store tests
- Large VM0007 58-requirement upload/Evidence Map smoke test
- Next.js tests and build
- pr-gate
- TypeScript
- ESLint
- git diff --check

No migration or environment variables are required.