### PR TITLE
Raise Quick Check PDF upload limit to 150 MiB

### DIFF
--- a/src/app/api/quick-check/r2-upload/route.ts
+++ b/src/app/api/quick-check/r2-upload/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { confirmQuickCheckUpload, MAX_QUICK_CHECK_PDF_BYTES, presignQuickCheckUpload, QuickCheckUploadError } from "@/lib/quickCheck/r2Upload";
+import { formatQuickCheckPdfLimitLabel, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
+import { confirmQuickCheckUpload, presignQuickCheckUpload, QuickCheckUploadError } from "@/lib/quickCheck/r2Upload";
 import { authorizeQuickCheckUploadOrigin } from "@/lib/quickCheck/uploadOriginPolicy";
 export const runtime = "nodejs";
 const json = (body: unknown, status = 200) => NextResponse.json(body, { status, headers: { "Cache-Control": "no-store" } });
@@ -9,7 +10,7 @@ export async function POST(request: Request) {
     if (body.action === "presign") {
       const originDecision = authorizeQuickCheckUploadOrigin(request.headers.get("origin"));
       if (!originDecision.allowed) return json({ error: originDecision.error, code: originDecision.code }, originDecision.status);
-      if (!Number.isInteger(body.size) || body.size! <= 0 || body.size! > MAX_QUICK_CHECK_PDF_BYTES) return json({ error: "PDF must be smaller than 50 MiB.", code: "upload-too-large" }, 413);
+      if (!Number.isInteger(body.size) || body.size! <= 0 || body.size! > MAX_QUICK_CHECK_PDF_BYTES) return json({ error: `PDF must be no larger than ${formatQuickCheckPdfLimitLabel()}.`, code: "upload-too-large" }, 413);
       if (body.contentType !== "application/pdf") return json({ error: "Only PDF files are accepted.", code: "invalid-file" }, 415);
       return json(await presignQuickCheckUpload(body.size!));
     }

--- a/src/app/api/quick-check/upload/route.ts
+++ b/src/app/api/quick-check/upload/route.ts
@@ -2,7 +2,7 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import { withMetrics } from "@/lib/metrics";
-import { MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
+import { formatQuickCheckPdfLimitLabel, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 
 /**
  * Quick Check PDF upload endpoint.
@@ -24,7 +24,7 @@ async function handlePost() {
     ok: true,
     store: blobAvailable ? "vercel-blob" : "in-memory",
     maxSizeBytes: MAX_QUICK_CHECK_PDF_BYTES,
-    maxSizeLabel: "50 MiB",
+    maxSizeLabel: formatQuickCheckPdfLimitLabel(),
   });
 }
 
@@ -35,7 +35,7 @@ async function handleGet() {
     ok: true,
     store: blobAvailable ? "vercel-blob" : "in-memory",
     maxSizeBytes: MAX_QUICK_CHECK_PDF_BYTES,
-    maxSizeLabel: "50 MiB",
+    maxSizeLabel: formatQuickCheckPdfLimitLabel(),
   });
 }
 

--- a/src/components/chat/QuickCheckPanel.tsx
+++ b/src/components/chat/QuickCheckPanel.tsx
@@ -51,7 +51,7 @@ import {
   normalizeQuickCheckUiResult,
 } from "@/lib/chat/quickCheckUi";
 import { createQuickCheckPdfUploadCache, resolveQuickCheckPdfText } from "@/lib/chat/quickCheckPdfClient";
-import { MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
+import { formatQuickCheckPdfLimitLabel, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 import { coalesceEvidencePins, type EvidenceInventoryItem } from "@/lib/evidence/inventory";
 import { createAndStoreEvidenceAttachment, getAttachmentBytes } from "@/lib/proofMap/attachments";
 import { isRuleLikeId } from "@/lib/proofMap/pins";
@@ -1619,7 +1619,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
 
     setIsDragActive(false);
     if (file.size > MAX_QUICK_CHECK_PDF_BYTES) {
-      setFieldErrors({ evidence: "PDF exceeds the Quick Check upload limit of 50 MiB." });
+      setFieldErrors({ evidence: `PDF exceeds the Quick Check upload limit of ${formatQuickCheckPdfLimitLabel()}.` });
       return;
     }
     if (file.type !== "application/pdf" && !file.name.toLowerCase().endsWith(".pdf")) {
@@ -1632,7 +1632,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
     setRecoveryState(null);
     try {
       const evidenceId = newPinId();
-      const attachmentResult = await createAndStoreEvidenceAttachment({ pin_id: evidenceId, file, maxBytes: MAX_QUICK_CHECK_PDF_BYTES, maxBytesLabel: "50 MiB" });
+      const attachmentResult = await createAndStoreEvidenceAttachment({ pin_id: evidenceId, file, maxBytes: MAX_QUICK_CHECK_PDF_BYTES, maxBytesLabel: formatQuickCheckPdfLimitLabel() });
       if (!attachmentResult.ok) {
         setFieldErrors({ evidence: attachmentResult.message });
         return;
@@ -2471,7 +2471,7 @@ export default function QuickCheckPanel({ initialMethod, initialVersion, onConti
                     Drop your document
                   </div>
                   <div className="mt-2 text-sm text-slate-600">
-                    PDF only · up to 50 MiB
+                    PDF only · up to {formatQuickCheckPdfLimitLabel()}
                   </div>
                 </div>
                 <button

--- a/src/lib/chat/quickCheckPdfClient.ts
+++ b/src/lib/chat/quickCheckPdfClient.ts
@@ -1,6 +1,6 @@
 import { extractMethodologyMentions, type QuickCheckPdfParserDebug, type QuickCheckResolvedPdfText } from "@/lib/chat/quickCheckEvidence";
 import { formatQuickCheckPdfPages, type QuickCheckPdfPage } from "@/lib/chat/quickCheckPdfPages";
-import { isLikelyPdfBytes, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
+import { formatQuickCheckPdfLimitLabel, isLikelyPdfBytes, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 import type { ParsedDocument } from "@/lib/documentParsing";
 export type QuickCheckUploadProgress = (percent: number) => void;
 const RECOVERED_TEXT_WARNING = "Server extraction failed, but Quick Check recovered document signals locally. Review extracted details before relying on matches.";
@@ -10,7 +10,7 @@ const defaultUploadCache = createQuickCheckPdfUploadCache();
 export function clearQuickCheckUploadCache() { defaultUploadCache.clear(); }
 export async function resolveQuickCheckPdfText(input: { attachmentId?: string; sha256?: string; uploadCache?: QuickCheckPdfUploadCache; bytes: ArrayBuffer; filename: string; onProgress?: QuickCheckUploadProgress; onConfirm?: () => void; onConfirmed?: () => void; onRetrieving?: () => void; onExtracting?: () => void; onRunning?: () => void }): Promise<QuickCheckResolvedPdfText> {
   const { bytes, onProgress, onConfirm, onConfirmed, onRetrieving, onExtracting, onRunning } = input;
-  if (bytes.byteLength > MAX_QUICK_CHECK_PDF_BYTES) throw new Error("PDF exceeds the Quick Check upload limit of 50 MiB.");
+  if (bytes.byteLength > MAX_QUICK_CHECK_PDF_BYTES) throw new Error(`PDF exceeds the Quick Check upload limit of ${formatQuickCheckPdfLimitLabel()}.`);
   if (!isLikelyPdfBytes(bytes)) throw new Error("Only valid PDF files can be uploaded.");
   const cacheKeys = [input.sha256?.trim(), input.attachmentId?.trim()].filter((key): key is string => Boolean(key));
   const cache = input.uploadCache ?? defaultUploadCache;

--- a/src/lib/chat/quickCheckPdfUpload.ts
+++ b/src/lib/chat/quickCheckPdfUpload.ts
@@ -1,4 +1,4 @@
-export const MAX_QUICK_CHECK_PDF_BYTES = 50 * 1024 * 1024;
+export const MAX_QUICK_CHECK_PDF_BYTES = 150 * 1024 * 1024;
 
 export type QuickCheckPdfRouteErrorCode = "missing-file" | "invalid-file" | "file-too-large";
 

--- a/src/lib/quickCheck/r2Upload.ts
+++ b/src/lib/quickCheck/r2Upload.ts
@@ -1,7 +1,7 @@
 import { createHmac, randomUUID, timingSafeEqual } from "crypto";
 import { DeleteObjectCommand, GetObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
+import { formatQuickCheckPdfLimitLabel, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 
 const PREFIX = "quick-check/";
 const REFERENCE_TTL_SECONDS = 600;
@@ -58,7 +58,7 @@ export async function confirmQuickCheckUpload(reference: string) {
     const actualSize = head.ContentLength;
     if (actualSize !== undefined && actualSize > MAX_QUICK_CHECK_PDF_BYTES) {
       await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: objectKey(claims) })).catch(() => undefined);
-      throw new QuickCheckUploadError("upload-too-large", "The uploaded PDF exceeds the Quick Check upload limit.");
+      throw new QuickCheckUploadError("upload-too-large", `The uploaded PDF exceeds the Quick Check upload limit of ${formatQuickCheckPdfLimitLabel()}.`);
     }
     if (actualSize === undefined || actualSize <= 0 || actualSize !== claims.expectedSize || head.ContentType?.toLowerCase() !== claims.contentType) {
       await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: objectKey(claims) })).catch(() => undefined);
@@ -91,7 +91,7 @@ export async function retrieveQuickCheckUpload(reference: string): Promise<{ byt
     const size = head.ContentLength;
     const contentType = head.ContentType?.toLowerCase();
     if (size === undefined || size <= 0) throw new QuickCheckUploadError("upload-not-found", "The uploaded PDF was not found.");
-    if (size > MAX_QUICK_CHECK_PDF_BYTES) throw new QuickCheckUploadError("upload-too-large", "The uploaded PDF exceeds the Quick Check upload limit.");
+    if (size > MAX_QUICK_CHECK_PDF_BYTES) throw new QuickCheckUploadError("upload-too-large", `The uploaded PDF exceeds the Quick Check upload limit of ${formatQuickCheckPdfLimitLabel()}.`);
     if (size !== claims.expectedSize) throw new QuickCheckUploadError("upload-metadata-mismatch", "The uploaded PDF metadata did not match the upload reference.");
     if (contentType !== claims.contentType) throw new QuickCheckUploadError("upload-unsupported-content-type", "The uploaded object is not a PDF.");
 

--- a/tests/api/quick-check.pdf-extract.route.test.ts
+++ b/tests/api/quick-check.pdf-extract.route.test.ts
@@ -6,6 +6,7 @@ import path from "path";
 
 import { POST } from "@/app/api/quick-check/pdf-extract/route";
 import { issueUploadReference } from "@/lib/quickCheck/r2Upload";
+import { MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 
 describe("POST /api/quick-check/pdf-extract", () => {
   beforeEach(() => {
@@ -137,7 +138,7 @@ describe("POST /api/quick-check/pdf-extract", () => {
   });
 
   it("rejects oversized PDF with file-too-large code", async () => {
-    const oversized = new Uint8Array((50 * 1024 * 1024) + 1); // > 50 MiB
+    const oversized = new Uint8Array(MAX_QUICK_CHECK_PDF_BYTES + 1); // > 150 MiB
     // make it look like PDF to pass magic check
     const header = new TextEncoder().encode("%PDF-1.4\n");
     oversized.set(header, 0);

--- a/tests/components/quickCheckPanel.upload-errors.test.tsx
+++ b/tests/components/quickCheckPanel.upload-errors.test.tsx
@@ -24,7 +24,7 @@ jest.mock("@/lib/chat/quickCheckPdfClient", () => ({
         text: "",
         engine: "heuristic" as const,
         methodologyMentions: [],
-        warning: "PDF exceeds the Quick Check upload limit of 50 MiB.",
+        warning: "PDF exceeds the Quick Check upload limit of 150 MiB.",
         diagnosticCode: "file-too-large" as const,
       };
     }

--- a/tests/lib/quickCheckPdfClient.test.ts
+++ b/tests/lib/quickCheckPdfClient.test.ts
@@ -1,11 +1,16 @@
 /** @jest-environment jsdom */
 import { clearQuickCheckUploadCache, resolveQuickCheckPdfText } from "@/lib/chat/quickCheckPdfClient";
+import { formatQuickCheckPdfLimitLabel, MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 
 function pdfBytes(size: number) { const bytes = new Uint8Array(size); bytes.set(new TextEncoder().encode("%PDF-1.4\n(sample)\n%%EOF")); return bytes.buffer; }
 class FakeXhr { upload = { onprogress: undefined as ((event: ProgressEvent) => void) | undefined }; onload?: () => void; onerror?: () => void; status = 200; open() {} setRequestHeader() {} send() { this.upload.onprogress?.({ lengthComputable: true, loaded: 1, total: 1 } as ProgressEvent); this.onload?.(); } }
 
 describe("Quick Check PDF client", () => {
   beforeEach(() => { clearQuickCheckUploadCache(); global.XMLHttpRequest = FakeXhr as unknown as typeof XMLHttpRequest; });
+
+  it("reports the 150 MiB user-facing limit", () => {
+    expect(formatQuickCheckPdfLimitLabel()).toBe("150 MiB");
+  });
 
   it("uploads directly, confirms with only the reference, and preserves server page extraction", async () => {
     const calls: Array<{ url: string; body?: string }> = [];
@@ -38,10 +43,14 @@ describe("Quick Check PDF client", () => {
     expect(urls).toEqual(["/api/quick-check/r2-upload", "/api/quick-check/r2-upload", "/api/quick-check/pdf-extract"]);
   });
 
-  it("accepts exactly 50 MiB and rejects 50 MiB plus one byte before presign", async () => {
-    global.fetch = jest.fn(async () => new Response(JSON.stringify({ uploadRef: "signed-reference", url: "https://r2.example/signed", size: 50 * 1024 * 1024 }))) as typeof fetch;
-    await expect(resolveQuickCheckPdfText({ bytes: pdfBytes(50 * 1024 * 1024), filename: "limit.pdf" })).resolves.toMatchObject({ pdfRef: "signed-reference" });
-    await expect(resolveQuickCheckPdfText({ bytes: pdfBytes(50 * 1024 * 1024 + 1), filename: "over-limit.pdf" })).rejects.toThrow("50 MiB");
+  it("accepts just under and exactly 150 MiB, and rejects 150 MiB plus one byte before presign", async () => {
+    const limit = MAX_QUICK_CHECK_PDF_BYTES;
+    global.fetch = jest.fn(async () => new Response(JSON.stringify({ uploadRef: "signed-reference", url: "https://r2.example/signed", size: limit }))) as typeof fetch;
+    await expect(resolveQuickCheckPdfText({ bytes: pdfBytes(limit - 1), filename: "under-limit.pdf" })).resolves.toMatchObject({ pdfRef: "signed-reference" });
+    clearQuickCheckUploadCache();
+    await expect(resolveQuickCheckPdfText({ bytes: pdfBytes(limit), filename: "limit.pdf" })).resolves.toMatchObject({ pdfRef: "signed-reference" });
+    clearQuickCheckUploadCache();
+    await expect(resolveQuickCheckPdfText({ bytes: pdfBytes(limit + 1), filename: "over-limit.pdf" })).rejects.toThrow("150 MiB");
   });
 
   it("shares concurrent uploads and reuses the confirmed reference by SHA-256", async () => {

--- a/tests/lib/quickCheckR2Upload.test.ts
+++ b/tests/lib/quickCheckR2Upload.test.ts
@@ -1,5 +1,6 @@
 import { GetObjectCommand, HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { issueUploadReference, retrieveQuickCheckUpload, verifyUploadReference } from "@/lib/quickCheck/r2Upload";
+import { MAX_QUICK_CHECK_PDF_BYTES } from "@/lib/chat/quickCheckPdfUpload";
 
 describe("Quick Check R2 upload references", () => {
   beforeEach(() => {
@@ -15,6 +16,11 @@ describe("Quick Check R2 upload references", () => {
   it("binds size, content type, environment, and expiry to a signed reference", () => {
     const reference = issueUploadReference(1234);
     expect(verifyUploadReference(reference)).toMatchObject({ expectedSize: 1234, contentType: "application/pdf", environment: "preview" });
+  });
+
+  it("accepts a signed reference at exactly 150 MiB", () => {
+    const reference = issueUploadReference(MAX_QUICK_CHECK_PDF_BYTES);
+    expect(verifyUploadReference(reference).expectedSize).toBe(MAX_QUICK_CHECK_PDF_BYTES);
   });
 
   it("rejects altered and wrong-environment references", () => {
@@ -70,7 +76,7 @@ describe("Quick Check R2 upload references", () => {
     const send = jest.spyOn(S3Client.prototype, "send");
     send.mockRejectedValueOnce(Object.assign(new Error("not found"), { name: "NotFound" }));
     await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-not-found" });
-    send.mockResolvedValueOnce({ ContentLength: 51 * 1024 * 1024, ContentType: "application/pdf" } as never);
+    send.mockResolvedValueOnce({ ContentLength: MAX_QUICK_CHECK_PDF_BYTES + 1, ContentType: "application/pdf" } as never);
     await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-too-large" });
     send.mockResolvedValueOnce({ ContentLength: 10, ContentType: "text/plain" } as never);
     await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-unsupported-content-type" });
@@ -83,7 +89,7 @@ describe("Quick Check R2 upload references", () => {
     await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-metadata-mismatch" });
     send.mockResolvedValueOnce({ ContentLength: 11, ContentType: "application/pdf" } as never);
     await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-metadata-mismatch" });
-    send.mockResolvedValueOnce({ ContentLength: 50 * 1024 * 1024 + 1, ContentType: "application/pdf" } as never);
+    send.mockResolvedValueOnce({ ContentLength: MAX_QUICK_CHECK_PDF_BYTES + 1, ContentType: "application/pdf" } as never);
     await expect(retrieveQuickCheckUpload(reference)).rejects.toMatchObject({ code: "upload-too-large" });
   });
 });


### PR DESCRIPTION
## Summary

- raise the canonical Quick Check PDF limit from 50 MiB to 150 MiB
- keep direct browser-to-private-R2 upload and signed-reference validation unchanged
- update Quick Check routes, client validation, UI labels, R2 confirmation/retrieval errors, and Article6 extraction-bridge coverage
- add boundary and signed-reference regression coverage without adding a large fixture

## Preview verification

Verified with the real 119 MB / 481-page Guinea VCS 5427 PDD in the Vercel Preview deployment.

Observed result:

- browser upload completed successfully
- signed private R2 upload path completed successfully
- document retrieval/extraction completed successfully
- Quick Check produced page-linked evidence from the uploaded document, including evidence from pages well into the document (for example p.175, p.221, p.321)
- no upload-size, R2 retrieval, parser memory, or 30-second download-timeout failure was encountered during this test

This provides end-to-end evidence that the new 150 MiB limit supports the target 119 MB document through upload and extraction in Preview.

## Separate pre-existing Quick Check issues observed

The large-file test also exposed evidence-selection / methodology-provenance issues that are outside the scope of this PR and were not introduced by the size-limit change. Examples observed with VCS 5427:

- Host country evidence selected `Blue` from a sentence about Blue's Conakry office instead of identifying Guinea.
- Some generic Evidence Checks selected semantically weak spans for Additionality / Baseline Scenario.
- The Evidence Map provenance gate reported that the PDD does not declare VM0007 v1.8 even though the PDD explicitly declares VM0007 v1.8.

These should be fixed in a separate focused PR. They do not block merging this upload-limit change because the 119 MB document successfully reached and ran through the existing Quick Check pipeline.

## Validation

- real 119 MB Preview upload + extraction verification: PASS
- focused Jest tests for Quick Check client, R2 upload, PDF extraction, internal Article6 bridge, and upload errors: PASS
- TypeScript: PASS
- lint: PASS
- git diff --check: PASS
- Vercel Preview deployment: PASS

## Scope / architecture

- canonical limit: `150 * 1024 * 1024`
- direct browser -> private R2 architecture preserved
- signed-reference security and metadata validation preserved
- no streaming/memory architecture rewrite
- remaining 50 MiB literals are parser subprocess/evaluation `maxBuffer` settings, not upload or object-size guards, and are intentionally unchanged
- no migration required
- no environment change required