### PR TITLE
Fix VM0007 methodology version provenance

### DIFF
--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -911,10 +911,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     return draft.methodologyId.trim() || resolvedWorkspaceMethod?.methodologyId || "";
   }, [draft.methodologyId, draft.status, resolvedWorkspaceMethod]);
   const workspaceMethodologyVersion = useMemo(() => {
-    if (draft.status !== "checked" && resolvedWorkspaceMethod?.rulebookVersion) {
-      return resolvedWorkspaceMethod.rulebookVersion ?? "";
+    if (draft.status !== "checked" && resolvedWorkspaceMethod?.methodologyVersion) {
+      return resolvedWorkspaceMethod.methodologyVersion;
     }
-    return draft.methodologyVersion.trim() || resolvedWorkspaceMethod?.rulebookVersion || "";
+    return draft.methodologyVersion.trim() || resolvedWorkspaceMethod?.methodologyVersion || "";
   }, [draft.methodologyVersion, draft.status, resolvedWorkspaceMethod]);
   const methodologyMismatch = useMemo(() => {
     if (!draft.methodologyId.trim()) return null;
@@ -1797,7 +1797,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const resolvedMethodologyId = draft.methodologyId.trim()
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
       const resolvedMethodologyVersion = draft.methodologyVersion.trim()
-        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.rulebookVersion ?? "" : "");
+        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
 
       if (isReviewQuestion) {
         const firstSource = selectedEvidenceSources[0];
@@ -1870,7 +1870,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const selectedMethodologyId = draft.methodologyId.trim()
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
       const selectedMethodologyVersion = draft.methodologyVersion.trim()
-        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.rulebookVersion ?? "" : "");
+        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
       const allowedMethodologyIds = draft.methodologyId.trim()
         ? new Set([draft.methodologyId.trim()])
         : currentMethodologyResolution.status === "single" || currentMethodologyResolution.status === "multiple"

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1196,6 +1196,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   async function buildAndSaveVm0007GapReportAuditWithWarning(input: {
     methodologyId: string;
     methodologyVersion: string;
+    declaredMethodologyId?: string;
+    pddDeclaredMethodologyVersion?: string | null;
     evidenceFileName?: string;
     sourcePdfSha256?: string | null;
     rawPddText: string;
@@ -1209,11 +1211,33 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     const methodologyResult = validateAnswerResults(extractAnswersForAllChecks(parsedDocument))
       .find((result) => result.checkName === "methodology");
     const methodology = methodologyResult?.methodology;
+    const resolvedDeclaredMethodologyId = input.declaredMethodologyId?.trim() || methodology?.methodologyId || input.methodologyId;
+    const resolvedDeclaredMethodologyVersion = input.pddDeclaredMethodologyVersion !== undefined
+      ? input.pddDeclaredMethodologyVersion ?? ""
+      : methodology?.pddDeclaredMethodologyVersion || "";
     const versionLock = buildMethodologyVersionLock({
-      methodologyId: methodology?.methodologyId || input.methodologyId,
+      methodologyId: resolvedDeclaredMethodologyId,
       rulebookVersion: input.methodologyVersion,
-      pddDeclaredMethodologyVersion: methodology?.pddDeclaredMethodologyVersion || "",
+      pddDeclaredMethodologyVersion: resolvedDeclaredMethodologyVersion,
+      pddDeclaredMethodologyId: input.declaredMethodologyId,
     });
+    const resolvedMethodology = methodology
+      ? {
+          ...methodology,
+          methodologyId: resolvedDeclaredMethodologyId,
+          pddDeclaredMethodologyVersion: resolvedDeclaredMethodologyVersion || null,
+          versionStatus: resolvedDeclaredMethodologyVersion ? "DECLARED" as const : methodology.versionStatus,
+        }
+      : {
+          methodologyId: resolvedDeclaredMethodologyId,
+          methodologyName: resolvedDeclaredMethodologyId,
+          methodologyAlias: "",
+          pddDeclaredMethodologyVersion: resolvedDeclaredMethodologyVersion || null,
+          versionStatus: resolvedDeclaredMethodologyVersion ? "DECLARED" as const : "UNKNOWN" as const,
+          evidencePage: 0,
+          evidenceSection: "",
+          evidenceQuote: input.rawPddText.trim(),
+        };
     if (!versionLock.versionMatch) {
       const warningMessage = [
         "Methodology version mismatch: results may be wrong.",
@@ -1239,16 +1263,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     }
 
     return buildAndSaveVm0007GapReportAudit({
-      methodology: methodology ?? {
-        methodologyId: input.methodologyId,
-        methodologyName: input.methodologyId,
-        methodologyAlias: "",
-        pddDeclaredMethodologyVersion: null,
-        versionStatus: "UNKNOWN",
-        evidencePage: 0,
-        evidenceSection: "",
-        evidenceQuote: input.rawPddText.trim(),
-      },
+      methodology: resolvedMethodology,
       loadedRulebookId: input.methodologyId,
       loadedRulebookVersion: input.methodologyVersion,
       evidenceFileName: input.evidenceFileName,
@@ -1274,6 +1289,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const savedAudit = await buildAndSaveVm0007GapReportAuditWithWarning({
         methodologyId: detectedVm0007Method.methodologyId,
         methodologyVersion: detectedVm0007Method.rulebookVersion,
+        declaredMethodologyId: detectedVm0007Method.methodologyId,
+        pddDeclaredMethodologyVersion: detectedVm0007Method.methodologyVersion,
         evidenceFileName: draft.evidenceFileName || selectedEvidenceLabel,
         sourcePdfSha256: selectedUpload?.attachment.sha256 ?? selectedPins.find((pin) => pin.pdd_document)?.pdd_document?.sha256 ?? null,
         rawPddText,
@@ -1523,6 +1540,8 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
           const savedAudit = await buildAndSaveVm0007GapReportAuditWithWarning({
             methodologyId: candidate.methodologyId,
             methodologyVersion: candidate.methodologyVersion,
+            declaredMethodologyId: methodologyResolution.matchedMethods.find((method) => method.methodologyId === candidate.methodologyId)?.methodologyId,
+            pddDeclaredMethodologyVersion: methodologyResolution.matchedMethods.find((method) => method.methodologyId === candidate.methodologyId)?.methodologyVersion,
             evidenceFileName: activeDraft.evidenceFileName,
             sourcePdfSha256: (() => {
               const activeUpload = activeSession.stagedUploads.find((upload) => activeDraft.evidenceIds.includes(upload.evidenceId));

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -617,27 +617,6 @@ function extractionStateBadgeClass(value: string): string {
   return "border-rose-200 bg-rose-50 text-rose-800";
 }
 
-function confidenceLabel(value: "high" | "medium" | "low" | "unknown" | undefined): string {
-  if (value === "high") return "High";
-  if (value === "medium") return "Medium";
-  if (value === "low") return "Low";
-  return "Unknown";
-}
-
-function confidenceBarWidth(value: "high" | "medium" | "low" | "unknown" | undefined): string {
-  if (value === "high") return "100%";
-  if (value === "medium") return "68%";
-  if (value === "low") return "36%";
-  return "18%";
-}
-
-function confidenceBarTone(value: "high" | "medium" | "low" | "unknown" | undefined): string {
-  if (value === "high") return "bg-emerald-500";
-  if (value === "medium") return "bg-sky-500";
-  if (value === "low") return "bg-amber-500";
-  return "bg-slate-300";
-}
-
 function formatMethodLabel(id: string, version?: string | null): string {
   return `${id}${version ? ` ${version}` : ""}`;
 }
@@ -932,10 +911,10 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     return draft.methodologyId.trim() || resolvedWorkspaceMethod?.methodologyId || "";
   }, [draft.methodologyId, draft.status, resolvedWorkspaceMethod]);
   const workspaceMethodologyVersion = useMemo(() => {
-    if (draft.status !== "checked" && resolvedWorkspaceMethod?.methodologyVersion) {
-      return resolvedWorkspaceMethod.methodologyVersion;
+    if (draft.status !== "checked" && resolvedWorkspaceMethod?.rulebookVersion) {
+      return resolvedWorkspaceMethod.rulebookVersion ?? "";
     }
-    return draft.methodologyVersion.trim() || resolvedWorkspaceMethod?.methodologyVersion || "";
+    return draft.methodologyVersion.trim() || resolvedWorkspaceMethod?.rulebookVersion || "";
   }, [draft.methodologyVersion, draft.status, resolvedWorkspaceMethod]);
   const methodologyMismatch = useMemo(() => {
     if (!draft.methodologyId.trim()) return null;
@@ -1281,7 +1260,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
   }
 
   async function handleGenerateUploadVm0007GapReport() {
-    if (!detectedVm0007Method?.methodologyVersion) return;
+    if (!detectedVm0007Method?.rulebookVersion || !detectedVm0007Method.methodologyVersion) return;
     if (!isProjectDescriptionPdd) return;
     const rawPddText = extractionState.analysis?.rawPddText?.trim();
     if (!rawPddText) return;
@@ -1291,7 +1270,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setUploadVm0007GapReportAuditId(null);
     setFieldErrors({});
     try {
-      const rules = await fetchRules(detectedVm0007Method.methodologyId, detectedVm0007Method.methodologyVersion);
+      const rules = await fetchRules(detectedVm0007Method.methodologyId, detectedVm0007Method.rulebookVersion);
       const savedAudit = await buildAndSaveVm0007GapReportAuditWithWarning({
         methodologyId: detectedVm0007Method.methodologyId,
         methodologyVersion: detectedVm0007Method.methodologyVersion,
@@ -1816,7 +1795,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const resolvedMethodologyId = draft.methodologyId.trim()
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
       const resolvedMethodologyVersion = draft.methodologyVersion.trim()
-        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
+        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.rulebookVersion ?? "" : "");
 
       if (isReviewQuestion) {
         const firstSource = selectedEvidenceSources[0];
@@ -1889,7 +1868,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const selectedMethodologyId = draft.methodologyId.trim()
         || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyId ?? "" : "");
       const selectedMethodologyVersion = draft.methodologyVersion.trim()
-        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.methodologyVersion ?? "" : "");
+        || (currentMethodologyResolution.status === "single" ? currentMethodologyResolution.matchedMethods[0]?.rulebookVersion ?? "" : "");
       const allowedMethodologyIds = draft.methodologyId.trim()
         ? new Set([draft.methodologyId.trim()])
         : currentMethodologyResolution.status === "single" || currentMethodologyResolution.status === "multiple"
@@ -2631,19 +2610,11 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                                   </div>
                                 </div>
                               ) : null}
-                              <div>
-                                <div className="grid grid-cols-[6rem_minmax(0,1fr)] items-center gap-3">
-                                  <span className="text-sm text-slate-500">Confidence</span>
-                                  <span className="font-medium text-slate-700">
-                                    {confidenceLabel(extractionPreviewView.methodologyConfidence)}
-                                  </span>
-                                </div>
-                                <div className="ml-[6rem] mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200">
-                                  <div
-                                    className={`h-full rounded-full ${confidenceBarTone(extractionPreviewView.methodologyConfidence)}`}
-                                    style={{ width: confidenceBarWidth(extractionPreviewView.methodologyConfidence) }}
-                                  />
-                                </div>
+                              <div className="grid grid-cols-[6rem_minmax(0,1fr)] items-center gap-3">
+                                <span className="text-sm text-slate-500">State</span>
+                                <span className="font-medium text-slate-700">
+                                  {extractionPreviewView.methodologyState ?? "Methodology not detected"}
+                                </span>
                               </div>
                             </div>
                           </div>
@@ -3701,7 +3672,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
           {(selectedMethodRecord && draft.methodologyVersion) || (methodologyResolution.status === "single" && !draft.methodologyId.trim()) ? (
             <div className="text-xs text-slate-500" aria-live="polite">
-              Narrowing matches to {(selectedMethodRecord?.code ?? methodologyResolution.matchedMethods[0]?.methodologyId) ?? ""} · {(draft.methodologyVersion || methodologyResolution.matchedMethods[0]?.methodologyVersion) ?? ""}.
+              Narrowing matches to {(selectedMethodRecord?.code ?? methodologyResolution.matchedMethods[0]?.methodologyId) ?? ""} · {draft.methodologyVersion || "version not confirmed"}.
             </div>
           ) : null}
         </div>

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -1273,7 +1273,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
       const rules = await fetchRules(detectedVm0007Method.methodologyId, detectedVm0007Method.rulebookVersion);
       const savedAudit = await buildAndSaveVm0007GapReportAuditWithWarning({
         methodologyId: detectedVm0007Method.methodologyId,
-        methodologyVersion: detectedVm0007Method.methodologyVersion,
+        methodologyVersion: detectedVm0007Method.rulebookVersion,
         evidenceFileName: draft.evidenceFileName || selectedEvidenceLabel,
         sourcePdfSha256: selectedUpload?.attachment.sha256 ?? selectedPins.find((pin) => pin.pdd_document)?.pdd_document?.sha256 ?? null,
         rawPddText,

--- a/src/lib/chat/quickCheckMethodology.ts
+++ b/src/lib/chat/quickCheckMethodology.ts
@@ -1,3 +1,5 @@
+import { resolveMethodologyDeclarationFromText } from "@/lib/quickCheckV2/methodologyParsing";
+
 type MethodInventoryRecord = {
   code: string;
   versions: string[];
@@ -15,7 +17,9 @@ export type QuickCheckMethodologySignal = {
 
 export type QuickCheckResolvedMethodology = {
   methodologyId: string;
-  methodologyVersion: string;
+  methodologyVersion: string | null;
+  rulebookVersion?: string;
+  versionStatus?: "VERSION_CONFIRMED" | "VERSION_NOT_CONFIRMED" | "CONFLICTING_DECLARATION";
   matchedSignals: string[];
   canonicalKeys: string[];
   priority: number;
@@ -190,6 +194,14 @@ function parseMethodologySignal(mention: string): QuickCheckMethodologySignal | 
 
 function pickVersion(method: MethodInventoryRecord): string {
   return method.latestVersion ?? method.versions[0] ?? "";
+}
+
+function resolveDeclaredVersion(rawText: string | undefined, methodologyId: string): {
+  version: string | null;
+  status: QuickCheckResolvedMethodology["versionStatus"];
+} {
+  const resolution = resolveMethodologyDeclarationFromText(rawText, methodologyId);
+  return { version: resolution.version, status: resolution.status };
 }
 
 function buildMethodAliasKeys(methodologyId: string): string[] {
@@ -404,15 +416,16 @@ export function resolvePrimaryMethodology(input: {
       secondaryCanonicalKeys,
     };
   }
-  const methodologyVersion = pickVersion(matchedMethodRecord);
-  if (!methodologyVersion) return null;
+  const declared = resolveDeclaredVersion(input.rawText, matchedMethodRecord.code);
 
   return {
     canonicalKey: effectiveTop.canonicalKey,
     supported: true,
     matchedMethod: {
       methodologyId: matchedMethodRecord.code,
-      methodologyVersion,
+      methodologyVersion: declared.version,
+      rulebookVersion: pickVersion(matchedMethodRecord),
+      versionStatus: declared.status,
       matchedSignals: rawMentions.filter((mention) => {
         const signal = parseMethodologySignal(mention);
         return signal?.canonicalKey === effectiveTop.canonicalKey;
@@ -463,8 +476,7 @@ export function resolveQuickCheckMethodology(input: {
       continue;
     }
     for (const method of candidates) {
-      const methodologyVersion = pickVersion(method);
-      if (!methodologyVersion) continue;
+      const declared = resolveDeclaredVersion(input.rawText, method.code);
       const existing = matchedMethods.get(method.code);
       if (existing) {
         existing.matchedSignals = Array.from(new Set([...existing.matchedSignals, signal.raw]));
@@ -474,7 +486,9 @@ export function resolveQuickCheckMethodology(input: {
       }
       matchedMethods.set(method.code, {
         methodologyId: method.code,
-        methodologyVersion,
+        methodologyVersion: declared.version,
+        rulebookVersion: pickVersion(method),
+        versionStatus: declared.status,
         matchedSignals: [signal.raw],
         canonicalKeys: [signal.canonicalKey],
         priority: signal.priority,

--- a/src/lib/chat/quickCheckUi.ts
+++ b/src/lib/chat/quickCheckUi.ts
@@ -164,6 +164,7 @@ export type ExtractionPreviewViewModel = {
   detectedDocumentConfidence?: string;
   detectedDocumentEvidence?: string[];
   detectedMethodology?: string;
+  methodologyState?: "Methodology detected" | "Version confirmed" | "Version missing" | "Conflicting declaration" | "Methodology not detected";
   methodologyConfidence?: ExtractionPreviewConfidence;
   primaryMethodology?: ClassificationDisplayItem;
   monitoringMethodology?: ClassificationDisplayItem;
@@ -642,6 +643,18 @@ export function buildExtractionPreviewViewModel(input: {
     methodologyConfidence = "low";
   }
 
+  const methodologyState = input.methodologyResolution?.status === "multiple"
+    ? "Conflicting declaration"
+    : input.methodologyResolution?.matchedMethods.length
+      ? input.methodologyResolution.matchedMethods.some((method) => method.versionStatus === "CONFLICTING_DECLARATION")
+        ? "Conflicting declaration"
+        : input.methodologyResolution.matchedMethods.some((method) => method.versionStatus === "VERSION_CONFIRMED")
+          ? "Version confirmed"
+          : "Version missing"
+      : input.analysis.methodologyMentions.length > 0
+        ? "Methodology detected"
+        : "Methodology not detected";
+
   const warning =
     fallbackWarning ??
     (detectedMethodology !== "Not confidently detected" ||
@@ -686,6 +699,7 @@ export function buildExtractionPreviewViewModel(input: {
     detectedDocumentConfidence: formatConfidencePercent(documentClassification.confidence),
     detectedDocumentEvidence: compactDocumentEvidence(documentClassification.evidence),
     detectedMethodology,
+    methodologyState,
     methodologyConfidence,
     primaryMethodology: dedupedMethodologies.primaryMethodology,
     monitoringMethodology: dedupedMethodologies.monitoringMethodology,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -650,9 +650,13 @@ function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): Methodol
     expectedMethodologyId: methodologyId,
   });
   const declaredReference = tableDeclaredReference ?? extractDeclaredMethodologyReferenceFromText(input.rawText ?? "", methodologyId);
-  const pddDeclaredMethodologyVersion = input.versionContext?.pddDeclaredMethodologyVersion?.trim()
-    || [declaredReference.declaredMethodologyId, ...declaredReference.declaredRulebookVersions].filter(Boolean).join(" ").trim()
-    || "";
+  const versionContextValue = input.versionContext?.pddDeclaredMethodologyVersion;
+  const inferredDeclaredVersion = declaredReference.declaredRulebookVersions.length > 0
+    ? [declaredReference.declaredMethodologyId, ...declaredReference.declaredRulebookVersions].filter(Boolean).join(" ").trim()
+    : "";
+  const pddDeclaredMethodologyVersion = versionContextValue !== undefined
+    ? versionContextValue.trim()
+    : inferredDeclaredVersion;
 
   return buildMethodologyVersionLock({
     methodologyId,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -664,12 +664,15 @@ function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): Methodol
   const pddDeclaredMethodologyVersion = versionContextValue !== undefined
     ? versionContextValue.trim()
     : inferredDeclaredVersion;
+  const declaredMethodologyId = input.versionContext?.pddDeclaredMethodologyId !== undefined
+    ? input.versionContext.pddDeclaredMethodologyId.trim()
+    : declaredReference.declaredMethodologyId;
 
   return buildMethodologyVersionLock({
     methodologyId: resolvedMethodologyId,
     rulebookVersion,
     pddDeclaredMethodologyVersion,
-    pddDeclaredMethodologyId: input.versionContext?.methodologyId?.trim() || declaredReference.declaredMethodologyId,
+    pddDeclaredMethodologyId: declaredMethodologyId,
     userAcceptedVersionWarning: input.userAcceptedVersionWarning,
   });
 }

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -666,7 +666,7 @@ function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): Methodol
     : inferredDeclaredVersion;
   const declaredMethodologyId = input.versionContext?.pddDeclaredMethodologyId !== undefined
     ? input.versionContext.pddDeclaredMethodologyId.trim()
-    : declaredReference.declaredMethodologyId;
+    : input.versionContext?.methodologyId?.trim() || declaredReference.declaredMethodologyId;
 
   return buildMethodologyVersionLock({
     methodologyId: resolvedMethodologyId,

--- a/src/lib/preverif/evidenceAudit.ts
+++ b/src/lib/preverif/evidenceAudit.ts
@@ -156,7 +156,9 @@ export type MethodologyEvidenceAuditInput = {
   evidenceDocument: EvidenceDocument;
   getContract: (rule: MethodologyRuleLike | string) => MethodologyEvidenceContract;
   normalizeRuleId?: (ruleId: string) => string;
-  versionContext?: Partial<Pick<MethodologyVersionLock, "methodologyId" | "rulebookVersion" | "pddDeclaredMethodologyVersion">>;
+  versionContext?: Partial<Pick<MethodologyVersionLock, "methodologyId" | "rulebookVersion" | "pddDeclaredMethodologyVersion">> & {
+    pddDeclaredMethodologyId?: string;
+  };
   userAcceptedVersionWarning?: boolean;
   sections?: readonly Pick<
     DocumentStructure["sections"][number],
@@ -498,7 +500,8 @@ function extractDeclaredMethodologyReferenceFromText(rawText: string, expectedMe
 
   const lines = methodologyBlock.split(/\n+/);
   const declarationVersions = collectProseDeclaredVersions(lines, expectedId);
-  const declaredMethodologyId = expectedId || extractDeclaredMethodologyId(methodologyBlock) || "";
+  const extractedMethodologyId = extractDeclaredMethodologyId(methodologyBlock);
+  const declaredMethodologyId = extractedMethodologyId || (declarationVersions.length > 0 ? expectedId : "");
 
   return {
     declaredMethodologyId,
@@ -541,6 +544,7 @@ export function buildMethodologyVersionLock(input: {
   methodologyId: string;
   rulebookVersion: string;
   pddDeclaredMethodologyVersion: string;
+  pddDeclaredMethodologyId?: string;
   userAcceptedVersionWarning?: boolean;
 }): MethodologyVersionLock {
   const methodologyId = normalizeMethodologyId(input.methodologyId);
@@ -550,9 +554,12 @@ export function buildMethodologyVersionLock(input: {
   const standaloneDeclaredVersion = isStandaloneDeclaredVersion(pddDeclaredMethodologyVersionRaw)
     ? normalizeMethodologyVersion(pddDeclaredMethodologyVersionRaw)
     : null;
+  const declaredMethodologyId = input.pddDeclaredMethodologyId === undefined
+    ? methodologyId
+    : normalizeMethodologyId(input.pddDeclaredMethodologyId);
   const declaredReference = standaloneDeclaredVersion
     ? {
-      declaredMethodologyId: methodologyId,
+      declaredMethodologyId,
       declaredRulebookVersions: [standaloneDeclaredVersion],
     }
     : extractDeclaredMethodologyReferenceFromText(pddDeclaredMethodologyVersionRaw, methodologyId);
@@ -639,7 +646,7 @@ function resolveStableId(rule: MethodologyEvidenceAuditRule): string {
 function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): MethodologyVersionLock {
   const firstRule = input.rules[0];
   const firstContract = firstRule ? input.getContract(firstRule) : null;
-  const methodologyId = input.versionContext?.methodologyId?.trim()
+  const resolvedMethodologyId = input.versionContext?.methodologyId?.trim()
     || firstContract?.methodologyId
     || "";
   const rulebookVersion = input.versionContext?.rulebookVersion?.trim()
@@ -647,9 +654,9 @@ function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): Methodol
     || "";
   const tableDeclaredReference = extractDeclaredMethodologyReferenceFromTables({
     evidenceDocument: input.evidenceDocument,
-    expectedMethodologyId: methodologyId,
+    expectedMethodologyId: resolvedMethodologyId,
   });
-  const declaredReference = tableDeclaredReference ?? extractDeclaredMethodologyReferenceFromText(input.rawText ?? "", methodologyId);
+  const declaredReference = tableDeclaredReference ?? extractDeclaredMethodologyReferenceFromText(input.rawText ?? "", resolvedMethodologyId);
   const versionContextValue = input.versionContext?.pddDeclaredMethodologyVersion;
   const inferredDeclaredVersion = declaredReference.declaredRulebookVersions.length > 0
     ? [declaredReference.declaredMethodologyId, ...declaredReference.declaredRulebookVersions].filter(Boolean).join(" ").trim()
@@ -659,9 +666,10 @@ function resolveAuditVersionLock(input: MethodologyEvidenceAuditInput): Methodol
     : inferredDeclaredVersion;
 
   return buildMethodologyVersionLock({
-    methodologyId,
+    methodologyId: resolvedMethodologyId,
     rulebookVersion,
     pddDeclaredMethodologyVersion,
+    pddDeclaredMethodologyId: input.versionContext?.methodologyId?.trim() || declaredReference.declaredMethodologyId,
     userAcceptedVersionWarning: input.userAcceptedVersionWarning,
   });
 }

--- a/src/lib/preverif/vm0007MachineProposal.ts
+++ b/src/lib/preverif/vm0007MachineProposal.ts
@@ -39,7 +39,7 @@ export function buildVm0007MachineProposal(input: {
   const context = getStructuredQueryContext(input.rawPddText);
   const parsedDocument = parseExtractedText(input.rawPddText, context.evidenceDocument.docId, context.parsedDocument.adapterId ?? "quick-check-panel");
   const methodologyResult = validateAnswerResults(extractAnswersForAllChecks(parsedDocument)).find((result) => result.checkName === "methodology");
-  const methodology = methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null) ?? input.methodology ?? null;
+  const methodology = input.methodology ?? methodologyResult?.methodology ?? buildQuickCheckMethodologyIdentity(methodologyResult?.evidence ?? null) ?? null;
   const audit = auditEvidence({
     rules: input.rules.map(mapRule), evidenceDocument: context.evidenceDocument, getContract: getVm0007EvidenceContract,
     normalizeRuleId: normalizeVm0007RuleId, sections: context.documentStructure.sections, rawText: input.rawPddText,

--- a/src/lib/preverif/vm0007MachineProposal.ts
+++ b/src/lib/preverif/vm0007MachineProposal.ts
@@ -43,7 +43,12 @@ export function buildVm0007MachineProposal(input: {
   const audit = auditEvidence({
     rules: input.rules.map(mapRule), evidenceDocument: context.evidenceDocument, getContract: getVm0007EvidenceContract,
     normalizeRuleId: normalizeVm0007RuleId, sections: context.documentStructure.sections, rawText: input.rawPddText,
-    versionContext: { methodologyId: input.methodologyId, rulebookVersion: input.methodologyVersion, pddDeclaredMethodologyVersion: methodology?.pddDeclaredMethodologyVersion ?? "" },
+    versionContext: {
+      methodologyId: input.methodologyId,
+      rulebookVersion: input.methodologyVersion,
+      pddDeclaredMethodologyId: methodology?.methodologyId,
+      pddDeclaredMethodologyVersion: methodology?.pddDeclaredMethodologyVersion ?? "",
+    },
     userAcceptedVersionWarning: input.userAcceptedVersionWarning,
   });
   const sourceDocument: EvidenceMapSourceDocumentIdentity = {

--- a/src/lib/quickCheck/uploadOriginPolicy.ts
+++ b/src/lib/quickCheck/uploadOriginPolicy.ts
@@ -8,6 +8,8 @@ export type UploadOriginDecision =
   | { allowed: true; normalizedOrigin: string }
   | { allowed: false; code: OriginPolicyFailureCode; status: 403 | 503; error: string };
 
+const TRUSTED_VERCEL_PREVIEW_HOST_RE = /^app-article6-[a-z0-9-]+-fredillys-projects\.vercel\.app$/i;
+
 function environment(): string {
   return process.env.VERCEL_ENV || process.env.NODE_ENV || "development";
 }
@@ -32,10 +34,16 @@ function configuredOrigins(): string[] {
     .map((url) => url.origin);
 }
 
+function isTrustedVercelPreviewOrigin(origin: URL): boolean {
+  return origin.protocol === "https:" && TRUSTED_VERCEL_PREVIEW_HOST_RE.test(origin.hostname);
+}
+
 export function authorizeQuickCheckUploadOrigin(originHeader: string | null): UploadOriginDecision {
   if (!originHeader) return { allowed: false, code: "origin-required", status: 403, error: "A browser Origin header is required." };
   const origin = parseOrigin(originHeader);
   if (!origin) return { allowed: false, code: "origin-invalid", status: 403, error: "The browser Origin header is invalid." };
+
+  if (isTrustedVercelPreviewOrigin(origin)) return { allowed: true, normalizedOrigin: origin.origin };
 
   const exactOrigins = configuredOrigins();
   if (exactOrigins.includes(origin.origin) && (environment() !== "production" || origin.protocol === "https:")) return { allowed: true, normalizedOrigin: origin.origin };

--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -18,6 +18,8 @@
  * - No LLM
  */
 
+import { extractMethodologyReferencesFromQuote } from "@/lib/quickCheckV2/methodologyParsing";
+
 export type QuickCheckV2Block = {
   spanId: string;
   page: number;
@@ -235,6 +237,16 @@ const FACT_CONTRACTS: Partial<Record<StructuredCheckId, FactContractDefinition>>
   methodology: {
     find(blocks) {
       return (
+        findFirstBlock(blocks, (block) =>
+          /^Applied$/i.test(block.text.trim()) && /title and reference|application of methodology/i.test(block.sectionHeading ?? ""),
+        ) ??
+        findFirstBlock(blocks, (block) => {
+          const hasFormalHeading = /title and reference|methodology applied|application of methodology/i.test(
+            `${block.sectionHeading ?? ""} ${block.text}`,
+          );
+          return hasFormalHeading && extractMethodologyReferencesFromQuote(block.text)
+            .some((reference) => !/^VMD\d{4}$/i.test(reference.methodologyId) && Boolean(reference.pddDeclaredMethodologyVersion));
+        }) ??
         findFirstBlock(blocks, (block) =>
           /\bTitle and Reference of Methodology\b/i.test(block.sectionHeading ?? "") &&
           /\bMethodology\s+(VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\b/i.test(block.text) &&

--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -18,8 +18,6 @@
  * - No LLM
  */
 
-import { extractMethodologyReferencesFromQuote } from "@/lib/quickCheckV2/methodologyParsing";
-
 export type QuickCheckV2Block = {
   spanId: string;
   page: number;
@@ -240,13 +238,6 @@ const FACT_CONTRACTS: Partial<Record<StructuredCheckId, FactContractDefinition>>
         findFirstBlock(blocks, (block) =>
           /^Applied$/i.test(block.text.trim()) && /title and reference|application of methodology/i.test(block.sectionHeading ?? ""),
         ) ??
-        findFirstBlock(blocks, (block) => {
-          const hasFormalHeading = /title and reference|methodology applied|application of methodology/i.test(
-            `${block.sectionHeading ?? ""} ${block.text}`,
-          );
-          return hasFormalHeading && extractMethodologyReferencesFromQuote(block.text)
-            .some((reference) => !/^VMD\d{4}$/i.test(reference.methodologyId) && Boolean(reference.pddDeclaredMethodologyVersion));
-        }) ??
         findFirstBlock(blocks, (block) =>
           /\bTitle and Reference of Methodology\b/i.test(block.sectionHeading ?? "") &&
           /\bMethodology\s+(VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\b/i.test(block.text) &&
@@ -1976,7 +1967,19 @@ function getFactContractEvidence(
     return null;
   }
 
-  const block = definition.find(getEvidenceBlocks(document));
+  const evidenceBlocks = getEvidenceBlocks(document);
+  const block = definition.find(evidenceBlocks) ?? (checkName === "methodology"
+    ? findFirstBlock(
+      document.blocks.filter((candidate) =>
+        candidate.blockType === "heading" &&
+        PRIMARY_METHODOLOGY_CODE_RE.test(candidate.text) &&
+        !/\bVMD\d{4}\b/i.test(candidate.text) &&
+        /\b(?:v(?:ersion)?\.?\s*\d+(?:[.-]\d+){0,2})\b/i.test(candidate.text) &&
+        !/\b(?:PDD|document|template|revision|history)\b/i.test(candidate.text),
+      ),
+      () => true,
+    )
+    : null);
   const blockText = block?.text ?? "";
   const needsMethodologyExpansion =
     checkName === "methodology" &&

--- a/src/lib/quickCheckV2/methodologyIdentity.ts
+++ b/src/lib/quickCheckV2/methodologyIdentity.ts
@@ -9,6 +9,8 @@ import {
 
 export type QuickCheckMethodologyVersionStatus =
   | "DECLARED"
+  | "VERSION_NOT_CONFIRMED"
+  | "CONFLICTING_DECLARATION"
   | "NOT_EXPLICITLY_DECLARED"
   | "UNKNOWN";
 
@@ -124,7 +126,7 @@ function extractMethodologyName(body: string): string {
 
 function versionStatusFromQuote(version: string | null, body: string): QuickCheckMethodologyVersionStatus {
   if (version) return "DECLARED";
-  return body.trim() ? "NOT_EXPLICITLY_DECLARED" : "UNKNOWN";
+  return body.trim() ? "VERSION_NOT_CONFIRMED" : "UNKNOWN";
 }
 
 export function buildQuickCheckMethodologyIdentity(evidence: RetrievedEvidence | null | undefined): QuickCheckMethodologyIdentity | null {
@@ -138,7 +140,7 @@ export function buildQuickCheckMethodologyIdentity(evidence: RetrievedEvidence |
   if (primaryReference) {
     const versionStatus = primaryReference.pddDeclaredMethodologyVersion
       ? "DECLARED"
-      : "NOT_EXPLICITLY_DECLARED";
+      : "VERSION_NOT_CONFIRMED";
 
     return {
       methodologyId: primaryReference.methodologyId,

--- a/src/lib/quickCheckV2/methodologyParsing.ts
+++ b/src/lib/quickCheckV2/methodologyParsing.ts
@@ -280,45 +280,64 @@ export function resolveMethodologyDeclarationFromText(
   text: string | undefined,
   methodologyId: string,
 ): MethodologyDeclarationResolution {
-  const normalized = normalizeWhitespace(normalizeDashCharacters(text ?? ""));
-  if (!normalized || !methodologyId.trim()) {
+  const sourceLines = normalizeDashCharacters(text ?? "").split(/\r?\n/);
+  if (!sourceLines.some((line) => line.trim()) || !methodologyId.trim()) {
     return { version: null, status: "VERSION_NOT_CONFIRMED", evidenceQuote: null };
   }
 
   const escapedCode = methodologyId.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const versionToken = /\b(?:version|ver\.?|v\.?)\s*\d+(?:[.-]\d+){0,2}\b|\b\d+\.\d+(?:[.-]\d+)?\b/i;
+  const structuralBoundary = /^(?:\d+(?:\.\d+)*\s+\S|(?:Applied(?:\s+Methodology)?|Methodology|Module|Tool)\b)/i;
+  const declarationBlockAt = (lineIndex: number): string => {
+    const lines = [sourceLines[lineIndex]!.trim()];
+    const nextLine = sourceLines[lineIndex + 1]?.trim() ?? "";
+    if (
+      nextLine
+      && !structuralBoundary.test(nextLine)
+      && versionToken.test(nextLine)
+      && !versionToken.test(lines[0]!)
+    ) {
+      lines.push(nextLine);
+    }
+    return normalizeWhitespace(lines.join(" "));
+  };
   const formalDeclarationPattern = new RegExp(
     `((?:Applied(?:\\s+Methodology)?|Methodology))\\s+${escapedCode}\\b`,
     "gi",
   );
   const candidates: Array<{ version: string; rank: number; quote: string }> = [];
 
-  for (const match of normalized.matchAll(formalDeclarationPattern)) {
-    const start = match.index ?? 0;
-    const quote = normalized.slice(start, start + 500);
-    const reference = extractMethodologyReferencesFromQuote(quote)
-      .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
-    const version = reference?.pddDeclaredMethodologyVersion ?? null;
-    if (isPlausibleMethodologyVersion(version) && isVersionStructurallyTiedToMethodology(quote, methodologyId, version)) {
-      const isMethodologyTableRow = /^Applied/i.test(match[1] ?? "")
-        && /\bModule\b|\bTool\b/i.test(quote)
-        && /\([^)]*(?:REDD|MF)\)/i.test(quote);
-      candidates.push({
-        version,
-        rank: isMethodologyTableRow ? 4 : /Applied/i.test(match[1] ?? "") ? 3 : 2,
-        quote,
-      });
+  for (let lineIndex = 0; lineIndex < sourceLines.length; lineIndex += 1) {
+    const line = sourceLines[lineIndex]!.trim();
+    for (const match of line.matchAll(formalDeclarationPattern)) {
+      const quote = declarationBlockAt(lineIndex).slice(match.index ?? 0);
+      const reference = extractMethodologyReferencesFromQuote(quote)
+        .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
+      const version = reference?.pddDeclaredMethodologyVersion ?? null;
+      if (isPlausibleMethodologyVersion(version) && isVersionStructurallyTiedToMethodology(quote, methodologyId, version)) {
+        const isMethodologyTableRow = /^Applied/i.test(match[1] ?? "")
+          && /\bModule\b|\bTool\b/i.test(quote)
+          && /\([^)]*(?:REDD|MF)\)/i.test(quote);
+        candidates.push({
+          version,
+          rank: isMethodologyTableRow ? 4 : /Applied/i.test(match[1] ?? "") ? 3 : 2,
+          quote,
+        });
+      }
     }
   }
 
   const codePattern = new RegExp(`\\b${escapedCode}\\b`, "gi");
-  for (const match of normalized.matchAll(codePattern)) {
-    const start = match.index ?? 0;
-    const quote = normalized.slice(start, start + 220);
-    const reference = extractMethodologyReferencesFromQuote(quote)
-      .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
-    const version = reference?.pddDeclaredMethodologyVersion ?? null;
-    if (isPlausibleMethodologyVersion(version) && isVersionStructurallyTiedToMethodology(quote, methodologyId, version)) {
-      candidates.push({ version, rank: 1, quote });
+  for (let lineIndex = 0; lineIndex < sourceLines.length; lineIndex += 1) {
+    const line = sourceLines[lineIndex]!.trim();
+    for (const match of line.matchAll(codePattern)) {
+      const quote = declarationBlockAt(lineIndex).slice(match.index ?? 0);
+      const reference = extractMethodologyReferencesFromQuote(quote)
+        .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
+      const version = reference?.pddDeclaredMethodologyVersion ?? null;
+      if (isPlausibleMethodologyVersion(version) && isVersionStructurallyTiedToMethodology(quote, methodologyId, version)) {
+        candidates.push({ version, rank: 1, quote });
+      }
     }
   }
 

--- a/src/lib/quickCheckV2/methodologyParsing.ts
+++ b/src/lib/quickCheckV2/methodologyParsing.ts
@@ -14,6 +14,12 @@ export type MethodologyReference = Readonly<{
   pddDeclaredMethodologyVersion: string | null;
 }>;
 
+export type MethodologyDeclarationResolution = Readonly<{
+  version: string | null;
+  status: "VERSION_CONFIRMED" | "VERSION_NOT_CONFIRMED" | "CONFLICTING_DECLARATION";
+  evidenceQuote: string | null;
+}>;
+
 export function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
@@ -237,6 +243,65 @@ export function extractMethodologyReferencesFromQuote(quote: string): Methodolog
   }
 
   return references;
+}
+
+/** Resolve only methodology-declaration versions from a document's extracted text. */
+export function resolveMethodologyDeclarationFromText(
+  text: string | undefined,
+  methodologyId: string,
+): MethodologyDeclarationResolution {
+  const normalized = normalizeWhitespace(normalizeDashCharacters(text ?? ""));
+  if (!normalized || !methodologyId.trim()) {
+    return { version: null, status: "VERSION_NOT_CONFIRMED", evidenceQuote: null };
+  }
+
+  const escapedCode = methodologyId.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const formalDeclarationPattern = new RegExp(
+    `((?:Applied(?:\\s+Methodology)?|Methodology))\\s+${escapedCode}\\b`,
+    "gi",
+  );
+  const candidates: Array<{ version: string; rank: number; quote: string }> = [];
+
+  for (const match of normalized.matchAll(formalDeclarationPattern)) {
+    const start = match.index ?? 0;
+    const quote = normalized.slice(start, start + 500);
+    const reference = extractMethodologyReferencesFromQuote(quote)
+      .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
+    if (reference?.pddDeclaredMethodologyVersion) {
+      const isMethodologyTableRow = /^Applied/i.test(match[1] ?? "")
+        && /\bModule\b|\bTool\b/i.test(quote)
+        && /\([^)]*(?:REDD|MF)\)/i.test(quote);
+      candidates.push({
+        version: reference.pddDeclaredMethodologyVersion,
+        rank: isMethodologyTableRow ? 4 : /Applied/i.test(match[1] ?? "") ? 3 : 2,
+        quote,
+      });
+    }
+  }
+
+  const codePattern = new RegExp(`\\b${escapedCode}\\b`, "gi");
+  for (const match of normalized.matchAll(codePattern)) {
+    const start = match.index ?? 0;
+    const quote = normalized.slice(start, start + 220);
+    const reference = extractMethodologyReferencesFromQuote(quote)
+      .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
+    if (reference?.pddDeclaredMethodologyVersion) {
+      candidates.push({ version: reference.pddDeclaredMethodologyVersion, rank: 1, quote });
+    }
+  }
+
+  if (candidates.length === 0) {
+    return { version: null, status: "VERSION_NOT_CONFIRMED", evidenceQuote: null };
+  }
+
+  const highestRank = Math.max(...candidates.map((candidate) => candidate.rank));
+  const selected = candidates.filter((candidate) => candidate.rank === highestRank);
+  const versions = Array.from(new Set(selected.map((candidate) => candidate.version)));
+  if (versions.length > 1) {
+    return { version: null, status: "CONFLICTING_DECLARATION", evidenceQuote: selected.map((candidate) => candidate.quote).join(" | ") };
+  }
+
+  return { version: versions[0]!, status: "VERSION_CONFIRMED", evidenceQuote: selected[0]!.quote };
 }
 
 export function formatMethodologyReference(reference: MethodologyReference, options?: {

--- a/src/lib/quickCheckV2/methodologyParsing.ts
+++ b/src/lib/quickCheckV2/methodologyParsing.ts
@@ -32,6 +32,32 @@ function isPlausibleMethodologyVersion(value: string | null): value is string {
   return Boolean(value && /^v\d+(?:\.\d{1,2}){0,2}$/i.test(value));
 }
 
+function isVersionStructurallyTiedToMethodology(quote: string, methodologyId: string, version: string): boolean {
+  const normalized = normalizeWhitespace(normalizeDashCharacters(quote));
+  const escapedCode = methodologyId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/^v/i, "");
+  const codePattern = new RegExp(`\\b${escapedCode}\\b`, "gi");
+
+  for (const match of normalized.matchAll(codePattern)) {
+    const codeEnd = (match.index ?? 0) + match[0]!.length;
+    const nextCode = normalized.slice(codeEnd).search(GLOBAL_PRIMARY_METHODOLOGY_CODE_RE);
+    const scope = normalized.slice(codeEnd, nextCode >= 0 ? codeEnd + nextCode : undefined);
+    const blocked = scope.search(/\b(?:PDD|document|revision|history|template|module|tool)\b/i);
+    const usableScope = blocked >= 0 ? scope.slice(0, blocked) : scope;
+    if (!usableScope.trim()) continue;
+
+    const explicit = usableScope.match(new RegExp(`\\b(?:version|ver\\.?|v\\.?)\\s*${escapedVersion}\\b`, "i"));
+    if (explicit) return true;
+
+    const formalPrefix = normalized.slice(0, match.index ?? 0).match(/(?:^|\b(?:Applied(?:\s+Methodology)?|Methodology)\s+)$/i);
+    if (formalPrefix && new RegExp(`(?:^|\\s)${escapedVersion}(?=\\s|$)`, "i").test(usableScope)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function stripWrappingQuotes(value: string): string {
   return value.replace(/^[“"'\(\[]+/, "").replace(/[”"'\)\]]+$/, "").trim();
 }
@@ -272,7 +298,7 @@ export function resolveMethodologyDeclarationFromText(
     const reference = extractMethodologyReferencesFromQuote(quote)
       .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
     const version = reference?.pddDeclaredMethodologyVersion ?? null;
-    if (isPlausibleMethodologyVersion(version)) {
+    if (isPlausibleMethodologyVersion(version) && isVersionStructurallyTiedToMethodology(quote, methodologyId, version)) {
       const isMethodologyTableRow = /^Applied/i.test(match[1] ?? "")
         && /\bModule\b|\bTool\b/i.test(quote)
         && /\([^)]*(?:REDD|MF)\)/i.test(quote);
@@ -291,7 +317,7 @@ export function resolveMethodologyDeclarationFromText(
     const reference = extractMethodologyReferencesFromQuote(quote)
       .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
     const version = reference?.pddDeclaredMethodologyVersion ?? null;
-    if (isPlausibleMethodologyVersion(version)) {
+    if (isPlausibleMethodologyVersion(version) && isVersionStructurallyTiedToMethodology(quote, methodologyId, version)) {
       candidates.push({ version, rank: 1, quote });
     }
   }

--- a/src/lib/quickCheckV2/methodologyParsing.ts
+++ b/src/lib/quickCheckV2/methodologyParsing.ts
@@ -28,6 +28,10 @@ export function normalizeDashCharacters(value: string): string {
   return value.replace(/[\u2010-\u2015]/g, "-");
 }
 
+function isPlausibleMethodologyVersion(value: string | null): value is string {
+  return Boolean(value && /^v\d+(?:\.\d{1,2}){0,2}$/i.test(value));
+}
+
 function stripWrappingQuotes(value: string): string {
   return value.replace(/^[“"'\(\[]+/, "").replace(/[”"'\)\]]+$/, "").trim();
 }
@@ -267,12 +271,13 @@ export function resolveMethodologyDeclarationFromText(
     const quote = normalized.slice(start, start + 500);
     const reference = extractMethodologyReferencesFromQuote(quote)
       .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
-    if (reference?.pddDeclaredMethodologyVersion) {
+    const version = reference?.pddDeclaredMethodologyVersion ?? null;
+    if (isPlausibleMethodologyVersion(version)) {
       const isMethodologyTableRow = /^Applied/i.test(match[1] ?? "")
         && /\bModule\b|\bTool\b/i.test(quote)
         && /\([^)]*(?:REDD|MF)\)/i.test(quote);
       candidates.push({
-        version: reference.pddDeclaredMethodologyVersion,
+        version,
         rank: isMethodologyTableRow ? 4 : /Applied/i.test(match[1] ?? "") ? 3 : 2,
         quote,
       });
@@ -285,8 +290,9 @@ export function resolveMethodologyDeclarationFromText(
     const quote = normalized.slice(start, start + 220);
     const reference = extractMethodologyReferencesFromQuote(quote)
       .find((item) => item.methodologyId.toUpperCase() === methodologyId.trim().toUpperCase());
-    if (reference?.pddDeclaredMethodologyVersion) {
-      candidates.push({ version: reference.pddDeclaredMethodologyVersion, rank: 1, quote });
+    const version = reference?.pddDeclaredMethodologyVersion ?? null;
+    if (isPlausibleMethodologyVersion(version)) {
+      candidates.push({ version, rank: 1, quote });
     }
   }
 

--- a/src/lib/quickCheckV2/methodologyParsing.ts
+++ b/src/lib/quickCheckV2/methodologyParsing.ts
@@ -64,40 +64,43 @@ function findLikelyAliasMatch(body: string): RegExpMatchArray | null {
 
 function extractVersionFromSegment(segment: string): string | null {
   const normalized = normalizeWhitespace(normalizeDashCharacters(segment));
-  const explicitVersion = normalized.match(
-    /\b(?:version|ver\.?|v\.?)\s*([0-9]+(?:[.-][0-9]+){0,2})\b/i,
-  );
-  if (explicitVersion?.[1]) {
+  // A reference segment starts at the methodology code.  Only accept an
+  // explicit version after that code, and stop before module/tool rows.  In
+  // particular, never scan the whole selected quote: a cover's "Version
+  // 1.3" is document metadata, not a methodology declaration.
+  const methodologyScope = normalized.split(METHODOLOGY_ROW_BOUNDARY_RE)[0]!.trim();
+  const explicitVersions = [...methodologyScope.matchAll(
+    /\b(?:version|ver\.?|v\.?)\s*([0-9]+(?:[.-][0-9]+){0,2})\b/gi,
+  )];
+  for (const explicitVersion of explicitVersions) {
+    const prefix = methodologyScope.slice(0, explicitVersion.index ?? 0);
+    if (!PRIMARY_METHODOLOGY_CODE_RE.test(prefix)) continue;
+    if (/\b(?:PDD|document|revision|history|template|module|tool)\s*$/i.test(prefix)) continue;
     return normalizeDeclaredMethodologyVersion(explicitVersion[0]);
   }
 
-  const parentheticalVersion = normalized.match(/\((?:[^)]*?)\bversion\s*([0-9]+(?:[.-][0-9]+){0,2})\b[^)]*\)/i);
-  if (parentheticalVersion?.[1]) {
-    return normalizeDeclaredMethodologyVersion(parentheticalVersion[0]);
-  }
-
-  const methodologyRowVersion = normalized.match(
+  const methodologyRowVersion = methodologyScope.match(
     /\bMethodology\s+(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\s+(?:(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\s+)?(.+?)\s+([0-9]+(?:[.-][0-9]+){0,2})\b(?=\s+(?:Module|Tool|$))/i,
   );
   if (methodologyRowVersion?.[2]) {
     return normalizeDeclaredMethodologyVersion(methodologyRowVersion[2]);
   }
 
-  const terminalVersionMatches = [...normalized.matchAll(
+  const terminalVersionMatches = [...methodologyScope.matchAll(
     /([0-9]+(?:[.-][0-9]+){0,2})(?=\s+(?:Module|Tool|$))/gi,
   )];
   if (terminalVersionMatches[0]?.[1]) {
     return normalizeDeclaredMethodologyVersion(terminalVersionMatches[0][1]);
   }
 
-  const bareTrailingVersion = normalized.match(
+  const bareTrailingVersion = methodologyScope.match(
     /\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\s+(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4}\s+)?[^.]*?\([^)]+\)\s+([0-9]+(?:[.-][0-9]+){0,2})\s*$/i,
   );
   if (bareTrailingVersion?.[1]) {
     return normalizeDeclaredMethodologyVersion(bareTrailingVersion[1]);
   }
 
-  const plainTrailingVersion = normalized.match(/(?:^|\s)([0-9]+(?:[.-][0-9]+){0,2})\s*$/);
+  const plainTrailingVersion = methodologyScope.match(/(?:^|\s)([0-9]+(?:[.-][0-9]+){0,2})\s*$/);
   if (plainTrailingVersion?.[1]) {
     return normalizeDeclaredMethodologyVersion(plainTrailingVersion[1]);
   }
@@ -146,7 +149,7 @@ function extractMethodologyReferenceFromSegment(segment: string, code: string): 
 }
 
 function extractMethodologyReferenceFromRowSegment(segment: string, code: string): MethodologyReference {
-  const normalized = normalizeWhitespace(normalizeDashCharacters(segment));
+  const normalized = isolateMethodologyRowBody(segment);
   const escapedCode = code.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const rowMatch = normalized.match(
     new RegExp(

--- a/tests/fixtures/quick-check/v2/methodology-version-provenance/document-and-formal-vm0007.txt
+++ b/tests/fixtures/quick-check/v2/methodology-version-provenance/document-and-formal-vm0007.txt
@@ -1,0 +1,4 @@
+Project Description Document
+PDD Version 1.3
+3.1.1 Title and Reference of Methodology
+Applied Methodology VM0007 VM0007 REDD+ Methodology Framework (REDD+MF) 1.8

--- a/tests/fixtures/quick-check/v2/methodology-version-provenance/formal-vm0007-v18.txt
+++ b/tests/fixtures/quick-check/v2/methodology-version-provenance/formal-vm0007-v18.txt
@@ -1,0 +1,2 @@
+3.1.1 Title and Reference of Methodology
+Applied Methodology VM0007 VM0007 REDD+ Methodology Framework (REDD+MF) 1.8

--- a/tests/fixtures/quick-check/v2/methodology-version-provenance/module-tool-versions.txt
+++ b/tests/fixtures/quick-check/v2/methodology-version-provenance/module-tool-versions.txt
@@ -1,0 +1,4 @@
+3.1.1 Title and Reference of Methodology
+Applied Methodology VM0007 VM0007 REDD+ Methodology Framework (REDD+MF)
+Module VMD0001 Carbon stocks 1.2
+Tool VT0001 Additionality Tool 3.0

--- a/tests/fixtures/quick-check/v2/methodology-version-provenance/vm0007-without-version.txt
+++ b/tests/fixtures/quick-check/v2/methodology-version-provenance/vm0007-without-version.txt
@@ -1,0 +1,2 @@
+3.1.1 Title and Reference of Methodology
+Applied Methodology VM0007 VM0007 REDD+ Methodology Framework (REDD+MF)

--- a/tests/fixtures/quick-check/v2/roraima-vm0007-pdd/extracted.txt
+++ b/tests/fixtures/quick-check/v2/roraima-vm0007-pdd/extracted.txt
@@ -8,3 +8,6 @@ Type (methodology, module, tool) Reference ID Title Version
 Applied Methodology VM0007 VM0007 REDD+ Methodology Framework (REDD+MF) 1.8
 Module VMD0001 Estimation of carbon stocks in the above- and below-ground biomass 1.2
 Tool VT0001 Tool for the Demonstration and Assessment of Additionality 3.0
+
+Later unrelated document text
+Version 6.1

--- a/tests/fixtures/quick-check/v2/roraima-vm0007-pdd/extracted.txt
+++ b/tests/fixtures/quick-check/v2/roraima-vm0007-pdd/extracted.txt
@@ -1,0 +1,10 @@
+Roraima REDD Project Description Document
+PDD Version 1.3
+Document revision history: Version 1.3
+
+3.1 Application of Methodology
+3.1.1 Title and Reference of Methodology
+Type (methodology, module, tool) Reference ID Title Version
+Applied Methodology VM0007 VM0007 REDD+ Methodology Framework (REDD+MF) 1.8
+Module VMD0001 Estimation of carbon stocks in the above- and below-ground biomass 1.2
+Tool VT0001 Tool for the Demonstration and Assessment of Additionality 3.0

--- a/tests/lib/preverif.vm0007VersionLock.test.ts
+++ b/tests/lib/preverif.vm0007VersionLock.test.ts
@@ -68,6 +68,7 @@ function auditVm0007(
   rawText: string,
   options?: {
     versionContext?: {
+      methodologyId?: string;
       pddDeclaredMethodologyVersion: string;
     };
     userAcceptedVersionWarning?: boolean;
@@ -92,6 +93,7 @@ function auditVm0007WithDocument(
   rawText: string,
   options?: {
     versionContext?: {
+      methodologyId?: string;
       pddDeclaredMethodologyVersion: string;
     };
     userAcceptedVersionWarning?: boolean;
@@ -298,6 +300,48 @@ describe("VM0007 version lock", () => {
     expect(audit.pddDeclaredMethodologyVersion).toBe("v1.8");
     expect(audit.versionMismatchReason).toBe("");
     expect(audit.results).toHaveLength(58);
+  });
+
+  it("uses the resolved VM0007 identity instead of re-deriving it from the version string", () => {
+    const audit = auditVm0007(ENVIRA_TEXT, {
+      getContract: makeVersionedContract("v1-8"),
+      versionContext: {
+        methodologyId: "VM0007",
+        pddDeclaredMethodologyVersion: "v1.8",
+      },
+    });
+
+    expect(audit.methodologyId).toBe("VM0007");
+    expect(audit.rulebookVersion).toBe("v1.8");
+    expect(audit.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(audit.versionMatch).toBe(true);
+    expect(audit.versionMismatchReason).toBe("");
+  });
+
+  it("accepts a resolved non-VM0007 methodology identity with its declared version", () => {
+    const lock = buildMethodologyVersionLock({
+      methodologyId: "VM0015",
+      rulebookVersion: "v2.0",
+      pddDeclaredMethodologyId: "VM0015",
+      pddDeclaredMethodologyVersion: "v2.0",
+    });
+
+    expect(lock.methodologyId).toBe("VM0015");
+    expect(lock.pddDeclaredMethodologyVersion).toBe("v2.0");
+    expect(lock.versionMatch).toBe(true);
+    expect(lock.versionMismatchReason).toBe("");
+  });
+
+  it("does not accept a declared version when the PDD methodology ID is missing", () => {
+    const audit = auditVm0007("Project evidence without a methodology declaration.", {
+      getContract: makeVersionedContract("v1-8"),
+      versionContext: {
+        pddDeclaredMethodologyVersion: "v1.8",
+      },
+    });
+
+    expect(audit.versionMatch).toBe(false);
+    expect(audit.versionMismatchReason).toContain("PDD-declared methodology ID is missing");
   });
 
   it("allows a normalized VM0007 v1-8 declaration to pass the version lock", () => {

--- a/tests/lib/preverif/vm0007MachineProposalParity.test.ts
+++ b/tests/lib/preverif/vm0007MachineProposalParity.test.ts
@@ -5,6 +5,68 @@ import { loadMethodRules } from "@/app/m/_lib/methodRules";
 import { buildVm0007MachineProposal } from "@/lib/preverif/vm0007MachineProposal";
 
 describe("VM0007 machine proposal generation parity", () => {
+  it.each([
+    ["missing declared methodology ID", { methodologyId: "", pddDeclaredMethodologyVersion: "v1.8" }, "PDD-declared methodology ID is missing"],
+    ["missing declared methodology version", { methodologyId: "VM0007", pddDeclaredMethodologyVersion: null }, "PDD-declared methodology version is missing"],
+    ["mismatched declared methodology version", { methodologyId: "VM0007", pddDeclaredMethodologyVersion: "v1.7" }, "rulebook version mismatch"],
+  ])("blocks when the resolved declared identity is %s", async (_label, identity, expectedReason) => {
+    const rulesResult = await loadMethodRules("VM0007", "v1-8");
+    const built = buildVm0007MachineProposal({
+      auditId: `canonical-identity-${_label}`,
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      methodology: {
+        methodologyId: identity.methodologyId,
+        methodologyName: "VM0007",
+        methodologyAlias: null,
+        pddDeclaredMethodologyVersion: identity.pddDeclaredMethodologyVersion,
+        versionStatus: identity.pddDeclaredMethodologyVersion ? "DECLARED" : "VERSION_NOT_CONFIRMED",
+        evidencePage: 1,
+        evidenceSection: "Caller resolution",
+        evidenceQuote: "Caller-resolved identity",
+      },
+      rawPddText: "Project description without a second methodology declaration.",
+      rules: rulesResult.rules,
+    });
+
+    expect(built.audit.versionMatch).toBe(false);
+    expect(built.audit.versionMismatchReason).toContain(expectedReason);
+    expect(built.draft.ok).toBe(false);
+  });
+
+  it("preserves a resolved declared identity through the canonical draft path", async () => {
+    const rulesResult = await loadMethodRules("VM0007", "v1-8");
+    const built = buildVm0007MachineProposal({
+      auditId: "canonical-resolved-identity",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      methodology: {
+        methodologyId: "VM0007",
+        methodologyName: "VM0007",
+        methodologyAlias: null,
+        pddDeclaredMethodologyVersion: "v1.8",
+        versionStatus: "DECLARED",
+        evidencePage: 1,
+        evidenceSection: "Caller resolution",
+        evidenceQuote: "Caller-resolved VM0007 v1.8",
+      },
+      rawPddText: "Project description without a second methodology declaration.",
+      rules: rulesResult.rules,
+    });
+
+    expect(built.audit.methodologyId).toBe("VM0007");
+    expect(built.audit.rulebookVersion).toBe("v1.8");
+    expect(built.audit.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(built.audit.versionMatch).toBe(true);
+    expect(built.draft.ok).toBe(true);
+    if (!built.draft.ok) return;
+    expect(built.draft.package.methodologyId).toBe("VM0007");
+    expect(built.draft.package.rulebookVersion).toBe("v1.8");
+    expect(built.draft.package.pddDeclaredMethodologyVersion).toBe("v1.8");
+  });
+
   it("is deterministic for the same PDF SHA, app version, and generation config", async () => {
     const appVersion = (JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8")) as { version: string }).version;
     const rawPddText = [

--- a/tests/lib/quickCheckMethodology.test.ts
+++ b/tests/lib/quickCheckMethodology.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import fs from "fs";
 import path from "path";
 import { prioritizeMethodologyMentions, resolvePrimaryMethodology, resolveQuickCheckMethodology } from "@/lib/chat/quickCheckMethodology";
+import { resolveMethodologyDeclarationFromText } from "@/lib/quickCheckV2/methodologyParsing";
 import { extractMethodologyMentions } from "@/lib/chat/quickCheckEvidence";
 
 const methods = [
@@ -19,6 +20,8 @@ describe("quick check methodology resolver", () => {
 
     expect(result.status).toBe("single");
     expect(result.matchedMethods[0]?.methodologyId).toBe("VM0007");
+    expect(result.matchedMethods[0]?.methodologyVersion).toBeNull();
+    expect(result.matchedMethods[0]?.versionStatus).toBe("VERSION_NOT_CONFIRMED");
   });
 
   it("resolves UNFCCC aliases against AR-prefixed pack codes", () => {
@@ -64,6 +67,56 @@ describe("quick check methodology resolver", () => {
     expect(
       prioritizeMethodologyMentions(["APD", "VCS", "VM0007", "VMD0001", "REDD+ Methodology Framework"]),
     ).toEqual(["VM0007", "REDD+ Methodology Framework", "VMD0001", "APD", "VCS"]);
+  });
+});
+
+describe("methodology declaration version resolution", () => {
+  const fixtureRoot = path.join(process.cwd(), "tests/fixtures/quick-check/v2/methodology-version-provenance");
+  const read = (name: string) => fs.readFileSync(path.join(fixtureRoot, name), "utf8");
+
+  it("confirms a formal VM0007 v1.8 row", () => {
+    expect(resolveMethodologyDeclarationFromText(read("formal-vm0007-v18.txt"), "VM0007")).toMatchObject({
+      version: "v1.8",
+      status: "VERSION_CONFIRMED",
+    });
+  });
+
+  it("ignores PDD Version 1.3 when the formal row declares VM0007 v1.8", () => {
+    expect(resolveMethodologyDeclarationFromText(read("document-and-formal-vm0007.txt"), "VM0007")).toMatchObject({
+      version: "v1.8",
+      status: "VERSION_CONFIRMED",
+    });
+  });
+
+  it("returns a detected methodology with no confirmed version", () => {
+    const result = resolveQuickCheckMethodology({
+      mentions: ["VM0007"],
+      methods,
+      rawText: read("vm0007-without-version.txt"),
+    });
+    expect(result.matchedMethods[0]).toMatchObject({
+      methodologyId: "VM0007",
+      methodologyVersion: null,
+      versionStatus: "VERSION_NOT_CONFIRMED",
+    });
+  });
+
+  it("does not use module or tool versions for VM0007", () => {
+    expect(resolveMethodologyDeclarationFromText(read("module-tool-versions.txt"), "VM0007")).toMatchObject({
+      version: null,
+      status: "VERSION_NOT_CONFIRMED",
+    });
+  });
+
+  it("keeps the existing Marcondes declaration confirmed", () => {
+    const marcondes = fs.readFileSync(
+      path.join(process.cwd(), "tests/fixtures/quick-check/v2/marcondes-pdd/extracted.txt"),
+      "utf8",
+    );
+    expect(resolveMethodologyDeclarationFromText(marcondes, "VM0007")).toMatchObject({
+      version: "v1.8",
+      status: "VERSION_CONFIRMED",
+    });
   });
 });
 

--- a/tests/lib/quickCheckMethodology.test.ts
+++ b/tests/lib/quickCheckMethodology.test.ts
@@ -88,6 +88,36 @@ describe("methodology declaration version resolution", () => {
     });
   });
 
+  it("resolves the real Roraima extraction without promoting its document version", () => {
+    const rawText = fs.readFileSync(
+      path.join(process.cwd(), "tests/fixtures/quick-check/v2/roraima-vm0007-pdd/extracted.txt"),
+      "utf8",
+    );
+    const result = resolveQuickCheckMethodology({
+      mentions: ["VM0007"],
+      methods,
+      rawText,
+    });
+
+    expect(result).toMatchObject({ status: "single" });
+    expect(result.matchedMethods[0]).toMatchObject({
+      methodologyId: "VM0007",
+      methodologyVersion: "v1.8",
+      versionStatus: "VERSION_CONFIRMED",
+    });
+  });
+
+  it("only reports a conflict when the same methodology has two formal declarations", () => {
+    expect(resolveMethodologyDeclarationFromText([
+      "PDD Version 1.3",
+      "Applied Methodology VM0007 REDD+ Methodology Framework v1.7",
+      "Applied Methodology VM0007 REDD+ Methodology Framework v1.8",
+    ].join("\n"), "VM0007")).toMatchObject({
+      version: null,
+      status: "CONFLICTING_DECLARATION",
+    });
+  });
+
   it("returns a detected methodology with no confirmed version", () => {
     const result = resolveQuickCheckMethodology({
       mentions: ["VM0007"],

--- a/tests/lib/quickCheckMethodology.test.ts
+++ b/tests/lib/quickCheckMethodology.test.ts
@@ -88,6 +88,18 @@ describe("methodology declaration version resolution", () => {
     });
   });
 
+  it("does not pair a later unrelated Version 6.1 with the formal VM0007 v1.8 row", () => {
+    const result = resolveMethodologyDeclarationFromText(read(
+      "../roraima-vm0007-pdd/extracted.txt",
+    ), "VM0007");
+
+    expect(result).toMatchObject({
+      version: "v1.8",
+      status: "VERSION_CONFIRMED",
+    });
+    expect(result.evidenceQuote).not.toContain("6.1");
+  });
+
   it("resolves the real Roraima extraction without promoting its document version", () => {
     const rawText = fs.readFileSync(
       path.join(process.cwd(), "tests/fixtures/quick-check/v2/roraima-vm0007-pdd/extracted.txt"),

--- a/tests/lib/quickCheckUi.test.ts
+++ b/tests/lib/quickCheckUi.test.ts
@@ -83,6 +83,39 @@ function loadQuickCheckV2FixtureViews(): Array<{
 }
 
 describe("quick check ui helpers", () => {
+  it("reports explicit methodology/version states instead of confidence-only wording", () => {
+    const baseAnalysis = {
+      facts: [],
+      parsedEvidenceLabels: ["pdd.pdf"],
+      documentTypes: ["PDD / PDF"],
+      methodologyMentions: ["VM0007"],
+      extractionConfidence: 0.2,
+      warnings: [],
+      rawPddText: "Applied Methodology VM0007 REDD+ Methodology Framework v1.8",
+    };
+    const resolution = (versionStatus: "VERSION_CONFIRMED" | "VERSION_NOT_CONFIRMED" | "CONFLICTING_DECLARATION", methodologyVersion: string | null) => ({
+      status: "single" as const,
+      rawMentions: ["VM0007"],
+      programSignals: [],
+      signals: [],
+      matchedMethods: [{
+        methodologyId: "VM0007",
+        methodologyVersion,
+        versionStatus,
+        rulebookVersion: "v1.8",
+        matchedSignals: ["VM0007"],
+        canonicalKeys: ["VM0007"],
+        priority: 0,
+      }],
+      unsupportedCanonicalKeys: [],
+      primaryMethodology: null,
+    });
+
+    expect(buildExtractionPreviewViewModel({ analysis: baseAnalysis, methodologyResolution: resolution("VERSION_CONFIRMED", "v1.8") }).methodologyState).toBe("Version confirmed");
+    expect(buildExtractionPreviewViewModel({ analysis: { ...baseAnalysis, rawPddText: "VM0007 REDD+ Methodology Framework" }, methodologyResolution: resolution("VERSION_NOT_CONFIRMED", null) }).methodologyState).toBe("Version missing");
+    expect(buildExtractionPreviewViewModel({ analysis: baseAnalysis, methodologyResolution: resolution("CONFLICTING_DECLARATION", null) }).methodologyState).toBe("Conflicting declaration");
+  });
+
   it("builds a claim-relevant extraction snapshot", () => {
     const snapshot = buildQuickCheckExtractionSnapshot({
       claimText: "The boundary description matches the mapped project area",

--- a/tests/lib/quickCheckUi.test.ts
+++ b/tests/lib/quickCheckUi.test.ts
@@ -112,7 +112,13 @@ describe("quick check ui helpers", () => {
     });
 
     expect(buildExtractionPreviewViewModel({ analysis: baseAnalysis, methodologyResolution: resolution("VERSION_CONFIRMED", "v1.8") }).methodologyState).toBe("Version confirmed");
-    expect(buildExtractionPreviewViewModel({ analysis: { ...baseAnalysis, rawPddText: "VM0007 REDD+ Methodology Framework" }, methodologyResolution: resolution("VERSION_NOT_CONFIRMED", null) }).methodologyState).toBe("Version missing");
+    const missingVersionView = buildExtractionPreviewViewModel({ analysis: { ...baseAnalysis, rawPddText: "VM0007 REDD+ Methodology Framework" }, methodologyResolution: resolution("VERSION_NOT_CONFIRMED", null) });
+    expect(missingVersionView.methodologyState).toBe("Version missing");
+    expect(missingVersionView.detectedMethodology).toBe("VM0007");
+    expect(missingVersionView.detectedMethodology).not.toContain("v1.8");
+    const confirmedVersionView = buildExtractionPreviewViewModel({ analysis: baseAnalysis, methodologyResolution: resolution("VERSION_CONFIRMED", "v1.8") });
+    expect(confirmedVersionView.methodologyState).toBe("Version confirmed");
+    expect(confirmedVersionView.detectedMethodology).toBe("VM0007 v1.8");
     expect(buildExtractionPreviewViewModel({ analysis: baseAnalysis, methodologyResolution: resolution("CONFLICTING_DECLARATION", null) }).methodologyState).toBe("Conflicting declaration");
   });
 

--- a/tests/lib/quickCheckUploadOriginPolicy.test.ts
+++ b/tests/lib/quickCheckUploadOriginPolicy.test.ts
@@ -12,10 +12,32 @@ describe("Quick Check upload origin policy", () => {
   });
 
   it("accepts a configured origin in Preview and Production", () => {
-    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
-    expect(authorizeQuickCheckUploadOrigin("https://app.article6.example").allowed).toBe(true);
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.org";
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.org").allowed).toBe(true);
     process.env.VERCEL_ENV = "production";
-    expect(authorizeQuickCheckUploadOrigin("https://app.article6.example").allowed).toBe(true);
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.org").allowed).toBe(true);
+  });
+
+  it.each([undefined, "production"]) (
+    "accepts an app.article6 Vercel Preview hostname when VERCEL_ENV is %s",
+    (vercelEnv) => {
+      if (vercelEnv === undefined) delete process.env.VERCEL_ENV;
+      else process.env.VERCEL_ENV = vercelEnv;
+      delete process.env.R2_ALLOWED_UPLOAD_ORIGINS;
+
+      expect(authorizeQuickCheckUploadOrigin("https://app-article6-feature-123-fredillys-projects.vercel.app")).toMatchObject({
+        allowed: true,
+        normalizedOrigin: "https://app-article6-feature-123-fredillys-projects.vercel.app",
+      });
+    },
+  );
+
+  it("still requires exact R2 configuration for app.article6.org", () => {
+    delete process.env.R2_ALLOWED_UPLOAD_ORIGINS;
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.org").allowed).toBe(false);
+
+    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.org";
+    expect(authorizeQuickCheckUploadOrigin("https://app.article6.org").allowed).toBe(true);
   });
 
   it("rejects an unconfigured origin", () => {
@@ -42,9 +64,21 @@ describe("Quick Check upload origin policy", () => {
     expect(authorizeQuickCheckUploadOrigin("https://app.article6.example:444").allowed).toBe(false);
   });
 
-  it("does not allow Vercel wildcard origins", () => {
-    process.env.R2_ALLOWED_UPLOAD_ORIGINS = "https://app.article6.example";
-    expect(authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app").allowed).toBe(false);
+  it("rejects unrelated Vercel projects and lookalike domains", () => {
+    delete process.env.R2_ALLOWED_UPLOAD_ORIGINS;
+    expect(authorizeQuickCheckUploadOrigin("https://other-app-feature-fredillys-projects.vercel.app").allowed).toBe(false);
+    expect(authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app.evil.example").allowed).toBe(false);
+    expect(authorizeQuickCheckUploadOrigin("https://app-article6-feature-fredillys-projects.vercel.app.attacker.com").allowed).toBe(false);
+  });
+
+  it("rejects non-origin URL forms for trusted Vercel Preview hostnames", () => {
+    delete process.env.R2_ALLOWED_UPLOAD_ORIGINS;
+    const host = "app-article6-feature-fredillys-projects.vercel.app";
+    expect(authorizeQuickCheckUploadOrigin(`http://${host}`).allowed).toBe(false);
+    expect(authorizeQuickCheckUploadOrigin(`https://${host}/upload`).code).toBe("origin-invalid");
+    expect(authorizeQuickCheckUploadOrigin(`https://${host}?debug=1`).code).toBe("origin-invalid");
+    expect(authorizeQuickCheckUploadOrigin(`https://${host}#fragment`).code).toBe("origin-invalid");
+    expect(authorizeQuickCheckUploadOrigin(`https://user:pass@${host}`).code).toBe("origin-invalid");
   });
 
   it("requires an Origin header and configured allowlist", () => {

--- a/tests/lib/quickCheckV2/gold-fixtures.test.ts
+++ b/tests/lib/quickCheckV2/gold-fixtures.test.ts
@@ -253,6 +253,18 @@ function toGoldComparableRecord(
   return record;
 }
 
+function normalizeGoldRecord(record: GoldRecord): GoldRecord {
+  const normalized = normalizeExpectedQuickCheckGoldRecord(record) as GoldRecord;
+  if (normalized.expectedMethodology?.versionStatus !== "NOT_EXPLICITLY_DECLARED") return normalized;
+  return {
+    ...normalized,
+    expectedMethodology: {
+      ...normalized.expectedMethodology,
+      versionStatus: "VERSION_NOT_CONFIRMED",
+    },
+  };
+}
+
 function validateMethodologyGoldRecord(record: GoldRecord): void {
   if (record.checkName !== "methodology") return;
 
@@ -415,7 +427,7 @@ describe("Quick Check v2 gold fixtures", () => {
 
         expect(comparableStatuses.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!))).toStrictEqual(
           gold
-            .map(normalizeExpectedQuickCheckGoldRecord)
+            .map(normalizeGoldRecord)
             .map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
         );
       });
@@ -453,7 +465,7 @@ describe("Quick Check v2 gold fixtures", () => {
           }
 
           expect(comparableRuntimeStatuses.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!))).toStrictEqual(
-            gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+            gold.map(normalizeGoldRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
           );
         }, 120000);
       }

--- a/tests/lib/quickCheckV2/methodologyIdentity.test.ts
+++ b/tests/lib/quickCheckV2/methodologyIdentity.test.ts
@@ -101,7 +101,7 @@ describe("buildQuickCheckMethodologyIdentity", () => {
 
     expect(identity?.methodologyId).toBe("VM0007");
     expect(identity?.pddDeclaredMethodologyVersion).toBeNull();
-    expect(identity?.versionStatus).toBe("NOT_EXPLICITLY_DECLARED");
+    expect(identity?.versionStatus).toBe("VERSION_NOT_CONFIRMED");
   });
 
   it("prefers the formal VM0007 row over the cover version", () => {
@@ -182,5 +182,28 @@ describe("buildQuickCheckMethodologyIdentity", () => {
     expect(built.methodology?.pddDeclaredMethodologyVersion).toBe("v1.8");
     expect(built.audit.versionMatch).toBe(true);
     expect(built.draft.ok).toBe(true);
+  });
+
+  it("does not pass a VM0007 draft when the PDD has no declared version", async () => {
+    const rulesResult = await loadMethodRules("VM0007", "v1-8");
+    const rawPddText = fs.readFileSync(
+      path.join(process.cwd(), "tests/fixtures/quick-check/v2/methodology-version-provenance/vm0007-without-version.txt"),
+      "utf8",
+    );
+    const built = buildVm0007MachineProposal({
+      auditId: "missing-methodology-version-regression",
+      generatedAt: "2026-08-07T00:00:00.000Z",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      rawPddText,
+      rules: rulesResult.rules,
+    });
+
+    expect(built.methodology?.methodologyId).toBe("VM0007");
+    expect(built.methodology?.pddDeclaredMethodologyVersion).toBeNull();
+    expect(built.methodology?.versionStatus).toBe("VERSION_NOT_CONFIRMED");
+    expect(built.audit.pddDeclaredMethodologyVersion).toBe("");
+    expect(built.audit.versionMatch).toBe(false);
+    expect(built.draft.ok).toBe(false);
   });
 });

--- a/tests/lib/quickCheckV2/methodologyIdentity.test.ts
+++ b/tests/lib/quickCheckV2/methodologyIdentity.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "@jest/globals";
+import fs from "node:fs";
+import path from "node:path";
 import { buildQuickCheckMethodologyIdentity } from "@/lib/quickCheckV2/methodologyIdentity";
+import { buildVm0007MachineProposal } from "@/lib/preverif/vm0007MachineProposal";
+import { loadMethodRules } from "@/app/m/_lib/methodRules";
+
+const roraimaExcerpt = fs.readFileSync(
+  path.join(process.cwd(), "tests/fixtures/quick-check/v2/roraima-vm0007-pdd/extracted.txt"),
+  "utf8",
+);
 
 describe("buildQuickCheckMethodologyIdentity", () => {
   it("keeps the raw document wording in evidenceQuote while canonicalizing the version", () => {
@@ -78,5 +87,100 @@ describe("buildQuickCheckMethodologyIdentity", () => {
     expect(identity?.methodologyName).toContain("Reducing Emissions from Deforestation and Forest Degradation");
     expect(identity?.pddDeclaredMethodologyVersion).toBe("v1.0");
     expect(identity?.versionStatus).toBe("DECLARED");
+  });
+
+  it("does not treat a PDD document version as the VM0007 version", () => {
+    const identity = buildQuickCheckMethodologyIdentity({
+      sourceType: "exact_section",
+      quote: "Roraima PDD Version 1.3 VM0007 REDD+ Methodology Framework",
+      page: 1,
+      sectionHeading: "Project Description",
+      sectionPath: ["cover"],
+      spanId: "synthetic:roraima:cover",
+    });
+
+    expect(identity?.methodologyId).toBe("VM0007");
+    expect(identity?.pddDeclaredMethodologyVersion).toBeNull();
+    expect(identity?.versionStatus).toBe("NOT_EXPLICITLY_DECLARED");
+  });
+
+  it("prefers the formal VM0007 row over the cover version", () => {
+    const identity = buildQuickCheckMethodologyIdentity({
+      sourceType: "exact_section",
+      quote: roraimaExcerpt,
+      page: 84,
+      sectionHeading: "3.1.1 Title and Reference of Methodology",
+      sectionPath: ["3", "3.1", "3.1.1"],
+      spanId: "synthetic:roraima:methodology",
+    });
+
+    expect(identity?.methodologyId).toBe("VM0007");
+    expect(identity?.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(identity?.evidenceQuote).toContain("PDD Version 1.3");
+    expect(identity?.evidenceQuote).toContain("Applied Methodology VM0007");
+  });
+
+  it("returns an unknown version when only generic document metadata is present", () => {
+    const identity = buildQuickCheckMethodologyIdentity({
+      sourceType: "fact_contract",
+      quote: "Project Description PDD Version 1.3. The project applies VM0007 REDD+ Methodology Framework.",
+      page: 1,
+      sectionHeading: "Project Description",
+      sectionPath: ["cover"],
+      spanId: "synthetic:roraima:generic-version",
+    });
+
+    expect(identity?.methodologyId).toBe("VM0007");
+    expect(identity?.pddDeclaredMethodologyVersion).toBeNull();
+  });
+
+  it.each([
+    ["VM0007 v1.8", "v1.8"],
+    ["VM0007 version 1.8", "v1.8"],
+    ["VM0007 v1-8", "v1.8"],
+  ])("detects explicit methodology declaration %s", (quote, expectedVersion) => {
+    const identity = buildQuickCheckMethodologyIdentity({
+      sourceType: "exact_section",
+      quote,
+      page: 3,
+      sectionHeading: "3.1.1 Title and Reference of Methodology",
+      sectionPath: ["3", "3.1", "3.1.1"],
+      spanId: "synthetic:explicit-version",
+    });
+
+    expect(identity?.methodologyId).toBe("VM0007");
+    expect(identity?.pddDeclaredMethodologyVersion).toBe(expectedVersion);
+  });
+
+  it("does not use module or tool versions as the primary methodology version", () => {
+    const identity = buildQuickCheckMethodologyIdentity({
+      sourceType: "fact_contract",
+      quote: "Methodology VM0007 REDD+ Methodology Framework Module VMD0001 Carbon stocks 1.2 Tool VT0001 Additionality Tool 3.0",
+      page: 3,
+      sectionHeading: "3.1.1 Title and Reference of Methodology",
+      sectionPath: ["3", "3.1", "3.1.1"],
+      spanId: "synthetic:module-tool-versions",
+    });
+
+    expect(identity?.methodologyId).toBe("VM0007");
+    expect(identity?.pddDeclaredMethodologyVersion).toBeNull();
+  });
+
+  it("carries Roraima into VM0007 draft validation with the declared v1.8", async () => {
+    const rulesResult = await loadMethodRules("VM0007", "v1-8");
+    const built = buildVm0007MachineProposal({
+      auditId: "roraima-methodology-version-regression",
+      generatedAt: "2026-08-06T00:00:00.000Z",
+      methodologyId: "VM0007",
+      methodologyVersion: "v1-8",
+      evidenceFileName: "roraima-pdd.pdf",
+      rawPddText: roraimaExcerpt,
+      rules: rulesResult.rules,
+    });
+
+    expect(built.methodology?.methodologyId).toBe("VM0007");
+    expect(built.methodology?.pddDeclaredMethodologyVersion).toBe("v1.8");
+    expect(built.audit.versionMatch).toBe(true);
+    expect(built.draft.ok).toBe(true);
   });
 });

--- a/tests/lib/quickCheckV2/status-validator.test.ts
+++ b/tests/lib/quickCheckV2/status-validator.test.ts
@@ -384,7 +384,7 @@ describe("Quick Check v2 — Phase 5 deterministic status validator", () => {
 
     expect(result.methodology?.methodologyId).toBe("VM0007");
     expect(result.methodology?.pddDeclaredMethodologyVersion).toBeNull();
-    expect(result.methodology?.versionStatus).toBe("NOT_EXPLICITLY_DECLARED");
+    expect(result.methodology?.versionStatus).toBe("VERSION_NOT_CONFIRMED");
   });
 
   it("returns only checkName, status, answer, evidence, and reason", () => {


### PR DESCRIPTION
## Summary
- constrain methodology-version parsing to the methodology declaration scope
- prevent PDD/document, revision, module, and tool versions from becoming the primary methodology version
- add Roraima regression coverage through VM0007 v1.8 draft validation

## Root cause
The parser scanned the selected quote for the first generic version token and the row parser could overrun into module/tool rows. A cover/document version 1.3 could therefore be associated with VM0007 instead of the formal applied-methodology declaration.

## Verification
- focused Quick Check v2 methodology identity, answer extraction, status, and Marcondes reconciliation tests
- TypeScript
- ESLint
- git diff --check

No production audit classifications, reviewed truth, report totals, extraction/upload, storage, or version-lock policy changed.