### PR TITLE
fix: resolve 5739 Quick Check gold regressions

### DIFF
--- a/src/lib/quickCheckV2/evidence/index.ts
+++ b/src/lib/quickCheckV2/evidence/index.ts
@@ -1445,6 +1445,45 @@ function buildForwardSectionQuote(
   return parts.join(" ").replace(/\s+/g, " ").trim();
 }
 
+function expandAdditionalityRequirementBlock(
+  document: QuickCheckV2ExtractedDocument,
+  block: QuickCheckV2Block,
+): QuickCheckV2Block {
+  if (
+    !/\b(?:barrier analysis|common practice analysis|additionality shall be)\b/i.test(
+      block.text,
+    )
+  ) {
+    return block;
+  }
+
+  const blockIndex = document.blocks.findIndex(
+    (candidate) => candidate.spanId === block.spanId,
+  );
+  if (blockIndex <= 0) {
+    return block;
+  }
+
+  let regulatorySurplusBlock: QuickCheckV2Block | null = null;
+  for (let index = blockIndex - 1; index >= 0; index -= 1) {
+    const candidate = document.blocks[index]!;
+    if (
+      candidate.sectionPath.join(">") !== block.sectionPath.join(">") ||
+      candidate.blockType === "heading"
+    ) {
+      break;
+    }
+    if (/\badditionality methods\b/i.test(candidate.text)) {
+      return candidate;
+    }
+    if (/\bregulatory surplus\b/i.test(candidate.text)) {
+      regulatorySurplusBlock = candidate;
+    }
+  }
+
+  return regulatorySurplusBlock ?? block;
+}
+
 function splitEvidenceSentences(value: string): string[] {
   return value
     .replace(/\s+/g, " ")
@@ -2064,7 +2103,10 @@ function getFactContractEvidence(
   }
 
   const block = definition.find(getEvidenceBlocks(document));
-  const blockText = block?.text ?? "";
+  const evidenceBlock = block && checkName === "additionality"
+    ? expandAdditionalityRequirementBlock(document, block)
+    : block;
+  const blockText = evidenceBlock?.text ?? "";
   const needsMethodologyExpansion =
     checkName === "methodology" &&
     (/\bMethodology\s+for\b/i.test(blockText) ||
@@ -2076,20 +2118,20 @@ function getFactContractEvidence(
     checkName === "stakeholder_consultation" &&
     (/\bFPIC Principal Assembly\b/i.test(blockText) ||
       /\bPhase 2 — On-Site Field Engagement and Validation\b/i.test(blockText));
-  const quote = block
+  const quote = evidenceBlock
     ? trimQuoteForCheck(
       checkName,
       needsStakeholderExpansion
-        ? buildForwardSectionQuote(document, block)
+        ? buildForwardSectionQuote(document, evidenceBlock)
         : checkName === "methodology" && /\bMethodology\s+for\b/i.test(blockText)
-          ? buildForwardSectionQuote(document, block)
+          ? buildForwardSectionQuote(document, evidenceBlock)
           : needsMethodologyExpansion || shouldExpandQuote(blockText)
-          ? buildQuoteFromBlock(document, block)
-          : block.text,
+          ? buildQuoteFromBlock(document, evidenceBlock)
+          : evidenceBlock.text,
     )
     : null;
-  if (!block) return null;
-  const evidence = toEvidence(block, "fact_contract", quote ?? block.text);
+  if (!evidenceBlock) return null;
+  const evidence = toEvidence(evidenceBlock, "fact_contract", quote ?? evidenceBlock.text);
   if (
     checkName === "host_country" &&
     evidence.page === 1 &&
@@ -2280,23 +2322,28 @@ function getExactSectionEvidence(
   const block = getBestExactSectionBlock(document, buildSectionTree(document), checkName);
   if (!block) return null;
 
+  const evidenceStartBlock =
+    checkName === "additionality"
+      ? expandAdditionalityRequirementBlock(document, block)
+      : block;
+
   const rawQuote = (
     checkName === "additionality" ||
     (checkName === "leakage" &&
-      !/\bThis section is not required at the Under Development stage\b/i.test(block.text)) ||
+      !/\bThis section is not required at the Under Development stage\b/i.test(evidenceStartBlock.text)) ||
     checkName === "stakeholder_consultation"
   )
-    ? buildForwardSectionQuote(document, block)
-    : buildQuoteFromBlock(document, block);
+    ? buildForwardSectionQuote(document, evidenceStartBlock)
+    : buildQuoteFromBlock(document, evidenceStartBlock);
   const quote = trimQuoteForCheck(checkName, rawQuote);
-  if (checkName === "leakage" && isTemplateInstruction(quote, block.sectionHeading ?? "")) {
+  if (checkName === "leakage" && isTemplateInstruction(quote, evidenceStartBlock.sectionHeading ?? "")) {
     return null;
   }
   if (isDelegatedSupportingDocumentReference(quote)) {
     return null;
   }
 
-  return toEvidence(block, "exact_section", quote);
+  return toEvidence(evidenceStartBlock, "exact_section", quote);
 }
 
 function getRawTextFallbackEvidence(

--- a/tests/lib/quickCheckV2/evidence-retrieval.test.ts
+++ b/tests/lib/quickCheckV2/evidence-retrieval.test.ts
@@ -7,6 +7,7 @@ import {
   type QuickCheckV2ExtractedDocument,
   type RetrievedCheckEvidence,
 } from "@/lib/quickCheckV2/evidence";
+import { validateAnswerResult } from "@/lib/quickCheckV2/status";
 
 const ENVIRA_FIXTURE_PATH =
   "tests/fixtures/quick-check/v2/envira/extracted.txt";
@@ -284,6 +285,136 @@ describe("Quick Check v2 — Phase 3 evidence retrieval", () => {
     expect(result.evidence!.quote).toContain("Alternative A - Clearing of Forest and Conversion to Agriculture - is selected as the baseline scenario.");
     expect(result.evidence!.quote).toContain("simple cost analysis (Option 1) is selected.");
     expect(result.evidence!.quote).not.toContain("The following analysis was conducted to determine alternative baseline scenarios");
+    expect(validateAnswerResult(extractAnswerForCheck(synthetic, "additionality")).status).toBe("FOUND");
+  });
+
+  it("retains regulatory-surplus context within the same additionality requirement block", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p1:b1:heading",
+        page: 1,
+        text: "3.5 Additionality",
+        blockType: "heading",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b2:body",
+        page: 1,
+        text: "Unrelated earlier additionality narrative.",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b3:body",
+        page: 1,
+        text: "Additionality Methods",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b4:body",
+        page: 1,
+        text: "The project shall demonstrate regulatory surplus at validation.",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b5:body",
+        page: 1,
+        text: "B. Barrier analysis",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b6:body",
+        page: 1,
+        text: "C. Common practice analysis",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b7:body",
+        page: 1,
+        text: "Additionality shall be demonstrated in accordance with the methodology.",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+    ]);
+
+    const result = retrieveEvidenceForCheck(synthetic, "additionality");
+    expect(result.evidence?.spanId).toBe("synthetic-doc:p1:b3:body");
+    expect(result.evidence?.quote).toContain("regulatory surplus");
+    expect(result.evidence?.quote).toContain("Barrier analysis");
+    expect(result.evidence?.quote).toContain("Common practice analysis");
+    expect(result.evidence?.quote).not.toContain("Unrelated earlier additionality narrative");
+  });
+
+  it("keeps requirement-only additionality evidence UNCLEAR", () => {
+    const synthetic = makeSyntheticDocument([
+      {
+        spanId: "synthetic-doc:p1:b1:heading",
+        page: 1,
+        text: "3.5 Additionality",
+        blockType: "heading",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b2:body",
+        page: 1,
+        text: "Additionality Methods",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b3:body",
+        page: 1,
+        text: "B. Barrier analysis",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b4:body",
+        page: 1,
+        text: "C. Common practice analysis",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+      {
+        spanId: "synthetic-doc:p1:b5:body",
+        page: 1,
+        text: "Additionality shall be demonstrated in accordance with the methodology.",
+        blockType: "body",
+        sectionHeading: "Additionality",
+        sectionPath: ["3", "3.5"],
+        source: "primary",
+      },
+    ]);
+
+    const result = validateAnswerResult(extractAnswerForCheck(synthetic, "additionality"));
+    expect(result.status).toBe("UNCLEAR");
+    expect(result.reason).toBe("insufficient_substantive_evidence");
   });
 
   it("prefers a formal additionality section over an earlier without-project narrative", () => {

--- a/tests/lib/quickCheckV2/gold-fixtures.test.ts
+++ b/tests/lib/quickCheckV2/gold-fixtures.test.ts
@@ -453,7 +453,7 @@ describe("Quick Check v2 gold fixtures", () => {
           }
 
           expect(comparableRuntimeStatuses.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!))).toStrictEqual(
-            gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+            gold.map(normalizeExpectedQuickCheckGoldRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
           );
         }, 120000);
       }
@@ -492,7 +492,7 @@ describe("Quick Check v2 gold fixtures", () => {
           }
 
           expect(comparableRuntimeStatuses.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!))).toStrictEqual(
-            gold.map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
+            gold.map(normalizeExpectedQuickCheckGoldRecord).map((record, index) => stripMethodologyIfNeeded(record, methodologyComparisonFlags[index]!)),
           );
         }, 30000);
       }

