### PR TITLE
fix: prioritize substantive leakage evidence

### DIFF
--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -937,6 +937,25 @@ function findSectionsByHeadingText(
   return results;
 }
 
+function findFirstSectionWithBodyEvidence(
+  document: QuickCheckV2ExtractedDocument,
+  tree: SectionTreeNode[],
+  predicate: (blocks: QuickCheckV2Block[]) => boolean,
+): SectionTreeNode | null {
+  function walk(nodes: SectionTreeNode[]): SectionTreeNode | null {
+    for (const node of nodes) {
+      if (predicate(collectSectionBodyBlocks(document, node))) {
+        return node;
+      }
+      const childMatch = walk(node.children);
+      if (childMatch) return childMatch;
+    }
+    return null;
+  }
+
+  return walk(tree);
+}
+
 function getHeadingMatchQuality(
   headingText: string,
   searchTexts: string[],
@@ -1900,6 +1919,22 @@ function getBestExactSectionBlock(
       null;
   } else if (checkName === "leakage") {
     bestSection =
+      findFirstSectionWithBodyEvidence(document, tree, (bodyBlocks) => {
+        const screeningPages = new Set(
+          bodyBlocks.filter((block) =>
+            /\bcommunity-use buffer zone\b/i.test(block.text) ||
+            /\breducing pressure on surrounding forests\b/i.test(block.text) ||
+            /\breducing pressure on surrounding forest\b/i.test(block.text) ||
+            /\bleakage (?:pathways?|through)|may result in leakage\b/i.test(block.text),
+          ).map((block) => block.page),
+        );
+        const hasPathwayScreening = screeningPages.size > 0;
+        const hasProjectConclusion = bodyBlocks.some((block) =>
+          screeningPages.has(block.page) &&
+          /\bnot applicable\b|\bno leakage\b|\bno displacement\b|\bnegligible leakage\b/i.test(block.text),
+        );
+        return hasPathwayScreening && hasProjectConclusion;
+      }) ??
       sectionsWithBodies.find(({ bodyBlocks }) =>
         bodyBlocks.some((block) =>
           /\bcommunity-use buffer zone\b/i.test(block.text) ||

--- a/tests/lib/quickCheckV2/evidence-retrieval.test.ts
+++ b/tests/lib/quickCheckV2/evidence-retrieval.test.ts
@@ -708,6 +708,94 @@ describe("Quick Check v2 — Phase 3 evidence retrieval", () => {
     expect(result.evidence!.quote).toBe("Leakage: Not applicable");
   });
 
+  it("prefers substantive leakage screening over omission boilerplate", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p3:b1:heading",
+        page: 3,
+        text: "4.3 Leakage Emissions",
+        blockType: "heading",
+        sectionHeading: "Leakage Emissions",
+        sectionPath: ["4", "4.3"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p3:b2:omission",
+        page: 3,
+        text: "This section has been omitted in accordance with the registration process.",
+        blockType: "body",
+        sectionHeading: "Leakage Emissions",
+        sectionPath: ["4", "4.3"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p10:b1:heading",
+        page: 10,
+        text: "1.19 Additional Information Relevant to the Project",
+        blockType: "heading",
+        sectionHeading: "Additional Information Relevant to the Project",
+        sectionPath: ["1", "1.19"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p10:b2:screening",
+        page: 10,
+        text: "Leakage Management: the project screens leakage pathways including displacement and diversion of biomass.",
+        blockType: "body",
+        sectionHeading: "Additional Information Relevant to the Project",
+        sectionPath: ["1", "1.19"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p10:b3:conclusion",
+        page: 10,
+        text: "The project does not involve these activities; thus, leakage is not applicable to this project.",
+        blockType: "body",
+        sectionHeading: "Additional Information Relevant to the Project",
+        sectionPath: ["1", "1.19"],
+        source: "primary",
+      },
+    ]);
+
+    const result = retrieveEvidenceForCheck(synthetic, "leakage");
+    expect(result.evidence).toMatchObject({
+      page: 10,
+      sectionPath: ["1", "1.19"],
+      sectionHeading: "Additional Information Relevant to the Project",
+    });
+    expect(result.evidence?.quote).toContain("not applicable");
+  });
+
+  it("keeps omission-only leakage evidence as the fallback", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p3:b1:heading",
+        page: 3,
+        text: "4.3 Leakage Emissions",
+        blockType: "heading",
+        sectionHeading: "Leakage Emissions",
+        sectionPath: ["4", "4.3"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p3:b2:omission",
+        page: 3,
+        text: "This section has been omitted in accordance with the registration process.",
+        blockType: "body",
+        sectionHeading: "Leakage Emissions",
+        sectionPath: ["4", "4.3"],
+        source: "primary",
+      },
+    ]);
+
+    const result = retrieveEvidenceForCheck(synthetic, "leakage");
+    expect(result.evidence).toMatchObject({
+      page: 3,
+      sectionHeading: "Leakage Emissions",
+      sectionPath: ["4", "4.3"],
+    });
+  });
+
   it("recognizes stakeholder consultation with a trailing colon in the heading", () => {
     const synthetic = makeSyntheticDocument([
       {


### PR DESCRIPTION
## Summary

Prefer substantive project-specific leakage screening and conclusions over deferred-section omission boilerplate.

## Root cause

Leakage exact-section selection searched formal Leakage Emissions headings first. Project-specific Leakage Management prose in another section was not considered as a section candidate, so omission boilerplate could win.

## Fix

Scan document sections for same-page leakage-pathway screening plus a project-specific conclusion such as not applicable, no leakage, or no displacement. Use that section before existing formal-section selection; retain the existing formal omission fallback when substantive evidence is absent.

## Validation

- Focused evidence and answer-extractor suites: 51 tests passed
- Existing gold-fixture regression suite: 48 tests passed
- Fixture 5739 replay: page 17, section 1.19 Leakage Management; answer `No leakage was identified.`
- `git diff --check`: passed
- Push-hook lint and typecheck: passed

No fixture truth or additionality logic was changed. No full gate, full test suite, or eval corpus was run.