### PR TITLE
fix: require substantive additionality evidence

### DIFF
--- a/src/lib/quickCheckV2/status/index.ts
+++ b/src/lib/quickCheckV2/status/index.ts
@@ -103,8 +103,13 @@ function hasWithoutProjectNarrative(evidence: RetrievedEvidence): boolean {
 function isAdditionalityFrameworkOnly(text: string): boolean {
   const lower = text.toLowerCase();
   const framework = /\b(?:requirements?|in two steps|shall be demonstrated|must be demonstrated|regulatory surplus)\b/.test(lower);
-  const completed = /\b(?:barrier analysis|investment analysis|common practice analysis)\b.{0,80}\b(?:completed|conducted|results?|concluded|demonstrated|identified)\b/.test(lower)
-    || /\b(?:concluded|demonstrated|identified)\b.{0,80}\b(?:barrier|common practice|investment)\b/.test(lower);
+  const analysis = /\b(?:barrier analysis|investment analysis|common practice analysis)\b/;
+  const completionVerb = /\b(?:completed|conducted|performed|undertaken|documented|reported|concluded)\b/;
+  const completed = (
+    analysis.test(lower) && completionVerb.test(lower.slice(Math.max(0, lower.search(analysis) - 80), lower.search(analysis) + 160))
+  ) || (
+    completionVerb.test(lower) && analysis.test(lower.slice(Math.max(0, lower.search(completionVerb) - 20), lower.search(completionVerb) + 160))
+  );
   return framework && !completed;
 }
 

--- a/tests/lib/quickCheckV2/genericReliability.test.ts
+++ b/tests/lib/quickCheckV2/genericReliability.test.ts
@@ -85,6 +85,23 @@ describe("Quick Check v2 generic reliability protections", () => {
     expect(result.status).toBe("UNCLEAR");
   });
 
+  it("does not treat referenced additionality steps as completed project analysis", () => {
+    const result = status(
+      "additionality",
+      "The project establishes regulatory surplus. Barrier analysis and common practice analysis are required by the methodology and will be addressed in the applicable sections.",
+    );
+    expect(result.status).toBe("UNCLEAR");
+    expect(result.reason).toBe("insufficient_substantive_evidence");
+  });
+
+  it("accepts completed project-specific barrier and common-practice analysis", () => {
+    const result = status(
+      "additionality",
+      "The project conducted a barrier analysis and common practice analysis. The analyses concluded that the project is additional because the activities are not common practice and face substantial implementation barriers, while regulatory surplus was confirmed.",
+    );
+    expect(result.status).toBe("FOUND");
+  });
+
   it("does not silently resolve contradictory methodology versions", () => {
     const result = validateAnswerResult({
       ...answer("methodology", "Methodology VM0042 Methodology for improved agricultural land management 2.0"),


### PR DESCRIPTION
## Summary

Require substantive project-specific additionality analysis before Quick Check reports FOUND.

## Root cause

The additionality sufficiency guard treated `demonstrated` near framework labels such as barrier analysis as evidence that the required analysis was completed. A methodology requirement sentence could therefore be promoted to FOUND.

## Fix

Completion is now recognized only when an explicit completion/conduct verb is tied to barrier, investment, or common-practice analysis. Framework requirements and referenced-but-unprovided steps remain UNCLEAR. Leakage logic and fixture truth are unchanged.

## Validation

- Focused additionality/status/extractor suites: 51 tests passed
- Existing gold-fixture regression suite: 48 tests passed
- Frozen 5739 additionality evidence: `UNCLEAR` / `insufficient_substantive_evidence`
- `git diff --check`: passed
- Push-hook lint/typecheck were not required for the final push; no broad gates were run.