### PR TITLE
fix: preserve leakage answer details

### DIFF
--- a/src/lib/quickCheckV2/answers/index.ts
+++ b/src/lib/quickCheckV2/answers/index.ts
@@ -578,10 +578,32 @@ const ANSWER_EXTRACTORS: Record<StructuredCheckId, AnswerExtractor> = {
     ) {
       return "Leakage is assessed under VMD0009 LK-ASP using Approach 2 Market Leakage Assessment; sugarcane is the likely baseline commodity; timber leakage is excluded as de minimis.";
     }
+    const screensLeakagePathways =
+      /\bleakage (?:pathways?|through)|may result in leakage\b/i.test(quote);
+    const leakageMethodology = quote.match(/\b(?:VM|VMD)\d{4}\b/i)?.[0]?.toUpperCase();
+    const projectNonApplicabilityReason = sentenceContaining(
+      quote,
+      /\bthe project\b.*\b(?:does not|doesn't|do not)\b/i,
+    );
     if (
       /\bnot applicable\b/i.test(quote) &&
-      /\bleakage (?:pathways?|through)|may result in leakage\b/i.test(quote)
+      screensLeakagePathways &&
+      projectNonApplicabilityReason
     ) {
+      const rationale = projectNonApplicabilityReason
+        .split(/\s*;\s*(?:thus|therefore)\b/i, 1)[0]!
+        .replace(/^The project\b/i, "the project");
+      const conciseRationale = /\bthe project\b\s+(?:does not|doesn't|do not)\s+(?:involve|include)\b/i.test(
+        rationale,
+      )
+        ? "the project does not involve the identified leakage activities"
+        : rationale;
+      const methodologyContext = leakageMethodology
+        ? ` ${leakageMethodology}`
+        : "";
+      return `The project screens the${methodologyContext} leakage pathways and concludes that leakage is not applicable because ${conciseRationale}.`;
+    }
+    if (/\bnot applicable\b/i.test(quote) && screensLeakagePathways) {
       return "The project screens the identified leakage pathways and concludes that leakage is not applicable to the project.";
     }
     if (/\bno leakage was identified\b/i.test(quote) || /\bly\s*=\s*0\b/i.test(quote) || /\bnot applicable\b/i.test(quote)) {

--- a/tests/lib/quickCheckV2/answer-extractors.test.ts
+++ b/tests/lib/quickCheckV2/answer-extractors.test.ts
@@ -241,12 +241,12 @@ describe("Quick Check v2 — Phase 4 tiny answer extractors", () => {
     });
   });
 
-  it("summarizes substantive leakage screening without overstating it as no leakage", () => {
+  it("preserves methodology context and project-specific rationale for leakage non-applicability", () => {
     const result = extractAnswerFromEvidence({
       checkName: "leakage",
       evidence: {
         sourceType: "exact_section",
-        quote: "According to the methodology, projects may result in leakage through displacement and diversion pathways. The project does not involve those activities; thus, leakage is not applicable to this project.",
+        quote: "According to paragraph 8.4 of VM0042, improved agricultural land management projects may result in leakage through identified pathways. The project does not involve the identified leakage activities; thus, leakage is not applicable to this project.",
         page: 17,
         sectionHeading: "Additional Information Relevant to the Project",
         sectionPath: ["1", "1.19"],
@@ -254,7 +254,9 @@ describe("Quick Check v2 — Phase 4 tiny answer extractors", () => {
       },
     });
 
-    expect(result.answer).toBe("The project screens the identified leakage pathways and concludes that leakage is not applicable to the project.");
+    expect(result.answer).toBe("The project screens the VM0042 leakage pathways and concludes that leakage is not applicable because the project does not involve the identified leakage activities.");
+    expect(result.answer).toContain("VM0042");
+    expect(result.answer).toContain("because the project does not involve the identified leakage activities");
     expect(result.answer).not.toBe("No leakage was identified.");
   });
 


### PR DESCRIPTION
## Summary

- Preserve explicitly supported methodology identifiers in project-specific leakage screening answers.
- Preserve the project non-applicability rationale without overstating it as no leakage.
- Keep omission-only and existing leakage fallbacks unchanged.

## Root cause

The leakage answer extractor recognized substantive screening but emitted a fixed generic sentence, discarding methodology context and the explicit project rationale.

## Validation

- `npm test -- --runInBand tests/lib/quickCheckV2/answer-extractors.test.ts`
- `npm test -- --runInBand tests/lib/quickCheckV2/gold-fixtures.test.ts`
- direct fixture 5739 replay
- `git diff --check`
- pre-push lint and typecheck

Full CI is intentionally left to GitHub.