### PR TITLE
fix: preserve Quick Check answer evidence fidelity

### DIFF
--- a/src/lib/quickCheckV2/answers/index.ts
+++ b/src/lib/quickCheckV2/answers/index.ts
@@ -469,6 +469,16 @@ const ANSWER_EXTRACTORS: Record<StructuredCheckId, AnswerExtractor> = {
     ) {
       return quote;
     }
+    if (
+      /\b(?:requirements?|in two steps|shall be demonstrated|must be demonstrated|regulatory surplus)\b/i.test(quote) &&
+      /\b(?:barrier analysis|investment analysis|common practice analysis)\b/i.test(quote) &&
+      !/\b(?:barrier analysis|investment analysis|common practice analysis)\b.{0,80}\b(?:completed|conducted|performed|undertaken|documented|reported|concluded)\b/i.test(quote) &&
+      !/\b(?:completed|conducted|performed|undertaken|documented|reported|concluded)\b.{0,80}\b(?:barrier analysis|investment analysis|common practice analysis)\b/i.test(quote)
+    ) {
+      return /\bregulatory surplus\b/i.test(quote)
+        ? "Regulatory surplus is addressed, but project-specific barrier and common-practice analyses are not provided."
+        : "Additionality requirements are stated, but project-specific barrier and common-practice analyses are not provided.";
+    }
     const selectedBaseline = quote.match(
       /Alternative [A-Z]\s*-\s*(.+?)\s*-\s*is selected as the baseline scenario/i,
     );
@@ -567,6 +577,12 @@ const ANSWER_EXTRACTORS: Record<StructuredCheckId, AnswerExtractor> = {
       /\bSugarcane\b/i.test(quote)
     ) {
       return "Leakage is assessed under VMD0009 LK-ASP using Approach 2 Market Leakage Assessment; sugarcane is the likely baseline commodity; timber leakage is excluded as de minimis.";
+    }
+    if (
+      /\bnot applicable\b/i.test(quote) &&
+      /\bleakage (?:pathways?|through)|may result in leakage\b/i.test(quote)
+    ) {
+      return "The project screens the identified leakage pathways and concludes that leakage is not applicable to the project.";
     }
     if (/\bno leakage was identified\b/i.test(quote) || /\bly\s*=\s*0\b/i.test(quote) || /\bnot applicable\b/i.test(quote)) {
       return "No leakage was identified.";

--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -1629,6 +1629,18 @@ function trimQuoteForCheck(checkName: StructuredCheckId, quote: string): string 
   }
 
   if (checkName === "leakage") {
+    const pathwayIndex = sentences.findIndex((sentence) =>
+      /\bleakage (?:pathways?|through)|may result in leakage\b/i.test(sentence),
+    );
+    if (pathwayIndex >= 0) {
+      const conclusionIndex = sentences.findIndex((sentence, index) =>
+        index >= pathwayIndex && /\bnot applicable\b|\bno leakage\b|\bno displacement\b|\bnegligible leakage\b/i.test(sentence),
+      );
+      if (conclusionIndex >= 0) {
+        return sentences.slice(0, conclusionIndex + 1).join(" ");
+      }
+    }
+
     const underDevelopmentPlaceholder = quote.match(
       /This section is not required at the Under Development stage in accordance with Section 3\.1\.6[\s\S]*?The relevant information will be provided(?:\s+during the validation stage of the project\.)?/i,
     );

--- a/tests/lib/quickCheckV2/answer-extractors.test.ts
+++ b/tests/lib/quickCheckV2/answer-extractors.test.ts
@@ -241,6 +241,40 @@ describe("Quick Check v2 — Phase 4 tiny answer extractors", () => {
     });
   });
 
+  it("summarizes substantive leakage screening without overstating it as no leakage", () => {
+    const result = extractAnswerFromEvidence({
+      checkName: "leakage",
+      evidence: {
+        sourceType: "exact_section",
+        quote: "According to the methodology, projects may result in leakage through displacement and diversion pathways. The project does not involve those activities; thus, leakage is not applicable to this project.",
+        page: 17,
+        sectionHeading: "Additional Information Relevant to the Project",
+        sectionPath: ["1", "1.19"],
+        spanId: "synthetic-doc:p17:b1:leakage",
+      },
+    });
+
+    expect(result.answer).toBe("The project screens the identified leakage pathways and concludes that leakage is not applicable to the project.");
+    expect(result.answer).not.toBe("No leakage was identified.");
+  });
+
+  it("summarizes partial additionality evidence instead of repeating methodology requirements", () => {
+    const result = extractAnswerFromEvidence({
+      checkName: "additionality",
+      evidence: {
+        sourceType: "exact_section",
+        quote: "The project addresses regulatory surplus. Barrier analysis and common practice analysis are required by the methodology, but the project-specific analyses are not provided.",
+        page: 26,
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        spanId: "synthetic-doc:p26:b1:additionality",
+      },
+    });
+
+    expect(result.answer).toBe("Regulatory surplus is addressed, but project-specific barrier and common-practice analyses are not provided.");
+    expect(result.answer).not.toContain("shall be demonstrated");
+  });
+
   it("does not mark the Marcondes leakage placeholder as FOUND", () => {
     const result = marcondesAnswers.find((item) => item.checkName === "leakage");
     expect(result?.answer).toBeNull();

--- a/tests/lib/quickCheckV2/evidence-retrieval.test.ts
+++ b/tests/lib/quickCheckV2/evidence-retrieval.test.ts
@@ -755,6 +755,15 @@ describe("Quick Check v2 — Phase 3 evidence retrieval", () => {
         sectionPath: ["1", "1.19"],
         source: "primary",
       },
+      {
+        spanId: "synthetic-doc:p10:b4:following",
+        page: 10,
+        text: "Commercially Sensitive Information. Further Information follows in the next section.",
+        blockType: "body",
+        sectionHeading: "Additional Information Relevant to the Project",
+        sectionPath: ["1", "1.19"],
+        source: "primary",
+      },
     ]);
 
     const result = retrieveEvidenceForCheck(synthetic, "leakage");
@@ -764,6 +773,7 @@ describe("Quick Check v2 — Phase 3 evidence retrieval", () => {
       sectionHeading: "Additional Information Relevant to the Project",
     });
     expect(result.evidence?.quote).toContain("not applicable");
+    expect(result.evidence?.quote).not.toContain("Commercially Sensitive Information");
   });
 
   it("keeps omission-only leakage evidence as the fallback", () => {


### PR DESCRIPTION
## Summary

Fix the two remaining reviewed-gold fidelity mismatches exposed by fixture 5739 after the host-country, additionality sufficiency, and leakage evidence-priority fixes.

## Root causes

- Additionality answer extraction fell through to the selected methodology-requirement sentence instead of summarizing the partial evidence and missing substantive analyses.
- Leakage answer extraction converted any detailed `not applicable` screening into `No leakage was identified.`; leakage quote construction also continued into unrelated following text after the project conclusion.

## Fix

- Summarize framework-only or partial additionality evidence as incomplete project-specific analysis.
- Preserve the distinction between pathway screening that concludes `not applicable` and a definitive no-leakage statement.
- Stop leakage quotes at the project-specific conclusion while retaining omission-only fallback behavior.

## Validation

- Focused Quick Check answer/evidence/status suites: 82 tests passed
- Existing gold-fixture regression suite: 48 tests passed
- Fixture 5739 replay: additionality `UNCLEAR` with an incompleteness summary; leakage `FOUND` with the project-specific not-applicable answer and page-17 section-bounded evidence
- `git diff --check`: passed
- No host-country logic, fixture truth, or broad gates changed.