--- a/tests/lib/quickCheckV2/goldComparison.test.ts
+++ b/tests/lib/quickCheckV2/goldComparison.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  buildComparableQuickCheckRecord,
+  normalizeExpectedQuickCheckGoldRecord,
+} from "./goldComparison";
+
+describe("Quick Check v2 gold answer comparison", () => {
+  it("treats one terminal period as equivalent in answers only", () => {
+    const runtime = buildComparableQuickCheckRecord(
+      {
+        checkName: "leakage",
+        status: "FOUND",
+        answer: "Leakage is not applicable.",
+        evidence: {
+          sourceType: "exact_section",
+          quote: "Leakage is not applicable.",
+          page: 17,
+          sectionHeading: "Leakage",
+          sectionPath: ["1", "1.19"],
+          spanId: "synthetic-doc:p17:b1:leakage",
+        },
+        evidenceStack: [],
+      },
+      {},
+    );
+    const gold = normalizeExpectedQuickCheckGoldRecord({
+      ...runtime,
+      expectedAnswer: "Leakage is not applicable",
+    });
+
+    expect(runtime.expectedAnswer).toBe("Leakage is not applicable");
+    expect(gold.expectedAnswer).toBe("Leakage is not applicable");
+    expect(runtime.goldQuote).toBe("Leakage is not applicable.");
+    expect(gold.goldQuote).toBe("Leakage is not applicable.");
+  });
+
+  it("does not remove substantive punctuation from answers", () => {
+    const gold = normalizeExpectedQuickCheckGoldRecord({
+      checkName: "leakage",
+      expectedStatus: "FOUND",
+      expectedAnswer: "Pathway A; pathway B",
+      goldQuote: null,
+      page: null,
+      sectionHeading: null,
+      sectionPath: [],
+      spanId: null,
+      sourceType: null,
+    });
+
+    expect(gold.expectedAnswer).toBe("Pathway A; pathway B");
+  });
+});

