### PR TITLE
fix: prefer project-level host country evidence

### DIFF
--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -99,6 +99,11 @@ const PRIMARY_METHODOLOGY_CODE_RE =
 const LEAKAGE_NOT_APPLICABLE_RE =
   /\bleakage\s*:\s*(?:not applicable|n\/a|none)\b|\bno leakage\b/i;
 
+const PROJECT_HOST_COUNTRY_CONTEXT_RE =
+  /\b(?:summary|overview|project description|project details|project location|general description|project design|project background|introduction|geographic location|geographic reference)\b/i;
+const CONTACT_HOST_COUNTRY_CONTEXT_RE =
+  /\b(?:other entities|contact|address|telephone|email|organization|consultant|proponent|participant|developer|role in the project)\b/i;
+
 const CHECK_SECTION_MAPPINGS: Record<
   StructuredCheckId,
   {
@@ -218,6 +223,17 @@ const FACT_CONTRACTS: Partial<Record<StructuredCheckId, FactContractDefinition>>
           /\bhost party(?:\(ies\))?\b/i.test(block.sectionHeading ?? "") &&
           /^[A-Z][A-Za-z]+(?:[ -][A-Z][A-Za-z]+)*$/.test(block.text.trim()),
         ) ??
+        findFirstBlock(blocks, (block) => {
+          const context = `${block.sectionHeading ?? ""} ${block.sectionPath.join(" ")}`;
+          const firstSentence = splitEvidenceSentences(block.text)[0]?.trim() ?? "";
+          const standaloneCountry = extractCountryName(firstSentence);
+          return (
+            block.page <= 5 &&
+            PROJECT_HOST_COUNTRY_CONTEXT_RE.test(context) &&
+            !CONTACT_HOST_COUNTRY_CONTEXT_RE.test(context) &&
+            Boolean(standaloneCountry && standaloneCountry.toLowerCase() === firstSentence.replace(/[.!?]+$/, "").toLowerCase())
+          );
+        }) ??
         findFirstBlock(blocks, (block) =>
           /\b[A-Z][a-z]+,\s*[A-Z][A-Za-z-]+(?:\s*\(|$)/.test(block.text) &&
           /\b(?:province|district|regency|location|located)\b/i.test(block.text) &&
@@ -1481,6 +1497,13 @@ function trimQuoteForCheck(checkName: StructuredCheckId, quote: string): string 
       return quotedMethodology[0]!.trim();
     }
     return sentences.find((sentence) => /\b(VM\d{4}|VMD\d{4})\b/i.test(sentence)) ?? quote.trim();
+  }
+
+  if (checkName === "host_country") {
+    const firstSentence = sentences[0]?.trim();
+    if (firstSentence && extractCountryName(firstSentence)?.toLowerCase() === firstSentence.replace(/[.!?]+$/, "").toLowerCase()) {
+      return firstSentence;
+    }
   }
 
   if (checkName === "additionality" && /\bThis section is under development\b/i.test(quote)) {

--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -228,7 +228,6 @@ const FACT_CONTRACTS: Partial<Record<StructuredCheckId, FactContractDefinition>>
           const firstSentence = splitEvidenceSentences(block.text)[0]?.trim() ?? "";
           const standaloneCountry = extractCountryName(firstSentence);
           return (
-            block.page <= 5 &&
             PROJECT_HOST_COUNTRY_CONTEXT_RE.test(context) &&
             !CONTACT_HOST_COUNTRY_CONTEXT_RE.test(context) &&
             Boolean(standaloneCountry && standaloneCountry.toLowerCase() === firstSentence.replace(/[.!?]+$/, "").toLowerCase())
@@ -237,10 +236,13 @@ const FACT_CONTRACTS: Partial<Record<StructuredCheckId, FactContractDefinition>>
         findFirstBlock(blocks, (block) =>
           /\b[A-Z][a-z]+,\s*[A-Z][A-Za-z-]+(?:\s*\(|$)/.test(block.text) &&
           /\b(?:province|district|regency|location|located)\b/i.test(block.text) &&
-          block.sectionPath.length > 0,
+          block.sectionPath.length > 0 &&
+          !CONTACT_HOST_COUNTRY_CONTEXT_RE.test(`${block.sectionHeading ?? ""} ${block.sectionPath.join(" ")}`),
         ) ??
         findFirstBlock(blocks, (block) =>
-          /\blocated\b/i.test(block.text) && /\b[A-Z][a-z]+,\s*[A-Z][a-z]+\b/.test(block.text),
+          /\blocated\b/i.test(block.text) &&
+          /\b[A-Z][a-z]+,\s*[A-Z][a-z]+\b/.test(block.text) &&
+          !CONTACT_HOST_COUNTRY_CONTEXT_RE.test(`${block.sectionHeading ?? ""} ${block.sectionPath.join(" ")}`),
         ) ??
         findFirstBlock(blocks, (block) =>
           /\bproject location\b/i.test(block.sectionHeading ?? "") &&

--- a/tests/lib/quickCheckV2/evidence-retrieval.test.ts
+++ b/tests/lib/quickCheckV2/evidence-retrieval.test.ts
@@ -184,6 +184,60 @@ describe("Quick Check v2 — Phase 3 evidence retrieval", () => {
     expect(extractAnswerForCheck(synthetic, "host_country").answer).toBe("Brazil");
   });
 
+  it("prefers a project-summary country after page five over an early consultant address", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p2:b1:contact",
+        page: 2,
+        text: "Address 10F, Block C, 515 Central Road, District, Lima, China",
+        blockType: "body",
+        sectionHeading: "Other Entities Involved in the Project",
+        sectionPath: ["1", "1.7"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p6:b1:summary",
+        page: 6,
+        text: "China. The project improves agricultural land management.",
+        blockType: "body",
+        sectionHeading: "Summary Description of the Project",
+        sectionPath: ["1", "1.1"],
+        source: "primary",
+      },
+    ]);
+
+    const evidence = retrieveEvidenceForCheck(synthetic, "host_country").evidence;
+    expect(evidence).toMatchObject({
+      quote: "China.",
+      page: 6,
+      sectionHeading: "Summary Description of the Project",
+      spanId: "synthetic-doc:p6:b1:summary",
+    });
+    expect(extractAnswerForCheck(synthetic, "host_country").answer).toBe("China");
+  });
+
+  it("excludes a contact country when no project-level country evidence exists", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p2:b1:contact",
+        page: 2,
+        text: "Address 10F, Block C, 515 Central Road, District, Lima, China",
+        blockType: "body",
+        sectionHeading: "Other Entities Involved in the Project",
+        sectionPath: ["1", "1.7"],
+        source: "primary",
+      },
+    ]);
+
+    expect(retrieveEvidenceForCheck(synthetic, "host_country").evidence).toBeNull();
+    expect(extractAnswerForCheck(synthetic, "host_country").answer).toBeNull();
+  });
+
+  it("keeps existing fixture host-country answers stable", () => {
+    expect(extractAnswerForCheck(enviraDoc, "host_country").answer).toBe("Brazil");
+    expect(extractAnswerForCheck(mayaDoc, "host_country").answer).toBe("Belize");
+  });
+
   it("prefers an additionality conclusion over an earlier VT0001 introduction", () => {
     const synthetic = makeSyntheticDocument([
       {

--- a/tests/lib/quickCheckV2/evidence-retrieval.test.ts
+++ b/tests/lib/quickCheckV2/evidence-retrieval.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
+import { extractAnswerForCheck } from "@/lib/quickCheckV2/answers";
 import {
   loadAndParseExtractedText,
   retrieveEvidenceForAllChecks,
@@ -147,6 +148,40 @@ describe("Quick Check v2 — Phase 3 evidence retrieval", () => {
     expect(stakeholder?.quote).toContain("Table 7. Stakeholder comments received and actions taken");
     expect(stakeholder?.quote).toContain("Request for inclusion of Freetown Sibun in the project");
     expect(stakeholder?.quote).toContain("Activities planned for La Democracia will include backyard gardens");
+  });
+
+  it("prefers project-summary country evidence over a consultant address", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p2:b1:summary",
+        page: 2,
+        text: "Brazil. The project implements improved agricultural land management practices.",
+        blockType: "body",
+        sectionHeading: "Summary Description of the Project",
+        sectionPath: ["1", "1.1"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p7:b1:contact",
+        page: 7,
+        text: "Address 10F, Block C, 515 Central Road, District, Lima, Brazil",
+        blockType: "body",
+        sectionHeading: "Other Entities Involved in the Project",
+        sectionPath: ["1", "1.7"],
+        source: "primary",
+      },
+    ]);
+
+    const evidence = retrieveEvidenceForCheck(synthetic, "host_country").evidence;
+    expect(evidence).toMatchObject({
+      sourceType: "fact_contract",
+      quote: "Brazil.",
+      page: 2,
+      sectionHeading: "Summary Description of the Project",
+      sectionPath: ["1", "1.1"],
+      spanId: "synthetic-doc:p2:b1:summary",
+    });
+    expect(extractAnswerForCheck(synthetic, "host_country").answer).toBe("Brazil");
   });
 
   it("prefers an additionality conclusion over an earlier VT0001 introduction", () => {


### PR DESCRIPTION
## Summary

Fix Quick Check v2 host_country evidence selection so project-level country statements take precedence over consultant/company/contact addresses.

## Root cause

The host_country fact contract fell through to a generic location-shaped pattern that accepted a consultant address on page 6 and extracted Minhang, before considering the project summary on page 4.

## Generic fix

Add a project-context preference for standalone country statements in early project-summary/location sections, exclude contact/entity contexts, and preserve concise country evidence quotes. No project, country, address, or page-specific values are hardcoded.

## Validation

- `npm test -- --runInBand tests/lib/quickCheckV2/evidence-retrieval.test.ts tests/lib/quickCheckV2/answer-extractors.test.ts` — 2 suites, 46 tests passed
- `npm test -- --runInBand tests/lib/quickCheckV2/gold-fixtures.test.ts tests/lib/quickCheckV2/no-fixture-hardcoding-guard.test.ts` — 2 suites, 52 tests passed
- Fixture 5739 replay — selected `China.` from page 4, section `Summary Description of the Project`, and returned `China`
- `git diff --check` — passed
- Push hook: `npm run lint` and `npm run typecheck` — passed

The full `pr:gate` was not rerun, and no PyMuPDF or CI/environment changes were made, per request.