### PR TITLE
fix: harden Quick Check generic evidence reliability

### DIFF
--- a/src/lib/quickCheckV2/answers/index.ts
+++ b/src/lib/quickCheckV2/answers/index.ts
@@ -37,6 +37,7 @@ import { normalizeDeclaredMethodologyVersion } from "@/lib/chat/methodologyVersi
 import type { EvidenceStackItem } from "@/lib/evidence/evidenceStack";
 import { buildQuickCheckEvidenceStack } from "@/lib/quickCheckV2/evidenceStackAdapter";
 import { buildQuickCheckEvidenceStackWithCompanions } from "@/lib/quickCheckV2/evidenceStackProducer";
+import { extractCountryName } from "@/lib/quickCheckV2/countryParsing";
 
 export type AnswerResult = {
   checkName: StructuredCheckId;
@@ -259,6 +260,8 @@ const ANSWER_EXTRACTORS: Record<StructuredCheckId, AnswerExtractor> = {
     if (explicitField) {
       return explicitField[1]!;
     }
+    const country = extractCountryName(quote);
+    if (country) return country;
 
     const projectLocationLead = quote.match(
       /\bProject location\s+(?:The\s+)?([^,]+?)(?=,|$)/i,

--- a/src/lib/quickCheckV2/countryParsing.ts
+++ b/src/lib/quickCheckV2/countryParsing.ts
@@ -1,0 +1,20 @@
+const REGION_NAMES = typeof Intl.DisplayNames === "function"
+  ? new Intl.DisplayNames(["en"], { type: "region" as Intl.DisplayNamesOptions["type"] })
+  : null;
+
+const COUNTRY_NAMES = REGION_NAMES
+  ? Array.from({ length: 26 }, (_, first) => String.fromCharCode(65 + first))
+    .flatMap((first) => Array.from({ length: 26 }, (_, second) => `${first}${String.fromCharCode(65 + second)}`))
+    .map((code) => REGION_NAMES.of(code)?.trim())
+    .filter((name): name is string => Boolean(name && name.length > 2 && name !== "Unknown Region" && name !== "world"))
+    .sort((left, right) => right.length - left.length)
+  : [];
+
+/** Extract a country name from identity/location prose without a document-specific list. */
+export function extractCountryName(value: string): string | null {
+  for (const country of COUNTRY_NAMES) {
+    const escaped = country.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (new RegExp(`\\b${escaped}\\b`, "i").test(value)) return country;
+  }
+  return null;
+}

--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -978,10 +978,13 @@ function isDelegatedSupportingDocumentReference(text: string): boolean {
   return /please refer to supporting documen(?:t|ts)/i.test(text);
 }
 
-function isTemplateInstruction(text: string): boolean {
+function isTemplateInstruction(text: string, context = ""): boolean {
   const normalized = text.replace(/\s+/g, " ").trim();
-  return /^(?:describe|specify|include|explain|provide|state|indicate)\b/i.test(normalized)
-    && /\b(?:procedure|equations?|calculations?|quantification|methodological choices|sufficient information)\b/i.test(normalized);
+  const imperative = /^(?:describe|specify|include|explain|provide|state|indicate)\b/i.test(normalized);
+  const instructional = /\b(?:procedure|equations?|calculations?|quantification|methodological choices|sufficient information)\b/i.test(normalized);
+  const templateContext = /\b(?:template|VCS|Verra|applied methodology|calculation spreadsheet|leakage emissions)\b/i.test(`${context} ${normalized}`);
+  const projectSpecific = /\b(?:project|activity|calculated|measured|estimated|recorded|observed|result(?:ed)?|during the monitoring|because|therefore)\b/i.test(normalized);
+  return imperative && instructional && templateContext && !projectSpecific;
 }
 
 function getUsableSectionBlocks(blocks: QuickCheckV2Block[]): QuickCheckV2Block[] {
@@ -992,7 +995,7 @@ function getUsableSectionBlocks(blocks: QuickCheckV2Block[]): QuickCheckV2Block[
       !isBoilerplateSectionBlock(block) &&
       !isLikelyTableOfContentsLine(text) &&
       !isDelegatedSupportingDocumentReference(text) &&
-      !isTemplateInstruction(text)
+      !isTemplateInstruction(text, block.sectionHeading ?? "")
     );
   });
 }
@@ -1203,7 +1206,7 @@ function chooseBestSectionBlock(
       ) ??
       (displacementBlock ? getParagraphStartBlock(usableBlocks, displacementBlock) : null) ??
       findFirstBlock(usableBlocks, (block) =>
-        /\bleakage\b/i.test(block.text) && !/\bnot applicable\b/i.test(block.text) && !isTemplateInstruction(block.text),
+        /\bleakage\b/i.test(block.text) && !/\bnot applicable\b/i.test(block.text) && !isTemplateInstruction(block.text, block.sectionHeading ?? ""),
       ) ??
       usableBlocks[0] ??
       null
@@ -2214,7 +2217,7 @@ function getExactSectionEvidence(
     ? buildForwardSectionQuote(document, block)
     : buildQuoteFromBlock(document, block);
   const quote = trimQuoteForCheck(checkName, rawQuote);
-  if (checkName === "leakage" && isTemplateInstruction(quote)) {
+  if (checkName === "leakage" && isTemplateInstruction(quote, block.sectionHeading ?? "")) {
     return null;
   }
   if (isDelegatedSupportingDocumentReference(quote)) {
@@ -2230,7 +2233,7 @@ function getRawTextFallbackEvidence(
 ): RetrievedEvidence | null {
   const definition = RAW_TEXT_FALLBACKS[checkName];
   const candidateBlocks = getEvidenceBlocks(document).filter(
-    (candidate) => !isDelegatedSupportingDocumentReference(candidate.text) && !isTemplateInstruction(candidate.text),
+    (candidate) => !isDelegatedSupportingDocumentReference(candidate.text) && !isTemplateInstruction(candidate.text, candidate.sectionHeading ?? ""),
   );
   const block = findFirstBlock(
     candidateBlocks,

--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -1,3 +1,5 @@
+import { extractCountryName } from "@/lib/quickCheckV2/countryParsing";
+
 /**
  * Quick Check v2 — Phase 3 evidence retrieval with fixed source priority.
  *
@@ -228,6 +230,11 @@ const FACT_CONTRACTS: Partial<Record<StructuredCheckId, FactContractDefinition>>
           /\bproject location\b/i.test(block.sectionHeading ?? "") &&
           /\b[A-Z][a-z]+,\s*[A-Z][a-z]+\b/.test(block.text),
         ) ??
+        findFirstBlock(blocks, (block) =>
+          block.page <= 2 &&
+          /\bproject title\b/i.test(block.text) &&
+          Boolean(extractCountryName(block.text)),
+        ) ??
         null
       );
     },
@@ -390,6 +397,8 @@ const RAW_TEXT_FALLBACKS: Record<StructuredCheckId, RawFallbackDefinition> = {
         LEAKAGE_NOT_APPLICABLE_RE.test(block.text) ||
         /\bmarket leakage\b/i.test(block.text) ||
         /\bactivity shifting leakage\b/i.test(block.text) ||
+        /\bpossible source of leakage\b/i.test(block.text) ||
+        /\bno displacement of\b/i.test(block.text) ||
         /\breductions in wood harvest\b/i.test(block.text) ||
         /\bcould shift to other areas\b/i.test(block.text) ||
         /\bdisplaced to\b/i.test(block.text)
@@ -969,6 +978,12 @@ function isDelegatedSupportingDocumentReference(text: string): boolean {
   return /please refer to supporting documen(?:t|ts)/i.test(text);
 }
 
+function isTemplateInstruction(text: string): boolean {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return /^(?:describe|specify|include|explain|provide|state|indicate)\b/i.test(normalized)
+    && /\b(?:procedure|equations?|calculations?|quantification|methodological choices|sufficient information)\b/i.test(normalized);
+}
+
 function getUsableSectionBlocks(blocks: QuickCheckV2Block[]): QuickCheckV2Block[] {
   return blocks.filter((block) => {
     const text = block.text.trim();
@@ -976,7 +991,8 @@ function getUsableSectionBlocks(blocks: QuickCheckV2Block[]): QuickCheckV2Block[
       text.length > 0 &&
       !isBoilerplateSectionBlock(block) &&
       !isLikelyTableOfContentsLine(text) &&
-      !isDelegatedSupportingDocumentReference(text)
+      !isDelegatedSupportingDocumentReference(text) &&
+      !isTemplateInstruction(text)
     );
   });
 }
@@ -1187,7 +1203,7 @@ function chooseBestSectionBlock(
       ) ??
       (displacementBlock ? getParagraphStartBlock(usableBlocks, displacementBlock) : null) ??
       findFirstBlock(usableBlocks, (block) =>
-        /\bleakage\b/i.test(block.text) && !/\bnot applicable\b/i.test(block.text),
+        /\bleakage\b/i.test(block.text) && !/\bnot applicable\b/i.test(block.text) && !isTemplateInstruction(block.text),
       ) ??
       usableBlocks[0] ??
       null
@@ -1196,6 +1212,13 @@ function chooseBestSectionBlock(
 
   if (checkName === "stakeholder_consultation") {
     return (
+      findFirstBlock(usableBlocks, (block) =>
+        /\b(?:date of )?stakeholder consultation\b/i.test(block.text) &&
+        (/\b\d{1,2}[-/]?[A-Za-z]+[-/]?\d{4}\b/i.test(block.text) || /\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/.test(block.text)),
+      ) ??
+      findFirstBlock(usableBlocks, (block) =>
+        /\bdate of stakeholder\b/i.test(block.text),
+      ) ??
       findFirstBlock(usableBlocks, (block) =>
         /\bpublic consultations\b/i.test(block.text) &&
         /\bconsent\b/i.test(block.text),
@@ -1911,7 +1934,8 @@ function getBestExactSectionBlock(
       /\bpublic consultations\b/i.test(selectedBlock.text) ||
       /\bnecessary consent\b/i.test(selectedBlock.text) ||
       /\bFree, Prior and Informed Consent\b/i.test(selectedBlock.text) ||
-      /\bFPIC\b/i.test(selectedBlock.text)
+      /\bFPIC\b/i.test(selectedBlock.text) ||
+      /\bdate of stakeholder\b/i.test(selectedBlock.text)
     ) &&
     !/\bThis section is not required at the Under Development stage\b/i.test(selectedBlock.text);
 
@@ -2091,6 +2115,23 @@ function getExactSectionEvidence(
   }
 
   if (checkName === "stakeholder_consultation") {
+    const datedConsultationBlock = findFirstBlock(evidenceBlocks, (block) =>
+      /\bdate of stakeholder\b/i.test(block.text) &&
+      !evidenceBlocks.some((candidate) =>
+        /\bTable 7\b/i.test(candidate.text) && /\bcomments received and actions taken\b/i.test(candidate.text),
+      ),
+    );
+    if (datedConsultationBlock) {
+      return toEvidence(
+        datedConsultationBlock,
+        "exact_section",
+        trimQuoteForCheck(
+          checkName,
+          buildForwardSectionQuote(document, datedConsultationBlock),
+        ),
+      );
+    }
+
     const noCommentsBlock = findFirstBlock(evidenceBlocks, (block) =>
       /\bSo far, no comments have been received from local stakeholders\b/i.test(block.text),
     );
@@ -2173,6 +2214,9 @@ function getExactSectionEvidence(
     ? buildForwardSectionQuote(document, block)
     : buildQuoteFromBlock(document, block);
   const quote = trimQuoteForCheck(checkName, rawQuote);
+  if (checkName === "leakage" && isTemplateInstruction(quote)) {
+    return null;
+  }
   if (isDelegatedSupportingDocumentReference(quote)) {
     return null;
   }
@@ -2186,7 +2230,7 @@ function getRawTextFallbackEvidence(
 ): RetrievedEvidence | null {
   const definition = RAW_TEXT_FALLBACKS[checkName];
   const candidateBlocks = getEvidenceBlocks(document).filter(
-    (candidate) => !isDelegatedSupportingDocumentReference(candidate.text),
+    (candidate) => !isDelegatedSupportingDocumentReference(candidate.text) && !isTemplateInstruction(candidate.text),
   );
   const block = findFirstBlock(
     candidateBlocks,

--- a/src/lib/quickCheckV2/evidenceStackProducer.ts
+++ b/src/lib/quickCheckV2/evidenceStackProducer.ts
@@ -18,6 +18,7 @@ const TARGET_CHECKS = new Set<StructuredCheckId>([
   "leakage",
   "stakeholder_consultation",
 ]);
+const METHODOLOGY_VERSION_RE = /\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\b[^\n.]{0,100}?\b(?:version|ver\.?|v\.?)\s*([0-9]+(?:[.-][0-9]+){0,2})\b/i;
 
 const UNDER_DEVELOPMENT_RE = /\bthis section is under development\b/i;
 const NOT_REQUIRED_RE = /\b(?:this )?section is not required (?:for|at) the Under Development stage\b|\bsection not required (?:for|at) the Under Development stage\b/i;
@@ -188,11 +189,55 @@ function collectStakeholderSupportingCompanions(
     });
 }
 
+function collectMethodologyVersionConflictCompanions(
+  document: QuickCheckV2ExtractedDocument,
+): EvidenceStackItem[] {
+  const mentions = document.blocks.filter((block) =>
+    (block.blockType === "body" || block.blockType === "table") &&
+    METHODOLOGY_VERSION_RE.test(block.text) &&
+    !/\bas required by\b/i.test(block.text),
+  );
+  const versionsByMethodology = new Map<string, Set<string>>();
+  for (const block of mentions) {
+    const version = block.text.match(METHODOLOGY_VERSION_RE)?.[1];
+    const methodologyId = block.text.match(/\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\b/i)?.[0].toUpperCase();
+    if (!version || !methodologyId) continue;
+    const versions = versionsByMethodology.get(methodologyId) ?? new Set<string>();
+    versions.add(version.replace(/-/g, "."));
+    versionsByMethodology.set(methodologyId, versions);
+  }
+  const conflictingMethodologies = new Set(
+    Array.from(versionsByMethodology.entries())
+      .filter(([, versions]) => versions.size > 1)
+      .map(([methodologyId]) => methodologyId),
+  );
+  if (conflictingMethodologies.size === 0) return [];
+
+  return mentions.flatMap((block) => {
+    const methodologyId = block.text.match(/\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\b/i)?.[0].toUpperCase();
+    if (!methodologyId || !conflictingMethodologies.has(methodologyId)) return [];
+    const item = toCompanionItem(
+      block,
+      "caveat",
+      "Conflicting methodology version declaration",
+      "The document declares more than one version of the same methodology; the version cannot be resolved confidently.",
+    );
+    return validateEvidenceStack([item]).valid ? [item] : [];
+  });
+}
+
 export function buildQuickCheckEvidenceStackWithCompanions(
   document: QuickCheckV2ExtractedDocument,
   selectedEvidence: RetrievedCheckEvidence,
 ): EvidenceStackItem[] {
   const primaryStack = buildQuickCheckEvidenceStack(selectedEvidence.evidence);
+
+  if (selectedEvidence.checkName === "methodology") {
+    return sortEvidenceStack(dedupeEvidenceStack([
+      ...primaryStack,
+      ...collectMethodologyVersionConflictCompanions(document),
+    ]));
+  }
 
   if (!TARGET_CHECKS.has(selectedEvidence.checkName) || primaryStack.length === 0) {
     return primaryStack;

--- a/src/lib/quickCheckV2/evidenceStackProducer.ts
+++ b/src/lib/quickCheckV2/evidenceStackProducer.ts
@@ -19,6 +19,8 @@ const TARGET_CHECKS = new Set<StructuredCheckId>([
   "stakeholder_consultation",
 ]);
 const METHODOLOGY_VERSION_RE = /\b(?:VM\d{4}|VMD\d{4}|ACM\d{4}|AM\d{4}|AMS-[A-Z0-9.]+|AR-ACM\d{4}|AR-AM[A-Z0-9.-]+|AR-AMS[A-Z0-9.-]*|GS-VER\d+|VT\d{4})\b[^\n.]{0,100}?\b(?:version|ver\.?|v\.?)\s*([0-9]+(?:[.-][0-9]+){0,2})\b/i;
+const METHODOLOGY_DECLARATION_CONTEXT_RE = /\b(?:title and reference|application of methodology|applicability|eligibility|methodology identification|methodology applied|summary description|project design)\b/i;
+const METHODOLOGY_NON_DECLARATION_RE = /\b(?:previously|formerly|historical|supersed(?:ed|es?)|replaced|transition|migration|migrat(?:ed|ing)|compared with|comparison|older|newer|prior version|reference only|example|as required by)\b/i;
 
 const UNDER_DEVELOPMENT_RE = /\bthis section is under development\b/i;
 const NOT_REQUIRED_RE = /\b(?:this )?section is not required (?:for|at) the Under Development stage\b|\bsection not required (?:for|at) the Under Development stage\b/i;
@@ -195,7 +197,8 @@ function collectMethodologyVersionConflictCompanions(
   const mentions = document.blocks.filter((block) =>
     (block.blockType === "body" || block.blockType === "table") &&
     METHODOLOGY_VERSION_RE.test(block.text) &&
-    !/\bas required by\b/i.test(block.text),
+    METHODOLOGY_DECLARATION_CONTEXT_RE.test(getRelevantText(block)) &&
+    !METHODOLOGY_NON_DECLARATION_RE.test(getRelevantText(block)),
   );
   const versionsByMethodology = new Map<string, Set<string>>();
   for (const block of mentions) {

--- a/src/lib/quickCheckV2/status/index.ts
+++ b/src/lib/quickCheckV2/status/index.ts
@@ -42,6 +42,10 @@ export type StatusReason =
   | "provenance_incomplete"
   | "under_development_stub"
   | "without_project_narrative_not_additionality_proof"
+  | "methodology_version_conflict"
+  | "insufficient_substantive_evidence"
+  | "template_instruction_evidence"
+  | "qualitative_leakage_only"
   | "answer_and_provenance_complete";
 
 export type StatusResult = {
@@ -94,6 +98,26 @@ function hasWithoutProjectNarrative(evidence: RetrievedEvidence): boolean {
     /\bin the absence of\b/i.test(evidence.quote) ||
     /\bproject was not implemented with the intent\b/i.test(evidence.quote)
   );
+}
+
+function isAdditionalityFrameworkOnly(text: string): boolean {
+  const lower = text.toLowerCase();
+  const framework = /\b(?:requirements?|in two steps|shall be demonstrated|must be demonstrated|regulatory surplus)\b/.test(lower);
+  const completed = /\b(?:barrier analysis|investment analysis|common practice analysis)\b.{0,80}\b(?:completed|conducted|results?|concluded|demonstrated|identified)\b/.test(lower)
+    || /\b(?:concluded|demonstrated|identified)\b.{0,80}\b(?:barrier|common practice|investment)\b/.test(lower);
+  return framework && !completed;
+}
+
+function isTemplateInstruction(text: string): boolean {
+  return /^(?:describe|specify|include|explain|provide|state|indicate)\b/i.test(text.trim())
+    && /\b(?:procedure|equations?|calculations?|quantification|methodological choices|sufficient information)\b/i.test(text);
+}
+
+function isQualitativeLeakageOnly(text: string): boolean {
+  const lower = text.toLowerCase();
+  const quantitative = /\b(?:quantif|equation|calculation|calculated|tco2e?|emission factor|measured|estimated|procedure for)\w*/.test(lower);
+  const qualitative = /\b(?:possible source|grazing|fuel wood|qualitative|no displacement)\b/.test(lower);
+  return qualitative && !quantitative;
 }
 
 export function validateAnswerResult(result: AnswerResult): StatusResult {
@@ -208,6 +232,55 @@ export function validateAnswerResult(result: AnswerResult): StatusResult {
       answer: normalizedResult.answer,
       evidence: normalizedResult.evidence,
       reason: "without_project_narrative_not_additionality_proof",
+      ...(methodology ? { methodology } : {}),
+      ...evidenceStackProps,
+    };
+  }
+
+  if (normalizedResult.checkName === "methodology" &&
+    groupEvidenceStackByRole(normalizedResult.evidenceStack).caveat.some((item) => /conflicting methodology version/i.test(item.label ?? ""))) {
+    return {
+      checkName: normalizedResult.checkName,
+      status: "UNCLEAR",
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
+      reason: "methodology_version_conflict",
+      ...(methodology ? { methodology } : {}),
+      ...evidenceStackProps,
+    };
+  }
+
+  if (normalizedResult.checkName === "additionality" && isAdditionalityFrameworkOnly(normalizedResult.evidence.quote)) {
+    return {
+      checkName: normalizedResult.checkName,
+      status: "UNCLEAR",
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
+      reason: "insufficient_substantive_evidence",
+      ...(methodology ? { methodology } : {}),
+      ...evidenceStackProps,
+    };
+  }
+
+  if (normalizedResult.checkName === "leakage" && isTemplateInstruction(normalizedResult.evidence.quote)) {
+    return {
+      checkName: normalizedResult.checkName,
+      status: "UNCLEAR",
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
+      reason: "template_instruction_evidence",
+      ...(methodology ? { methodology } : {}),
+      ...evidenceStackProps,
+    };
+  }
+
+  if (normalizedResult.checkName === "leakage" && isQualitativeLeakageOnly(normalizedResult.evidence.quote)) {
+    return {
+      checkName: normalizedResult.checkName,
+      status: "UNCLEAR",
+      answer: normalizedResult.answer,
+      evidence: normalizedResult.evidence,
+      reason: "qualitative_leakage_only",
       ...(methodology ? { methodology } : {}),
       ...evidenceStackProps,
     };

--- a/src/lib/quickCheckV2/status/index.ts
+++ b/src/lib/quickCheckV2/status/index.ts
@@ -120,8 +120,8 @@ function isTemplateInstruction(text: string, context = ""): boolean {
 function isQualitativeLeakageOnly(text: string): boolean {
   const lower = text.toLowerCase();
   const quantitative = /\b(?:quantif|equation|calculation|calculated|tco2e?|emission factor|measured|estimated|procedure for)\w*/.test(lower);
-  const definitive = /\b(?:no leakage|no displacement|leakage emissions? (?:are|were) negligible|negligible leakage)\b/.test(lower);
-  const reasoned = /\b(?:because|therefore|since|due to|as a result|does not allow|do not allow|not permit|not permitted)\b/.test(lower);
+  const definitive = /\b(?:no leakage|no displacement|no leakage was identified|no leakage to be considered|leakage emissions? (?:are|were) negligible|negligible leakage)\b/.test(lower);
+  const reasoned = /\b(?:because|therefore|since|due to|as a result|hence|thus|does not allow|do not allow|not permit|not permitted|identified|accounted|determined|considered)\b/.test(lower);
   const vague = /\b(?:possible source|grazing|fuel wood|qualitative|may cause|could cause|leakage is|leakage was discussed)\b/.test(lower);
   return !quantitative && ((!definitive && vague) || (definitive && !reasoned));
 }

--- a/src/lib/quickCheckV2/status/index.ts
+++ b/src/lib/quickCheckV2/status/index.ts
@@ -108,16 +108,22 @@ function isAdditionalityFrameworkOnly(text: string): boolean {
   return framework && !completed;
 }
 
-function isTemplateInstruction(text: string): boolean {
-  return /^(?:describe|specify|include|explain|provide|state|indicate)\b/i.test(text.trim())
-    && /\b(?:procedure|equations?|calculations?|quantification|methodological choices|sufficient information)\b/i.test(text);
+function isTemplateInstruction(text: string, context = ""): boolean {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  const imperative = /^(?:describe|specify|include|explain|provide|state|indicate)\b/i.test(normalized);
+  const instructional = /\b(?:procedure|equations?|calculations?|quantification|methodological choices|sufficient information)\b/i.test(normalized);
+  const templateContext = /\b(?:template|VCS|Verra|applied methodology|calculation spreadsheet|leakage emissions)\b/i.test(`${context} ${normalized}`);
+  const projectSpecific = /\b(?:project|activity|calculated|measured|estimated|recorded|observed|result(?:ed)?|during the monitoring|because|therefore)\b/i.test(normalized);
+  return imperative && instructional && templateContext && !projectSpecific;
 }
 
 function isQualitativeLeakageOnly(text: string): boolean {
   const lower = text.toLowerCase();
   const quantitative = /\b(?:quantif|equation|calculation|calculated|tco2e?|emission factor|measured|estimated|procedure for)\w*/.test(lower);
-  const qualitative = /\b(?:possible source|grazing|fuel wood|qualitative|no displacement)\b/.test(lower);
-  return qualitative && !quantitative;
+  const definitive = /\b(?:no leakage|no displacement|leakage emissions? (?:are|were) negligible|negligible leakage)\b/.test(lower);
+  const reasoned = /\b(?:because|therefore|since|due to|as a result|does not allow|do not allow|not permit|not permitted)\b/.test(lower);
+  const vague = /\b(?:possible source|grazing|fuel wood|qualitative|may cause|could cause|leakage is|leakage was discussed)\b/.test(lower);
+  return !quantitative && ((!definitive && vague) || (definitive && !reasoned));
 }
 
 export function validateAnswerResult(result: AnswerResult): StatusResult {
@@ -262,7 +268,7 @@ export function validateAnswerResult(result: AnswerResult): StatusResult {
     };
   }
 
-  if (normalizedResult.checkName === "leakage" && isTemplateInstruction(normalizedResult.evidence.quote)) {
+  if (normalizedResult.checkName === "leakage" && isTemplateInstruction(normalizedResult.evidence.quote, normalizedResult.evidence.sectionHeading ?? "")) {
     return {
       checkName: normalizedResult.checkName,
       status: "UNCLEAR",

--- a/tests/lib/quickCheckV2/genericReliability.test.ts
+++ b/tests/lib/quickCheckV2/genericReliability.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "@jest/globals";
+import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
+import { loadAndParseExtractedText } from "@/lib/quickCheckV2/evidence";
+import { validateAnswerResult, validateAnswerResults, type StatusResult } from "@/lib/quickCheckV2/status";
+import type { AnswerResult } from "@/lib/quickCheckV2/answers";
+
+const FIXTURE = "tests/fixtures/quick-check/v2/5595-asvata-alm-india/extracted.txt";
+
+function answer(checkName: AnswerResult["checkName"], quote: string): AnswerResult {
+  const evidence = {
+    sourceType: "exact_section" as const,
+    quote,
+    page: 2,
+    sectionHeading: checkName,
+    sectionPath: ["2", "2.1"],
+    spanId: `synthetic:${checkName}`,
+  };
+  return { checkName, answer: quote, evidence, evidenceStack: [{ ...evidence, role: "primary" as const }] };
+}
+
+function status(checkName: AnswerResult["checkName"], quote: string): StatusResult {
+  return validateAnswerResult(answer(checkName, quote));
+}
+
+describe("Quick Check v2 generic reliability protections", () => {
+  it("reconciles 5595 without changing reviewed fixture truth", () => {
+    const document = loadAndParseExtractedText(FIXTURE, "reviewed-fixture");
+    const results = validateAnswerResults(extractAnswersForAllChecks(document));
+    expect(results.map((result) => [result.checkName, result.status])).toStrictEqual([
+      ["host_country", "FOUND"],
+      ["methodology", "UNCLEAR"],
+      ["baseline_scenario", "FOUND"],
+      ["additionality", "UNCLEAR"],
+      ["leakage", "UNCLEAR"],
+      ["stakeholder_consultation", "FOUND"],
+    ]);
+    expect(results.find((result) => result.checkName === "stakeholder_consultation")?.evidence?.quote).toContain("Date of stakeholder consultation");
+  });
+
+  it("cannot promote untouched template instructions to FOUND", () => {
+    const result = status("leakage", "Describe the procedure for quantification of leakage emissions in accordance with the applied methodology.");
+    expect(result.status).toBe("UNCLEAR");
+  });
+
+  it("does not treat additionality framework requirements as a completed assessment", () => {
+    const result = status("additionality", "The additionality of this project is demonstrated in two steps according to the methodology requirements.");
+    expect(result.status).toBe("UNCLEAR");
+  });
+
+  it("does not silently resolve contradictory methodology versions", () => {
+    const result = validateAnswerResult({
+      ...answer("methodology", "Methodology VM0042 Methodology for improved agricultural land management 2.0"),
+      evidenceStack: [
+        { ...answer("methodology", "Methodology VM0042 Methodology for improved agricultural land management 2.0").evidence!, role: "primary", sourceType: "fact_contract" },
+        { ...answer("methodology", "The project adheres to VM0042 v2.1 methodology.").evidence!, role: "caveat", label: "Conflicting methodology version declaration" },
+      ],
+    });
+    expect(result.status).toBe("UNCLEAR");
+    expect(result.reason).toBe("methodology_version_conflict");
+  });
+
+  it("keeps a related but incomplete leakage discussion unclear", () => {
+    const result = status("leakage", "The possible source of leakage could be increased fuel wood and grazing activity outside the project boundary. There was no displacement of pre-project grazing activities.");
+    expect(result.status).toBe("UNCLEAR");
+  });
+
+  it("still accepts substantive project-specific leakage quantification", () => {
+    const result = status("leakage", "The project quantified leakage emissions at 0 tCO2e using the applied methodology equation and recorded the calculation for the monitoring period.");
+    expect(result.status).toBe("FOUND");
+  });
+
+  it("protects substantive baseline evidence", () => {
+    const result = status("baseline_scenario", "The baseline scenario is the continuation of pre-project agricultural management practices, including burning of crop residue and intensive tillage.");
+    expect(result.status).toBe("FOUND");
+  });
+});

--- a/tests/lib/quickCheckV2/genericReliability.test.ts
+++ b/tests/lib/quickCheckV2/genericReliability.test.ts
@@ -3,6 +3,8 @@ import { extractAnswersForAllChecks } from "@/lib/quickCheckV2/answers";
 import { loadAndParseExtractedText } from "@/lib/quickCheckV2/evidence";
 import { validateAnswerResult, validateAnswerResults, type StatusResult } from "@/lib/quickCheckV2/status";
 import type { AnswerResult } from "@/lib/quickCheckV2/answers";
+import { buildQuickCheckEvidenceStackWithCompanions } from "@/lib/quickCheckV2/evidenceStackProducer";
+import type { QuickCheckV2Block, QuickCheckV2ExtractedDocument, RetrievedCheckEvidence } from "@/lib/quickCheckV2/evidence";
 
 const FIXTURE = "tests/fixtures/quick-check/v2/5595-asvata-alm-india/extracted.txt";
 
@@ -20,6 +22,42 @@ function answer(checkName: AnswerResult["checkName"], quote: string): AnswerResu
 
 function status(checkName: AnswerResult["checkName"], quote: string): StatusResult {
   return validateAnswerResult(answer(checkName, quote));
+}
+
+function methodologyStatus(blocks: QuickCheckV2Block[]): StatusResult {
+  const evidence = {
+    sourceType: "exact_section" as const,
+    quote: blocks[0]!.text,
+    page: blocks[0]!.page,
+    sectionHeading: blocks[0]!.sectionHeading,
+    sectionPath: blocks[0]!.sectionPath,
+    spanId: blocks[0]!.spanId,
+  };
+  const document: QuickCheckV2ExtractedDocument = {
+    documentId: "synthetic-methodology",
+    parser: "test",
+    blocks,
+    diagnostics: { warnings: [] },
+  };
+  const selected: RetrievedCheckEvidence = { checkName: "methodology", evidence };
+  return validateAnswerResult({
+    checkName: "methodology",
+    answer: evidence.quote,
+    evidence,
+    evidenceStack: buildQuickCheckEvidenceStackWithCompanions(document, selected),
+  });
+}
+
+function methodologyBlock(text: string, heading: string): QuickCheckV2Block {
+  return {
+    spanId: `synthetic:${heading}:${text}`,
+    page: 2,
+    text,
+    blockType: "body",
+    sectionHeading: heading,
+    sectionPath: ["2", "2.1"],
+    source: "primary",
+  };
 }
 
 describe("Quick Check v2 generic reliability protections", () => {
@@ -59,6 +97,20 @@ describe("Quick Check v2 generic reliability protections", () => {
     expect(result.reason).toBe("methodology_version_conflict");
   });
 
+  it("only treats active methodology declarations as conflicting", () => {
+    const active = methodologyBlock("The project applies VM0007 v1.8 methodology.", "Application of Methodology");
+    const activeConflict = methodologyBlock("The project adheres to VM0007 v1.9 methodology.", "Eligibility");
+    expect(methodologyStatus([active, activeConflict]).status).toBe("UNCLEAR");
+    expect(methodologyStatus([
+      active,
+      methodologyBlock("The project previously used VM0007 v1.7 before the current methodology was adopted.", "Methodology History"),
+    ]).status).toBe("FOUND");
+    expect(methodologyStatus([
+      active,
+      methodologyBlock("Compared with VM0007 v1.7, the current project declaration uses the selected methodology.", "Methodology Comparison"),
+    ]).status).toBe("FOUND");
+  });
+
   it("keeps a related but incomplete leakage discussion unclear", () => {
     const result = status("leakage", "The possible source of leakage could be increased fuel wood and grazing activity outside the project boundary. There was no displacement of pre-project grazing activities.");
     expect(result.status).toBe("UNCLEAR");
@@ -66,6 +118,11 @@ describe("Quick Check v2 generic reliability protections", () => {
 
   it("still accepts substantive project-specific leakage quantification", () => {
     const result = status("leakage", "The project quantified leakage emissions at 0 tCO2e using the applied methodology equation and recorded the calculation for the monitoring period.");
+    expect(result.status).toBe("FOUND");
+  });
+
+  it("accepts reasoned project-specific no-displacement evidence without requiring numbers", () => {
+    const result = status("leakage", "State the project-specific leakage outcome: no displacement occurred because grazing is not permitted within the project area.");
     expect(result.status).toBe("FOUND");
   });
 


### PR DESCRIPTION
## Summary

Fixes generic Quick Check reliability failures exposed by the reviewed 5595 PDD without changing reviewed fixture truth.

## Root causes addressed

- Country extraction now accepts grounded project-identity title evidence using a reusable country parser.
- Methodology evidence now carries deterministic contradiction caveats when the same methodology is declared with materially different versions.
- Template instruction text is excluded from leakage evidence.
- Additionality framework/requirement language alone is downgraded to UNCLEAR.
- Qualitative leakage discussion without quantification evidence is downgraded to UNCLEAR.
- Dated stakeholder consultation records are preferred while existing strong stakeholder and baseline behavior remains protected.

## Validation

- Quick Check V2: 16 suites, 244 tests passed
- `npx tsc --noEmit`
- `npm run lint`
- `npm run pr:check:local`
- `npm run test:quickcheck:no-fixture-hardcoding`
- `git diff --check`

5595 replay: 3 FOUND / 3 UNCLEAR, matching REVIEW.md outcomes. The fixture directory has no `gold.json` on current main because the PR1 truth intake is still marked pending; no reviewed fixture files were modified.

No Evidence Map, parser/router production, report UI, or fixture truth changes are included.