--- a/tests/lib/quickCheckV2/goldComparison.ts
+++ b/tests/lib/quickCheckV2/goldComparison.ts
@@ -18,6 +18,10 @@ export type QuickCheckGoldComparableRecord = {
   evidenceStack?: EvidenceStackItem[];
 };
 
+function normalizeComparableAnswer(answer: string | null): string | null {
+  return answer?.replace(/\.$/, "") ?? null;
+}
+
 export function buildComparableQuickCheckRecord(
   result: Pick<StatusResult, "checkName" | "status" | "answer" | "evidence" | "evidenceStack">,
   expected: Pick<QuickCheckGoldComparableRecord, "evidenceStack">,
@@ -25,7 +29,7 @@ export function buildComparableQuickCheckRecord(
   const record: QuickCheckGoldComparableRecord = {
     checkName: result.checkName,
     expectedStatus: result.status,
-    expectedAnswer: result.answer,
+    expectedAnswer: normalizeComparableAnswer(result.answer),
     goldQuote: result.evidence?.quote ?? null,
     page: result.evidence?.page ?? null,
     sectionHeading: result.evidence?.sectionHeading ?? null,
@@ -44,12 +48,16 @@ export function buildComparableQuickCheckRecord(
 export function normalizeExpectedQuickCheckGoldRecord(
   record: QuickCheckGoldComparableRecord,
 ): QuickCheckGoldComparableRecord {
+  const normalizedRecord = {
+    ...record,
+    expectedAnswer: normalizeComparableAnswer(record.expectedAnswer),
+  };
   if (!record.evidenceStack) {
-    return record;
+    return normalizedRecord;
   }
 
   return {
-    ...record,
+    ...normalizedRecord,
     evidenceStack: normalizeEvidenceStack(record.evidenceStack),
   };
 }


### PR DESCRIPTION
## Summary

- Preserve regulatory-surplus context when additionality requirement evidence is selected from the same structured block.
- Treat only a terminal answer period as comparison-equivalent; quote and provenance remain exact.

## Root causes

Additionality evidence selection started at the barrier-analysis block, dropping the preceding regulatory-surplus lead-in. Gold comparison treated a terminal period in an answer as a substantive mismatch.

## Validation

- Focused evidence retrieval, answer/status, and gold-comparison tests: 57 passed
- Focused gold-fixture test: 49 passed
- Direct 5739 replay: UNCLEAR with regulatory-surplus, barrier-analysis, and common-practice context
- `git diff --check`
- Pre-push lint and typecheck

No fixture truth files were changed. Full CI is left to GitHub.